### PR TITLE
Raise and handle exceptions in SNMP module

### DIFF
--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -383,7 +383,7 @@ class SNMP:
 
     @property
     def udp_transport_target(self) -> UdpTransportTarget:
-        return UdpTransportTarget((str(self.device.address), self.device.port))
+        return UdpTransportTarget((str(self.device.address), self.device.port), timeout=self.device.timeout)
 
 
 def _convert_varbind(ident: ObjectIdentity, value: ObjectType) -> SNMPVarBind:

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -201,7 +201,7 @@ class SNMP:
             results.append(mib_object)
         return results
 
-    async def getbulk(self, *oid: str, max_repetitions: int = 10) -> list[MibObject]:
+    async def getbulk(self, *oid: str, max_repetitions: int = 1) -> list[MibObject]:
         """SNMP-BULKs the given oid
         Example usage:
             getbulk("IF-MIB", "ifName", max_repetitions=5)

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -69,7 +69,7 @@ class SnmpError(Exception):
 
 class ErrorIndication(Exception):
     """Class for SNMP errors that occur locally,
-    as opposed to being reported from a different SNMP entitiy.
+    as opposed to being reported from a different SNMP entity.
     """
 
 
@@ -80,7 +80,7 @@ class MibNotFoundError(ErrorIndication):
 
 
 class ErrorStatus(SnmpError):
-    """Raised if a SNMP entity includes a non-zero error status in its response PDU.
+    """Raised if an SNMP entity includes a non-zero error status in its response PDU.
     RFC 1905 defines the possible errors that can be specified in the error status field.
     This can either be used directly or subclassed for one of these specific errors.
     """

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -18,7 +18,7 @@ from pysnmp.hlapi.asyncio import (
     getCmd,
     nextCmd,
 )
-from pysnmp.proto.errind import RequestTimedOut
+from pysnmp.proto import errind
 from pysnmp.proto.rfc1905 import errorStatus
 from pysnmp.smi import builder, view
 from pysnmp.smi.error import MibNotFoundError as PysnmpMibNotFoundError
@@ -126,11 +126,17 @@ class SNMP:
         self._raise_errors(error_indication, error_status, error_index, query)
         return self._object_type_to_mib_object(var_binds[0])
 
-    def _raise_errors(self, error_indication: str, error_status: str, error_index: int, *query: ObjectType):
+    def _raise_errors(
+        self,
+        error_indication: Union[str, errind.ErrorIndication],
+        error_status: str,
+        error_index: int,
+        *query: ObjectType,
+    ):
         """Raises a relevant exception if an error has occurred"""
         # Local errors (timeout, config errors etc)
         if error_indication:
-            if isinstance(error_indication, RequestTimedOut):
+            if isinstance(error_indication, errind.RequestTimedOut):
                 raise TimeoutError(str(error_indication))
             else:
                 raise ErrorIndication(str(error_indication))

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -99,9 +99,8 @@ class SNMP:
 
     NON_REPEATERS = 0
 
-    def __init__(self, device: PollDevice, retries=5):
+    def __init__(self, device: PollDevice):
         self.device = device
-        self.retries = retries
 
     async def get(self, *oid: str) -> MibObject:
         """SNMP-GETs the given oid
@@ -379,7 +378,7 @@ class SNMP:
     @property
     def udp_transport_target(self) -> UdpTransportTarget:
         return UdpTransportTarget(
-            (str(self.device.address), self.device.port), timeout=self.device.timeout, retries=self.retries
+            (str(self.device.address), self.device.port), timeout=self.device.timeout, retries=self.device.retries
         )
 
 

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -99,8 +99,9 @@ class SNMP:
 
     NON_REPEATERS = 0
 
-    def __init__(self, device: PollDevice):
+    def __init__(self, device: PollDevice, retries=5):
         self.device = device
+        self.retries = retries
 
     async def get(self, *oid: str) -> Union[MibObject, None]:
         """SNMP-GETs the given oid
@@ -383,7 +384,9 @@ class SNMP:
 
     @property
     def udp_transport_target(self) -> UdpTransportTarget:
-        return UdpTransportTarget((str(self.device.address), self.device.port), timeout=self.device.timeout)
+        return UdpTransportTarget(
+            (str(self.device.address), self.device.port), timeout=self.device.timeout, retries=self.retries
+        )
 
 
 def _convert_varbind(ident: ObjectIdentity, value: ObjectType) -> SNMPVarBind:

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -181,7 +181,7 @@ class SNMP:
             results.append(mib_object)
         return results
 
-    async def getbulk(self, *oid: str, max_repetitions: int = 1) -> list[MibObject]:
+    async def getbulk(self, *oid: str, max_repetitions: int = 10) -> list[MibObject]:
         """SNMP-BULKs the given oid
         Example usage:
             getbulk("IF-MIB", "ifName", max_repetitions=5)

--- a/src/zino/tasks/vendor.py
+++ b/src/zino/tasks/vendor.py
@@ -14,8 +14,6 @@ class VendorTask(Task):
     async def run(self):
         vendor = await self._get_enterprise_id()
         _logger.debug("%s enterprise id: %r", self.device.name, vendor)
-        if not vendor:
-            return
 
         device = self.state.devices.get(self.device.name)
         if device.enterprise_id != vendor:
@@ -24,8 +22,6 @@ class VendorTask(Task):
 
     async def _get_enterprise_id(self) -> Optional[int]:
         sysobjectid = await self._get_sysobjectid()
-        if not sysobjectid:
-            return
         # This part can probably be a whole lot prettier if we learned how to utilize PySNMP properly:
         if sysobjectid[: len(ENTERPRISES)] == ENTERPRISES:
             return sysobjectid[len(ENTERPRISES)]
@@ -33,5 +29,4 @@ class VendorTask(Task):
     async def _get_sysobjectid(self) -> Optional[Tuple[int, ...]]:
         snmp = SNMP(self.device)
         result = await snmp.get("SNMPv2-MIB", "sysObjectID", 0)
-        if result:
-            return result.value
+        return result.value

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from zino.config.models import PollDevice
 from zino.oid import OID
-from zino.snmp import SNMP, MibNotFoundError
+from zino.snmp import SNMP, MibNotFoundError, ObjectNotFoundError
 
 
 @pytest.fixture(scope="session")
@@ -174,3 +174,9 @@ class TestUnreachableDeviceShouldRaiseException:
     async def test_sparsewalk(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.sparsewalk(("SNMPv2-MIB", "sysUpTime"))
+
+
+@pytest.mark.asyncio
+async def test_get_object_that_does_not_exist_should_raise_exception(snmp_client):
+    with pytest.raises(ObjectNotFoundError):
+        await snmp_client.get("SNMPv2-MIB", "sysUpTime", 1)

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from zino.config.models import PollDevice
 from zino.oid import OID
-from zino.snmp import SNMP, MibNotFoundError, ObjectNotFoundError
+from zino.snmp import SNMP, MibNotFoundError, NoSuchNameError
 
 
 @pytest.fixture(scope="session")
@@ -178,5 +178,5 @@ class TestUnreachableDeviceShouldRaiseException:
 
 @pytest.mark.asyncio
 async def test_get_object_that_does_not_exist_should_raise_exception(snmp_client):
-    with pytest.raises(ObjectNotFoundError):
+    with pytest.raises(NoSuchNameError):
         await snmp_client.get("SNMPv2-MIB", "sysUpTime", 1)

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -8,13 +8,13 @@ from zino.snmp import SNMP, MibNotFoundError, NoSuchNameError
 @pytest.fixture(scope="session")
 def snmp_client(snmpsim, snmp_test_port):
     device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port, timeout=1)
-    return SNMP(device, retries=0)
+    return SNMP(device)
 
 
 @pytest.fixture(scope="session")
 def unreachable_snmp_client():
-    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666, timeout=1)
-    return SNMP(device, retries=0)
+    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666, timeout=1, retries=0)
+    return SNMP(device)
 
 
 class TestSNMPRequestsResponseTypes:

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -7,7 +7,7 @@ from zino.snmp import SNMP, MibNotFoundError, NoSuchNameError
 
 @pytest.fixture(scope="session")
 def snmp_client(snmpsim, snmp_test_port):
-    device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port, timeout=1)
+    device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port)
     return SNMP(device)
 
 

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -7,14 +7,14 @@ from zino.snmp import SNMP, MibNotFoundError, NoSuchNameError
 
 @pytest.fixture(scope="session")
 def snmp_client(snmpsim, snmp_test_port):
-    device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port)
-    return SNMP(device)
+    device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port, timeout=1)
+    return SNMP(device, retries=0)
 
 
 @pytest.fixture(scope="session")
 def unreachable_snmp_client():
-    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666)
-    return SNMP(device)
+    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666, timeout=1)
+    return SNMP(device, retries=0)
 
 
 class TestSNMPRequestsResponseTypes:

--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from zino.config.models import PollDevice
@@ -20,7 +22,9 @@ def unreachable_task():
     device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666, timeout=1)
     state = ZinoState()
     task = ReachableTask(device, state)
-    yield task
+    with patch("zino.tasks.reachabletask.SNMP.get") as get_mock:
+        get_mock.side_effect = TimeoutError
+        yield task
     task._deschedule_extra_job()
 
 

--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -17,7 +17,7 @@ def reachable_task(snmpsim, snmp_test_port):
 
 @pytest.fixture()
 def unreachable_task():
-    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666)
+    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666, timeout=1)
     state = ZinoState()
     task = ReachableTask(device, state)
     yield task

--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -19,7 +19,7 @@ def reachable_task(snmpsim, snmp_test_port):
 
 @pytest.fixture()
 def unreachable_task():
-    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666, timeout=1)
+    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666)
     state = ZinoState()
     task = ReachableTask(device, state)
     with patch("zino.tasks.reachabletask.SNMP.get") as get_mock:

--- a/tests/tasks/test_vendor.py
+++ b/tests/tasks/test_vendor.py
@@ -19,11 +19,12 @@ class TestVendorTask:
         assert state.devices[device.name].enterprise_id == 11
 
     @pytest.mark.asyncio
-    async def test_run_should_do_nothing_when_there_is_no_response(self):
+    async def test_run_should_raise_exception_when_there_is_no_response(self):
         device = PollDevice(name="localhost", address="127.0.0.1", community="invalid", port=666)
         state = ZinoState()
         task = VendorTask(device, state)
         with patch("zino.tasks.reachabletask.SNMP.get") as get_mock:
             get_mock.side_effect = TimeoutError
-            assert (await task.run()) is None
+            with pytest.raises(TimeoutError):
+                await task.run()
         assert len(state.devices) == 0

--- a/tests/tasks/test_vendor.py
+++ b/tests/tasks/test_vendor.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from zino.config.models import PollDevice
@@ -21,5 +23,7 @@ class TestVendorTask:
         device = PollDevice(name="localhost", address="127.0.0.1", community="invalid", port=666)
         state = ZinoState()
         task = VendorTask(device, state)
-        assert (await task.run()) is None
+        with patch("zino.tasks.reachabletask.SNMP.get") as get_mock:
+            get_mock.side_effect = TimeoutError
+            assert (await task.run()) is None
         assert len(state.devices) == 0


### PR DESCRIPTION
Fixes #73 

This PR makes snmp functions raise exceptions if something goes wrong.
A hierarchy of exceptions for snmp related errors is added for this purpose.

This will cause tasks to fail unless its natural for the task to handle certain exceptions.
For example, it will be natural for ReachableTask to handle TimeoutError, since detecting 
a device not answering is the purpose of the task. VendorTask on the other hand can not function if
a timeout occurs, so it will be natural for this task to let the exception raise further up the chain.

Currently this will cause zino to crash, so a new issue will be needed for handling tasks failing.