### PR TITLE
Stop sparsewalk from always logging errors

### DIFF
--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -328,6 +328,8 @@ class SNMP:
 
             # Build next set of query objects from last result row
             query_objects = [v for v in var_binds if _var_bind_is_in_scope(v)]
+            if not query_objects:
+                break  # Nothing left to query
         return dict(results)
 
     @staticmethod


### PR DESCRIPTION
The sparsewalk routine had one bug: Once it had no more objects to query, it would still send out an empty GET-BULK query, which would always result in an error response from the SNMP agent, and thus, a pretty annoying error log