### PR TITLE
Convert OID response values to tuples of ints

### DIFF
--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -188,6 +188,8 @@ class SNMP:
             value = int(value)
         elif isinstance(value, univ.OctetString):
             value = str(value)
+        elif isinstance(value, ObjectIdentity):
+            value = value.getOid().asTuple()
         else:
             raise ValueError(f"Could not convert unknown type {type(value)}")
         return MibObject(oid_string, value)

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -36,7 +36,7 @@ def _get_engine():
 @dataclass
 class MibObject:
     oid: str
-    value: Union[str, int]
+    value: Union[str, int, tuple[int, ...]]
 
 
 class SNMP:

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -47,6 +47,13 @@ class TestSNMPRequestsResponseTypes:
             assert isinstance(mib_object.oid, str)
             assert isinstance(mib_object.value, int)
 
+    @pytest.mark.asyncio
+    async def test_get_sysobjectid_should_be_tuple_of_ints(self, snmp_client):
+        response = await snmp_client.get("SNMPv2-MIB", "sysObjectID", 0)
+        assert isinstance(response.oid, str)
+        assert isinstance(response.value, tuple)
+        assert all(isinstance(i, int) for i in response.value)
+
 
 class TestSNMPRequestsUnknownMib:
     @pytest.mark.asyncio


### PR DESCRIPTION
Trying to fetch a sysObjectID using `SNMP.get` will crash, as it doesn't know how to convert a response value type of OID.

This PRs adds a test for that issue, and updates the code to convert such responses to tuples of ints.
