### PR TITLE
Implement getnext capable of multi-var query

### DIFF
--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -197,8 +197,7 @@ class SNMP:
 
         :param variables: Values for defining OIDs. For detailed use see
         https://github.com/pysnmp/pysnmp/blob/bc1fb3c39764f36c1b7c9551b52ef8246b9aea7c/pysnmp/smi/rfc1902.py#L35-L49
-        :return: A sequence of MibObject instances representing the resulting MIB variables, or None if nothing could
-                 be found
+        :return: A sequence of MibObject instances representing the resulting MIB variables
         """
         query = [self._oid_to_object_type(*var) for var in variables]
         response = await self._getnext2(*query)
@@ -208,7 +207,7 @@ class SNMP:
         """SNMP-GETNEXTs the given variables
 
         :param variables: An sequence of ObjectTypes representing the objects you want to query
-        :return: A sequence of ObjectTypes representing the resulting MIB variables, or None if nothing could be found
+        :return: A sequence of ObjectTypes representing the resulting MIB variables
         """
         try:
             error_indication, error_status, error_index, var_bind_table = await nextCmd(

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -107,6 +107,11 @@ class TestUnknownMibShouldRaiseException:
             await snmp_client.getnext("NON-EXISTENT-MIB", "foo")
 
     @pytest.mark.asyncio
+    async def test_getnext2(self, snmp_client):
+        with pytest.raises(MibNotFoundError):
+            await snmp_client.getnext2(("NON-EXISTENT-MIB", "foo"))
+
+    @pytest.mark.asyncio
     async def test_walk(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.walk("NON-EXISTENT-MIB", "foo")
@@ -156,6 +161,11 @@ class TestUnreachableDeviceShouldRaiseException:
     async def test_getnext(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.getnext("SNMPv2-MIB", "sysUpTime")
+
+    @pytest.mark.asyncio
+    async def test_getnext2(self, unreachable_snmp_client):
+        with pytest.raises(TimeoutError):
+            await unreachable_snmp_client.getnext2(("SNMPv2-MIB", "sysUpTime"))
 
     @pytest.mark.asyncio
     async def test_walk(self, unreachable_snmp_client):

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -34,8 +34,8 @@ class TestSNMPRequestsResponseTypes:
     async def test_getnext2_should_return_symbolic_identifiers(self, snmp_client):
         response = await snmp_client.getnext2(("IF-MIB", "ifName", "1"), ("IF-MIB", "ifAlias", "1"))
         assert len(list(response)) == 2
-        assert any(k == Identifier("IF-MIB", "ifName", OID(".2")) for k, v in response)
-        assert any(k == Identifier("IF-MIB", "ifAlias", OID(".2")) for k, v in response)
+        assert any(identifier == Identifier("IF-MIB", "ifName", OID(".2")) for identifier, _ in response)
+        assert any(identifier == Identifier("IF-MIB", "ifAlias", OID(".2")) for identifier, _ in response)
 
     @pytest.mark.asyncio
     async def test_walk(self, snmp_client):

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from zino.config.models import PollDevice
 from zino.oid import OID
-from zino.snmp import SNMP, MibNotFoundError, NoSuchNameError
+from zino.snmp import SNMP, Identifier, MibNotFoundError, NoSuchNameError
 
 
 @pytest.fixture(scope="session")
@@ -29,6 +29,13 @@ class TestSNMPRequestsResponseTypes:
         response = await snmp_client.getnext("SNMPv2-MIB", "sysUpTime")
         assert isinstance(response.oid, OID)
         assert isinstance(response.value, int)
+
+    @pytest.mark.asyncio
+    async def test_getnext2_should_return_symbolic_identifiers(self, snmp_client):
+        response = await snmp_client.getnext2(("IF-MIB", "ifName", "1"), ("IF-MIB", "ifAlias", "1"))
+        assert len(list(response)) == 2
+        assert any(k == Identifier("IF-MIB", "ifName", OID(".2")) for k, v in response)
+        assert any(k == Identifier("IF-MIB", "ifAlias", OID(".2")) for k, v in response)
 
     @pytest.mark.asyncio
     async def test_walk(self, snmp_client):


### PR DESCRIPTION
This adds an alternative getnext implementation (getnext2), which is capable of dispatching multi-varbind queries, and capable of translating the response varbinds to symbolic names.