### PR TITLE
Add explicit path to black and isort config file

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -62,4 +62,6 @@ jobs:
           VALIDATE_PYTHON_FLAKE8: true
           VALIDATE_PYTHON_ISORT: true
           # Tell the linter the location of the configuration file (pyproject.toml)
-          LINTER_RULES_PATH: /
+          LINTER_RULES_PATH: .
+          PYTHON_BLACK_CONFIG_FILE: pyproject.toml
+          PYTHON_ISORT_CONFIG_FILE: pyproject.toml


### PR DESCRIPTION
This should fix the problem of super-linter not finding the config file. It needs to be explicitly stated for each linter. 

I tested this with #6.