### PR TITLE
Restructure event types to a class hierarchy

### DIFF
--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -1,3 +1,4 @@
+import logging
 from collections import namedtuple
 from typing import Optional, Tuple
 
@@ -5,6 +6,8 @@ from zino.statemodels import Event, EventState, EventType, PortOrIPAddress
 from zino.time import now
 
 EventIndex = namedtuple("EventIndex", "router port event_type")
+
+_log = logging.getLogger(__name__)
 
 
 class Events:
@@ -58,6 +61,7 @@ class Events:
         )
         self._events[event_id] = event
         self._events_by_index[index] = event
+        _log.debug("created %r", event)
         return event
 
     def get(self, device_name: str, port: Optional[PortOrIPAddress], event_type: EventType) -> Event:

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -53,15 +53,13 @@ class Events(BaseModel):
         event_id = self.last_event_id + 1
         self.last_event_id = event_id
 
-        timestamp = now()
         event = Event(
             id=event_id,
             router=device_name,
             port=port,
             event_type=event_type,
             state=EventState.EMBRYONIC,
-            opened=timestamp,
-            updated=timestamp,
+            opened=now(),
         )
         self.events[event_id] = event
         self._events_by_index[index] = event

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -1,10 +1,19 @@
 import logging
 from collections import namedtuple
-from typing import Optional, Tuple, Type
+from typing import Dict, Optional, Tuple, Type, Union
 
 from pydantic.main import BaseModel
 
-from zino.statemodels import Event, EventState, PortOrIPAddress
+from zino.statemodels import (
+    AlarmEvent,
+    BFDEvent,
+    BGPEvent,
+    Event,
+    EventState,
+    PortOrIPAddress,
+    PortStateEvent,
+    ReachabilityEvent,
+)
 from zino.time import now
 
 EventIndex = namedtuple("EventIndex", "router port type")
@@ -13,9 +22,9 @@ _log = logging.getLogger(__name__)
 
 
 class Events(BaseModel):
-    events: dict = {}
+    events: Dict[int, Union[PortStateEvent, BGPEvent, BFDEvent, ReachabilityEvent, AlarmEvent, Event]] = {}
     last_event_id: int = 0
-    _events_by_index: dict = {}
+    _events_by_index: Dict[EventIndex, Event] = {}
 
     class Config:
         underscore_attrs_are_private = True

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -1,13 +1,13 @@
 import logging
 from collections import namedtuple
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Type
 
 from pydantic.main import BaseModel
 
-from zino.statemodels import Event, EventState, EventType, PortOrIPAddress
+from zino.statemodels import Event, EventState, PortOrIPAddress
 from zino.time import now
 
-EventIndex = namedtuple("EventIndex", "router port event_type")
+EventIndex = namedtuple("EventIndex", "router port type")
 
 _log = logging.getLogger(__name__)
 
@@ -27,7 +27,10 @@ class Events(BaseModel):
         return len(self.events)
 
     def get_or_create_event(
-        self, device_name: str, port: Optional[PortOrIPAddress], event_type: EventType
+        self,
+        device_name: str,
+        port: Optional[PortOrIPAddress],
+        event_class: Type[Event],
     ) -> Tuple[Event, bool]:
         """Creates a new event for the given event identifiers, or, if one matching this identifier already exists,
         returns that.
@@ -37,38 +40,39 @@ class Events(BaseModel):
 
         """
         try:
-            return self.create_event(device_name, port, event_type), True
+            return self.create_event(device_name, port, event_class), True
         except EventExistsError:
-            return self.get(device_name, port, event_type), False
+            return self.get(device_name, port, event_class), False
 
-    def create_event(self, device_name: str, port: Optional[PortOrIPAddress], event_type: EventType) -> Event:
+    def create_event(self, device_name: str, port: Optional[PortOrIPAddress], event_class: Type[Event]) -> Event:
         """Creates a new event for the given event identifiers. If an event already exists for this combination of
         identifiers, an EventExistsError is raised.
 
         """
-        index = EventIndex(device_name, port, event_type)
+        index = EventIndex(device_name, port, event_class)
         if index in self._events_by_index:
             raise EventExistsError(f"Event for {index} already exists")
 
         event_id = self.last_event_id + 1
         self.last_event_id = event_id
 
-        event = Event(
+        event = event_class(
             id=event_id,
             router=device_name,
             port=port,
-            event_type=event_type,
             state=EventState.EMBRYONIC,
             opened=now(),
         )
+        _log.debug("created event %r", event)
+
         self.events[event_id] = event
         self._events_by_index[index] = event
         _log.debug("created %r", event)
         return event
 
-    def get(self, device_name: str, port: Optional[PortOrIPAddress], event_type: EventType) -> Event:
+    def get(self, device_name: str, port: Optional[PortOrIPAddress], event_class: Type[Event]) -> Event:
         """Returns an event based on its identifiers, None if no match was found"""
-        index = EventIndex(device_name, port, event_type)
+        index = EventIndex(device_name, port, event_class)
         return self._events_by_index.get(index)
 
 

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -2,6 +2,8 @@ import logging
 from collections import namedtuple
 from typing import Optional, Tuple
 
+from pydantic.main import BaseModel
+
 from zino.statemodels import Event, EventState, EventType, PortOrIPAddress
 from zino.time import now
 
@@ -10,17 +12,19 @@ EventIndex = namedtuple("EventIndex", "router port event_type")
 _log = logging.getLogger(__name__)
 
 
-class Events:
-    def __init__(self):
-        self._events = {}
-        self._events_by_index = {}
-        self._last_event_id = 0
+class Events(BaseModel):
+    events: dict = {}
+    last_event_id: int = 0
+    _events_by_index: dict = {}
+
+    class Config:
+        underscore_attrs_are_private = True
 
     def __getitem__(self, item):
-        return self._events[item]
+        return self.events[item]
 
     def __len__(self):
-        return len(self._events)
+        return len(self.events)
 
     def get_or_create_event(
         self, device_name: str, port: Optional[PortOrIPAddress], event_type: EventType
@@ -46,8 +50,8 @@ class Events:
         if index in self._events_by_index:
             raise EventExistsError(f"Event for {index} already exists")
 
-        event_id = self._last_event_id + 1
-        self._last_event_id = event_id
+        event_id = self.last_event_id + 1
+        self.last_event_id = event_id
 
         timestamp = now()
         event = Event(
@@ -59,7 +63,7 @@ class Events:
             opened=timestamp,
             updated=timestamp,
         )
-        self._events[event_id] = event
+        self.events[event_id] = event
         self._events_by_index[index] = event
         _log.debug("created %r", event)
         return event

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -22,7 +22,7 @@ class Events:
     def get_or_create_event(
         self, device_name: str, port: Optional[PortOrIPAddress], event_type: EventType
     ) -> Tuple[Event, bool]:
-        """Creates a new event for the given event identifers, or, if one matching this identifier already exists,
+        """Creates a new event for the given event identifiers, or, if one matching this identifier already exists,
         returns that.
 
         :returns: (Event, created) where Event is the existing or newly created Event object, while created is a boolean

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -2,7 +2,7 @@
 import datetime
 from enum import Enum, IntEnum
 from ipaddress import IPv4Address, IPv6Address
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -85,16 +85,6 @@ class EventState(Enum):
     CLOSED = "closed"
 
 
-class EventType(Enum):
-    """The set of allowable event types"""
-
-    PORTSTATE = "portstate"
-    BGP = "bgp"
-    BFD = "bfd"
-    REACHABILITY = "reachability"
-    ALARM = "alarm"
-
-
 class ReachabilityState(Enum):
     """The set of allowed reachability states"""
 
@@ -109,7 +99,7 @@ class Event(BaseModel):
 
     router: str
     port: Optional[PortOrIPAddress]
-    event_type: EventType
+    type: Literal["Event"] = "Event"
     state: EventState
     opened: datetime.datetime = Field(default_factory=now)
     updated: Optional[datetime.datetime]
@@ -119,22 +109,11 @@ class Event(BaseModel):
     history: List[LogEntry] = []
 
     # More-or-less optional event attrs (as guesstimated from the original Zino code)
-    ifindex: Optional[int]
     lasttrans: Optional[datetime.datetime]
     flaps: Optional[int]
     ac_down: Optional[datetime.timedelta]
 
     polladdr: Optional[IPAddress]
-    remote_addr: Optional[IPAddress]
-    remote_as: Optional[int]
-    peer_uptime: Optional[int]
-    alarm_count: Optional[int]
-
-    bfdix: Optional[int]
-    bfddiscr: Optional[int]
-    bfdaddr: Optional[IPAddress]
-
-    reachability: Optional[ReachabilityState]
 
     def add_log(self, message: str) -> LogEntry:
         entry = LogEntry(message=message)
@@ -146,3 +125,32 @@ class Event(BaseModel):
         entry = LogEntry(message=message)
         self.history.append(entry)
         return entry
+
+
+class PortStateEvent(Event):
+    type: Literal["portstate"] = "portstate"
+    ifindex: Optional[int]
+
+
+class BGPEvent(Event):
+    type: Literal["bgp"] = "bgp"
+    remote_addr: Optional[IPAddress]
+    remote_as: Optional[int]
+    peer_uptime: Optional[int]
+
+
+class BFDEvent(Event):
+    type: Literal["bfd"] = "bfd"
+    bfdix: Optional[int]
+    bfddiscr: Optional[int]
+    bfdaddr: Optional[IPAddress]
+
+
+class ReachabilityEvent(Event):
+    type: Literal["reachability"] = "reachability"
+    reachability: Optional[ReachabilityState]
+
+
+class AlarmEvent(Event):
+    type: Literal["alarm"] = "alarm"
+    alarm_count: Optional[int]

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -112,7 +112,7 @@ class Event(BaseModel):
     event_type: EventType
     state: EventState
     opened: datetime.datetime = Field(default_factory=now)
-    updated: datetime.datetime = Field(default_factory=now)
+    updated: Optional[datetime.datetime]
     priority: int = 100
 
     log: List[LogEntry] = []
@@ -139,6 +139,7 @@ class Event(BaseModel):
     def add_log(self, message: str) -> LogEntry:
         entry = LogEntry(message=message)
         self.log.append(entry)
+        self.updated = entry.timestamp
         return entry
 
     def add_history(self, message: str) -> LogEntry:

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -3,7 +3,7 @@ import logging
 from zino import state
 from zino.scheduler import get_scheduler
 from zino.snmp import SNMP
-from zino.statemodels import EventState, EventType, ReachabilityState
+from zino.statemodels import EventState, ReachabilityEvent, ReachabilityState
 from zino.tasks.task import Task
 
 _logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ class ReachableTask(Task):
         result = await self._get_sysuptime()
         if not result:
             _logger.debug("Device %s is not reachable", self.device.name)
-            event, created = state.events.get_or_create_event(self.device.name, None, EventType.REACHABILITY)
+            event, created = state.events.get_or_create_event(self.device.name, None, ReachabilityEvent)
             if created:
                 # TODO add attributes
                 event.state = EventState.OPEN
@@ -40,7 +40,7 @@ class ReachableTask(Task):
         result = await self._get_sysuptime()
         if result:
             _logger.debug("Device %s is reachable", self.device.name)
-            event = state.events.get(self.device.name, None, EventType.REACHABILITY)
+            event = state.events.get(self.device.name, None, ReachabilityEvent)
             if event:
                 # TODO update event attributes
                 if event.reachability != ReachabilityState.REACHABLE:

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from zino.events import EventExistsError, Events
-from zino.statemodels import Event, EventType
+from zino.statemodels import Event, ReachabilityEvent
 
 
 class TestEvents:
@@ -11,39 +11,39 @@ class TestEvents:
 
     def test_create_event_should_return_event(self):
         events = Events()
-        event = events.create_event("foobar", None, EventType.REACHABILITY)
+        event = events.create_event("foobar", None, ReachabilityEvent)
 
         assert event.id > 0
 
     def test_event_registry_should_contain_one_event_when_first_event_is_created(self):
         events = Events()
-        events.create_event("foobar", None, EventType.REACHABILITY)
+        events.create_event("foobar", None, ReachabilityEvent)
 
         assert len(events) == 1
 
     def test_adding_two_identical_events_should_raise(self):
         events = Events()
-        events.create_event("foobar", None, EventType.REACHABILITY)
+        events.create_event("foobar", None, ReachabilityEvent)
 
         with pytest.raises(EventExistsError):
-            events.create_event("foobar", None, EventType.REACHABILITY)
+            events.create_event("foobar", None, ReachabilityEvent)
 
     def test_event_should_be_gettable_by_id(self):
         events = Events()
-        event = events.create_event("foobar", None, EventType.REACHABILITY)
+        event = events.create_event("foobar", None, ReachabilityEvent)
 
         assert events[event.id] == event
 
     def test_get_or_create_event_should_return_new_event(self):
         events = Events()
-        event, created = events.get_or_create_event("foobar", None, EventType.REACHABILITY)
+        event, created = events.get_or_create_event("foobar", None, ReachabilityEvent)
 
         assert created
         assert isinstance(event, Event)
 
     def test_get_or_create_event_should_return_existing_event_on_same_index(self):
         events = Events()
-        event1, created1 = events.get_or_create_event("foobar", None, EventType.REACHABILITY)
-        event2, created2 = events.get_or_create_event("foobar", None, EventType.REACHABILITY)
+        event1, created1 = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        event2, created2 = events.get_or_create_event("foobar", None, ReachabilityEvent)
 
         assert event2 is event1

--- a/tests/statemodels_test.py
+++ b/tests/statemodels_test.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from zino.statemodels import Event, EventState, EventType
+from zino.statemodels import Event, EventState, ReachabilityEvent
 
 
 class TestEvent:
@@ -17,4 +17,4 @@ class TestEvent:
 
 @pytest.fixture
 def fake_event():
-    yield Event(id=42, router="example-gw.example.org", event_type=EventType.REACHABILITY, state=EventState.OPEN)
+    yield Event(id=42, router="example-gw.example.org", event_type=ReachabilityEvent, state=EventState.OPEN)


### PR DESCRIPTION
After our design discussions on Zino event types and attributes, we decided to subclass the `Event` class for every event type, rather than distinguish event types using an Enum.

This PR prepares the `Events` registry class for serialization/deserialization by turning it into a Pydantic model, then restructures the existing Event types to subclasses.  Fields that we have identified as pertaining only to specific event types are moved to those subclasses.

Also, this makes the necessary changes for Pydantic to be able to de-serialize an `Events` registry and ensure all the events are instantiated as the proper subclass.