### PR TITLE
Establish in-memory device state storage, with enterprise ID as proof-of-concept

### DIFF
--- a/src/zino/state.py
+++ b/src/zino/state.py
@@ -8,6 +8,7 @@ from typing import Dict
 
 from zino.config.models import PollDevice
 from zino.events import Events
+from zino.statemodels import DeviceStates
 
 _log = logging.getLogger(__name__)
 STATE_FILENAME = "zino-state.json"
@@ -16,7 +17,7 @@ STATE_FILENAME = "zino-state.json"
 polldevs: Dict[str, PollDevice] = {}
 
 # Dictionary of device state
-devices = {}
+devices = DeviceStates()
 
 # Dictionary of ongoing events
 events = Events()

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -72,7 +72,7 @@ class DeviceState(BaseModel):
 
     @property
     def is_juniper(self):
-        return self.enterprise_id == 2626
+        return self.enterprise_id == 2636
 
 
 class DeviceStates(BaseModel):

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -66,6 +66,27 @@ class DeviceState(BaseModel):
     # sawPeer
 
 
+class DeviceStates(BaseModel):
+    """Keeps track of the state of all devices we have polled from"""
+
+    devices: Dict[str, DeviceState] = {}
+
+    def __getitem__(self, item) -> DeviceState:
+        return self.devices[item]
+
+    def __contains__(self, item):
+        return item in self.devices
+
+    def __len__(self):
+        return len(self.devices)
+
+    def get(self, device_name: str) -> DeviceState:
+        """Returns a DeviceState object for device_name, creating a blank state object if none exists"""
+        if device_name not in self:
+            self.devices[device_name] = DeviceState(name=device_name)
+        return self[device_name]
+
+
 class LogEntry(BaseModel):
     """Event log entry attributes. These apply both for 'log' and 'history' lists"""
 

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -37,6 +37,7 @@ class DeviceState(BaseModel):
     """Keep device state"""
 
     name: str
+    enterprise_id: Optional[int]
     boot_time: Optional[int]
     ports: Optional[Dict[int, Port]]
 
@@ -64,6 +65,14 @@ class DeviceState(BaseModel):
     # portToIfDescr
     # portToLocIfDescr
     # sawPeer
+
+    @property
+    def is_cisco(self):
+        return self.enterprise_id == 9
+
+    @property
+    def is_juniper(self):
+        return self.enterprise_id == 2626
 
 
 class DeviceStates(BaseModel):

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -33,7 +33,7 @@ class Port(BaseModel):
     state: Optional[InterfaceOperState]
 
 
-class Device(BaseModel):
+class DeviceState(BaseModel):
     """Keep device state"""
 
     name: str

--- a/src/zino/tasks/__init__.py
+++ b/src/zino/tasks/__init__.py
@@ -6,5 +6,6 @@ async def run_all_tasks(device):
 
 def get_registered_tasks():
     from zino.tasks.reachabletask import ReachableTask
+    from zino.tasks.vendor import VendorTask
 
-    return [ReachableTask]
+    return [ReachableTask, VendorTask]

--- a/src/zino/tasks/vendor.py
+++ b/src/zino/tasks/vendor.py
@@ -1,0 +1,30 @@
+import logging
+from typing import Optional, Tuple
+
+from zino.snmp import SNMP
+from zino.tasks.task import Task
+
+_logger = logging.getLogger(__name__)
+ENTERPRISES = (1, 3, 6, 1, 4, 1)
+
+
+class VendorTask(Task):
+    """Fetches and stores state information about a Device's vendor"""
+
+    async def run(self):
+        vendor = await self._get_enterprise_id()
+        _logger.info("Device enterprise id: %r", vendor)
+
+    async def _get_enterprise_id(self) -> Optional[int]:
+        sysobjectid = await self._get_sysobjectid()
+        if not sysobjectid:
+            return
+        # This part can probably be a whole lot prettier if we learned how to utilize PySNMP properly:
+        if sysobjectid[: len(ENTERPRISES)] == ENTERPRISES:
+            return sysobjectid[len(ENTERPRISES)]
+
+    async def _get_sysobjectid(self) -> Optional[Tuple[int]]:
+        snmp = SNMP(self.device)
+        result = await snmp.get("SNMPv2-MIB", "sysObjectID", 0)
+        if result:
+            return result.value

--- a/src/zino/tasks/vendor.py
+++ b/src/zino/tasks/vendor.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, Tuple
 
+from zino import state
 from zino.snmp import SNMP
 from zino.tasks.task import Task
 
@@ -13,7 +14,14 @@ class VendorTask(Task):
 
     async def run(self):
         vendor = await self._get_enterprise_id()
-        _logger.info("Device enterprise id: %r", vendor)
+        _logger.debug("%s enterprise id: %r", self.device.name, vendor)
+        if not vendor:
+            return
+
+        device = state.devices.get(self.device.name)
+        if device.enterprise_id != vendor:
+            _logger.info("%s changed enterprise id from %s to %s", self.device.name, device.enterprise_id, vendor)
+            device.enterprise_id = vendor
 
     async def _get_enterprise_id(self) -> Optional[int]:
         sysobjectid = await self._get_sysobjectid()

--- a/src/zino/tasks/vendor.py
+++ b/src/zino/tasks/vendor.py
@@ -31,7 +31,7 @@ class VendorTask(Task):
         if sysobjectid[: len(ENTERPRISES)] == ENTERPRISES:
             return sysobjectid[len(ENTERPRISES)]
 
-    async def _get_sysobjectid(self) -> Optional[Tuple[int]]:
+    async def _get_sysobjectid(self) -> Optional[Tuple[int, ...]]:
         snmp = SNMP(self.device)
         result = await snmp.get("SNMPv2-MIB", "sysObjectID", 0)
         if result:

--- a/tests/statemodels_test.py
+++ b/tests/statemodels_test.py
@@ -18,7 +18,7 @@ class TestEvent:
 class TestDeviceState:
     @pytest.mark.parametrize(
         "enterprise_id,property_name,expected",
-        [(9, "is_cisco", True), (666, "is_cisco", False), (2626, "is_juniper", True), (666, "is_juniper", False)],
+        [(9, "is_cisco", True), (666, "is_cisco", False), (2636, "is_juniper", True), (666, "is_juniper", False)],
     )
     def test_vendor_utility_property_returns_expected_result(self, enterprise_id, property_name, expected):
         dev = DeviceState(name="foo", enterprise_id=enterprise_id)

--- a/tests/statemodels_test.py
+++ b/tests/statemodels_test.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from zino.statemodels import DeviceState, EventState, ReachabilityEvent
+from zino.statemodels import DeviceState, DeviceStates, EventState, ReachabilityEvent
 
 
 class TestEvent:
@@ -23,6 +23,22 @@ class TestDeviceState:
     def test_vendor_utility_property_returns_expected_result(self, enterprise_id, property_name, expected):
         dev = DeviceState(name="foo", enterprise_id=enterprise_id)
         assert getattr(dev, property_name) == expected
+
+
+class TestDeviceStates:
+    def test_empty_dict_should_not_contain_devices(self):
+        states = DeviceStates()
+        assert len(states) == 0
+        assert "foo" not in states
+
+    def test_get_should_create_new_device_state(self):
+        states = DeviceStates()
+        router = "new"
+        assert router not in states
+
+        result = states.get(router)
+        assert isinstance(result, DeviceState)
+        assert router in states
 
 
 @pytest.fixture

--- a/tests/statemodels_test.py
+++ b/tests/statemodels_test.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from zino.statemodels import EventState, ReachabilityEvent
+from zino.statemodels import DeviceState, EventState, ReachabilityEvent
 
 
 class TestEvent:
@@ -13,6 +13,16 @@ class TestEvent:
     def test_add_history_should_set_proper_timestamp(self, fake_event):
         log = fake_event.add_history("test")
         assert isinstance(log.timestamp, datetime.datetime)
+
+
+class TestDeviceState:
+    @pytest.mark.parametrize(
+        "enterprise_id,property_name,expected",
+        [(9, "is_cisco", True), (666, "is_cisco", False), (2626, "is_juniper", True), (666, "is_juniper", False)],
+    )
+    def test_vendor_utility_property_returns_expected_result(self, enterprise_id, property_name, expected):
+        dev = DeviceState(name="foo", enterprise_id=enterprise_id)
+        assert getattr(dev, property_name) == expected
 
 
 @pytest.fixture

--- a/tests/tasks/test_vendor.py
+++ b/tests/tasks/test_vendor.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+import pytest
+
+from zino.config.models import PollDevice
+from zino.statemodels import DeviceStates
+from zino.tasks.vendor import VendorTask
+
+
+class TestVendorTask:
+    @patch("zino.state.devices", DeviceStates())
+    @pytest.mark.asyncio
+    async def test_run_should_set_enterprise_id(self, snmpsim, snmp_test_port):
+        from zino import state
+
+        device = PollDevice(name="localhost", address="127.0.0.1", community="public", port=snmp_test_port)
+        task = VendorTask(device)
+        assert (await task.run()) is None
+        assert device.name in state.devices
+        # The "public" test fixture is from an HP switch
+        assert state.devices[device.name].enterprise_id == 11
+
+    @patch("zino.state.devices", DeviceStates())
+    @pytest.mark.asyncio
+    async def test_run_should_do_nothing_when_there_is_no_response(self):
+        from zino import state
+
+        device = PollDevice(name="localhost", address="127.0.0.1", community="invalid", port=666)
+        task = VendorTask(device)
+        assert (await task.run()) is None
+        assert len(state.devices) == 0


### PR DESCRIPTION
Closes #36 

Instead of storing explicit `is_cisco` or `is_juniper` values as part of the device state variables, this stores the raw enterprise ID value as a device state variable, and instead provides utility properties to detect either of the types we are interested in checking for.