### PR TITLE
Update reachability event attribute for new job

### DIFF
--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -37,13 +37,13 @@ class ReachableTask(Task):
             self._schedule_extra_job()
         else:
             _logger.debug("Device %s is reachable", self.device.name)
-            self._update_reachability_event()
+            self._update_reachability_event_as_reachable()
 
     async def _run_extra_job(self):
         result = await self._get_sysuptime()
         if result:
             _logger.debug("Device %s is reachable", self.device.name)
-            self._update_reachability_event()
+            self._update_reachability_event_as_reachable()
             self._deschedule_extra_job()
 
     async def _get_sysuptime(self):
@@ -51,7 +51,7 @@ class ReachableTask(Task):
         result = await snmp.get("SNMPv2-MIB", "sysUpTime", 0)
         return result
 
-    def _update_reachability_event(self):
+    def _update_reachability_event_as_reachable(self):
         event = state.events.get(self.device.name, None, ReachabilityEvent)
         if event and event.reachability != ReachabilityState.REACHABLE:
             event.reachability = ReachabilityState.REACHABLE

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -1,5 +1,7 @@
 import logging
 
+from apscheduler.jobstores.base import JobLookupError
+
 from zino.scheduler import get_scheduler
 from zino.snmp import SNMP
 from zino.state import state
@@ -68,7 +70,10 @@ class ReachableTask(Task):
 
     def _deschedule_extra_job(self):
         name = self._get_extra_job_name()
-        self._scheduler.remove_job(job_id=name)
+        try:
+            self._scheduler.remove_job(job_id=name)
+        except JobLookupError:
+            pass
 
     def _extra_job_is_running(self):
         name = self._get_extra_job_name()

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -27,7 +27,6 @@ class ReachableTask(Task):
             _logger.debug("Device %s is not reachable", self.device.name)
             event, created = state.events.get_or_create_event(self.device.name, None, ReachabilityEvent)
             if created:
-                # TODO add attributes
                 event.state = EventState.OPEN
                 event.add_history("Change state to Open")
             if event.reachability != ReachabilityState.NORESPONSE:
@@ -56,7 +55,6 @@ class ReachableTask(Task):
         if event and event.reachability != ReachabilityState.REACHABLE:
             event.reachability = ReachabilityState.REACHABLE
             event.add_log(f"{self.device.name} reachable")
-        # TODO we need a mechanism to "commit" event changes, to trigger notifications to clients
 
     def _schedule_extra_job(self):
         name = self._get_extra_job_name()


### PR DESCRIPTION
When a reachability task job is run and the job is marked an not reachable, an event is created with the reachability attribute `no-response` and another task is scheduled. That state is saved to file.
Now I stopped zino, to update the community of that device and started zino again. Now the reachability task job is run, but the event reachability attribute was not updated. This PR makes sure that it is updated.

And a JobLookupError is caught when removing the extra job, just in case, as we do it in `deschedule_deleted_devices`.