### PR TITLE
Schedule one extra job to run every minute

### DIFF
--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -93,6 +93,13 @@ class EventType(Enum):
     ALARM = "alarm"
 
 
+class ReachabilityState(Enum):
+    """The set of allowed reachability states"""
+
+    REACHABLE = "reachable"
+    NORESPONSE = "no-response"
+
+
 class Event(BaseModel):
     """Keeps track of event state"""
 
@@ -124,6 +131,8 @@ class Event(BaseModel):
     bfdix: Optional[int]
     bfddiscr: Optional[int]
     bfdaddr: Optional[IPAddress]
+
+    reachability: Optional[ReachabilityState]
 
     def add_log(self, message: str) -> LogEntry:
         entry = LogEntry(timestamp=datetime.datetime.now(), message=message)

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -10,6 +10,8 @@ _logger = logging.getLogger(__name__)
 
 
 class ReachableTask(Task):
+    EXTRA_JOB_INTERVAL = 60
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._scheduler = get_scheduler()
@@ -54,7 +56,7 @@ class ReachableTask(Task):
         self._scheduler.add_job(
             self._run_extra_job,
             "interval",
-            minutes=1,
+            seconds=self.EXTRA_JOB_INTERVAL,
             name=name,
             id=name,
         )

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -3,7 +3,7 @@ import logging
 from zino import state
 from zino.scheduler import get_scheduler
 from zino.snmp import SNMP
-from zino.statemodels import EventType
+from zino.statemodels import EventState, EventType
 from zino.tasks.task import Task
 
 _logger = logging.getLogger(__name__)
@@ -24,9 +24,9 @@ class ReachableTask(Task):
             event, created = state.events.get_or_create_event(self.device.name, None, EventType.REACHABILITY)
             if created:
                 # TODO add attributes
-                pass
-             # TODO we need a mechanism to "commit" event changes, to trigger notifications to clients
+                event.state = EventState.OPEN
             event.add_log(f"{self.device.name} no-response")
+            # TODO we need a mechanism to "commit" event changes, to trigger notifications to clients
             self._schedule_extra_job()
         else:
             _logger.debug("Device %s is reachable", self.device.name)

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -3,7 +3,7 @@ import logging
 from zino import state
 from zino.scheduler import get_scheduler
 from zino.snmp import SNMP
-from zino.statemodels import EventState, EventType
+from zino.statemodels import EventState, EventType, ReachabilityState
 from zino.tasks.task import Task
 
 _logger = logging.getLogger(__name__)
@@ -25,6 +25,7 @@ class ReachableTask(Task):
             if created:
                 # TODO add attributes
                 event.state = EventState.OPEN
+            event.reachability = ReachabilityState.NORESPONSE
             event.add_log(f"{self.device.name} no-response")
             # TODO we need a mechanism to "commit" event changes, to trigger notifications to clients
             self._schedule_extra_job()
@@ -38,6 +39,7 @@ class ReachableTask(Task):
             event = state.events.get(self.device.name, None, EventType.REACHABILITY)
             if event:
                 # TODO update event attributes
+                event.reachability = ReachabilityState.REACHABLE
                 event.add_log(f"{self.device.name} reachable")
                 # TODO we need a mechanism to "commit" event changes, to trigger notifications to clients
                 self._deschedule_extra_job()

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -35,8 +35,8 @@ class ReachableTask(Task):
             _logger.debug("Device %s is reachable", self.device.name)
 
     async def _run_extra_job(self):
-        uptime = await self._get_sysuptime()
-        if uptime:
+        result = await self._get_sysuptime()
+        if result:
             _logger.debug("Device %s is reachable", self.device.name)
             event = state.events.get(self.device.name, None, EventType.REACHABILITY)
             if event:

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -16,6 +16,8 @@ class ReachableTask(Task):
 
     async def run(self):
         """Checks if device is reachable. Schedules extra reachability checks if not."""
+        if self._extra_job_is_running():
+            return
         result = await self._get_sysuptime()
         if not result:
             _logger.debug("Device %s is not reachable", self.device.name)

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -27,6 +27,7 @@ class ReachableTask(Task):
             if created:
                 # TODO add attributes
                 event.state = EventState.OPEN
+                event.add_history("Change state to Open")
             event.reachability = ReachabilityState.NORESPONSE
             event.add_log(f"{self.device.name} no-response")
             # TODO we need a mechanism to "commit" event changes, to trigger notifications to clients

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -28,8 +28,9 @@ class ReachableTask(Task):
                 # TODO add attributes
                 event.state = EventState.OPEN
                 event.add_history("Change state to Open")
-            event.reachability = ReachabilityState.NORESPONSE
-            event.add_log(f"{self.device.name} no-response")
+            if event.reachability != ReachabilityState.NORESPONSE:
+                event.reachability = ReachabilityState.NORESPONSE
+                event.add_log(f"{self.device.name} no-response")
             # TODO we need a mechanism to "commit" event changes, to trigger notifications to clients
             self._schedule_extra_job()
         else:
@@ -42,8 +43,9 @@ class ReachableTask(Task):
             event = state.events.get(self.device.name, None, EventType.REACHABILITY)
             if event:
                 # TODO update event attributes
-                event.reachability = ReachabilityState.REACHABLE
-                event.add_log(f"{self.device.name} reachable")
+                if event.reachability != ReachabilityState.REACHABLE:
+                    event.reachability = ReachabilityState.REACHABLE
+                    event.add_log(f"{self.device.name} reachable")
                 # TODO we need a mechanism to "commit" event changes, to trigger notifications to clients
                 self._deschedule_extra_job()
 


### PR DESCRIPTION
Instead of scheduling many extra one-time jobs like original zino does, this PR makes it so a job running at a 60 second interval is used instead. While this extra job is running, the reachabilitytask run from the main loop will quit early.