### PR TITLE
Encapsulate global state into a ZinoState class

### DIFF
--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -1,8 +1,8 @@
 import logging
 
-from zino import state
 from zino.scheduler import get_scheduler
 from zino.snmp import SNMP
+from zino.state import state
 from zino.statemodels import EventState, ReachabilityEvent, ReachabilityState
 from zino.tasks.task import Task
 

--- a/src/zino/tasks/vendor.py
+++ b/src/zino/tasks/vendor.py
@@ -18,7 +18,7 @@ class VendorTask(Task):
         if not vendor:
             return
 
-        device = state.devices.get(self.device.name)
+        device = state.state.devices.get(self.device.name)
         if device.enterprise_id != vendor:
             _logger.info("%s changed enterprise id from %s to %s", self.device.name, device.enterprise_id, vendor)
             device.enterprise_id = vendor

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -6,7 +6,6 @@ from datetime import datetime
 
 from zino import state
 from zino.scheduler import get_scheduler, load_and_schedule_polldevs
-from zino.state import load_state_from_file
 
 _log = logging.getLogger("zino")
 
@@ -17,7 +16,7 @@ def main():
         level=logging.INFO if not args.debug else logging.DEBUG,
         format="%(asctime)s - %(levelname)s - %(name)s (%(threadName)s) - %(message)s",
     )
-    load_state_from_file()
+    state.state = state.ZinoState.load_state_from_file() or state.ZinoState()
     init_event_loop(args)
 
 
@@ -32,8 +31,8 @@ def init_event_loop(args: argparse.Namespace):
         minutes=1,
         next_run_time=datetime.now(),
     )
-    scheduler.add_job(func=state.dump_state_to_file, trigger="interval", seconds=30)
-    scheduler.add_job(func=state.dump_state_to_log, trigger="interval", seconds=30)
+    scheduler.add_job(func=state.state.dump_state_to_file, trigger="interval", seconds=30)
+    scheduler.add_job(func=state.state.dump_state_to_log, trigger="interval", seconds=30)
 
     try:
         asyncio.get_event_loop().run_forever()

--- a/tests/tasks/test_vendor.py
+++ b/tests/tasks/test_vendor.py
@@ -3,15 +3,15 @@ from unittest.mock import patch
 import pytest
 
 from zino.config.models import PollDevice
-from zino.statemodels import DeviceStates
+from zino.state import ZinoState
 from zino.tasks.vendor import VendorTask
 
 
 class TestVendorTask:
-    @patch("zino.state.devices", DeviceStates())
+    @patch("zino.state.state", ZinoState())
     @pytest.mark.asyncio
     async def test_run_should_set_enterprise_id(self, snmpsim, snmp_test_port):
-        from zino import state
+        from zino.state import state
 
         device = PollDevice(name="localhost", address="127.0.0.1", community="public", port=snmp_test_port)
         task = VendorTask(device)
@@ -20,10 +20,10 @@ class TestVendorTask:
         # The "public" test fixture is from an HP switch
         assert state.devices[device.name].enterprise_id == 11
 
-    @patch("zino.state.devices", DeviceStates())
+    @patch("zino.state.state", ZinoState())
     @pytest.mark.asyncio
     async def test_run_should_do_nothing_when_there_is_no_response(self):
-        from zino import state
+        from zino.state import state
 
         device = PollDevice(name="localhost", address="127.0.0.1", community="invalid", port=666)
         task = VendorTask(device)


### PR DESCRIPTION
This primarily changes how global state is handled, by encapsulating all state that needs to be persistent between Zino runs into a new ZinoState class (a Pydantic model).

The encapsulation includes the old `zino.state.devices` object, so that device state is now also persisted to disk.  I.e. : This closes #35. 