### PR TITLE
Rename task fixture in reachabletask tests to be more descriptive

### DIFF
--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -7,7 +7,7 @@ from zino.tasks.reachabletask import ReachableTask
 
 
 @pytest.fixture()
-def task(snmpsim, snmp_test_port):
+def reachable_task(snmpsim, snmp_test_port):
     device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port)
     state = ZinoState()
     task = ReachableTask(device, state)
@@ -26,7 +26,8 @@ def unreachable_task():
 
 class TestReachableTask:
     @pytest.mark.asyncio
-    async def test_run_should_not_create_event_if_device_is_reachable(self, task):
+    async def test_run_should_not_create_event_if_device_is_reachable(self, reachable_task):
+        task = reachable_task
         assert (await task.run()) is None
         event = task.state.events.get(task.device.name, None, ReachabilityEvent)
         assert not event
@@ -44,12 +45,14 @@ class TestReachableTask:
         assert unreachable_task._extra_job_is_running()
 
     @pytest.mark.asyncio
-    async def test_run_should_not_start_extra_job_if_device_is_reachable(self, task):
+    async def test_run_should_not_start_extra_job_if_device_is_reachable(self, reachable_task):
+        task = reachable_task
         assert (await task.run()) is None
         assert not task._extra_job_is_running()
 
     @pytest.mark.asyncio
-    async def test_run_should_update_event_to_reachable_when_device_is_reachable(self, task):
+    async def test_run_should_update_event_to_reachable_when_device_is_reachable(self, reachable_task):
+        task = reachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
         event.state = EventState.OPEN
         event.reachability = ReachabilityState.NORESPONSE
@@ -66,7 +69,8 @@ class TestReachableTask:
         assert event.reachability == ReachabilityState.NORESPONSE
 
     @pytest.mark.asyncio
-    async def test_run_extra_job_should_update_event_to_reachable_when_device_is_reachable(self, task):
+    async def test_run_extra_job_should_update_event_to_reachable_when_device_is_reachable(self, reachable_task):
+        task = reachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
         event.state = EventState.OPEN
         event.reachability = ReachabilityState.NORESPONSE


### PR DESCRIPTION
Supplement to #51.