### PR TITLE
Add IPv6 support to SNMP class

### DIFF
--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -13,6 +13,7 @@ from pysnmp.hlapi.asyncio import (
     ObjectIdentity,
     ObjectType,
     SnmpEngine,
+    Udp6TransportTarget,
     UdpTransportTarget,
     bulkCmd,
     getCmd,
@@ -382,8 +383,10 @@ class SNMP:
         return CommunityData(self.device.community, mpModel=self.mp_model)
 
     @property
-    def udp_transport_target(self) -> UdpTransportTarget:
-        return UdpTransportTarget(
+    def udp_transport_target(self) -> Union[UdpTransportTarget, Udp6TransportTarget]:
+        assert self.device.address.version in (4, 6)
+        target = UdpTransportTarget if self.device.address.version == 4 else Udp6TransportTarget
+        return target(
             (str(self.device.address), self.device.port), timeout=self.device.timeout, retries=self.device.retries
         )
 

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -1,4 +1,5 @@
 import pytest
+from pysnmp.hlapi.asyncio import Udp6TransportTarget, UdpTransportTarget
 
 from zino.config.models import PollDevice
 from zino.oid import OID
@@ -8,6 +9,12 @@ from zino.snmp import SNMP, MibNotFoundError, NoSuchNameError
 @pytest.fixture(scope="session")
 def snmp_client(snmpsim, snmp_test_port):
     device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port)
+    return SNMP(device)
+
+
+@pytest.fixture(scope="session")
+def ipv6_snmp_client(snmpsim, snmp_test_port) -> SNMP:
+    device = PollDevice(name="buick.lab.example.org", address="::1", port=snmp_test_port)
     return SNMP(device)
 
 
@@ -180,3 +187,11 @@ class TestUnreachableDeviceShouldRaiseException:
 async def test_get_object_that_does_not_exist_should_raise_exception(snmp_client):
     with pytest.raises(NoSuchNameError):
         await snmp_client.get("SNMPv2-MIB", "sysUpTime", 1)
+
+
+class TestUdpTransportTarget:
+    def test_when_device_address_is_ipv6_then_udp6_transport_should_be_returned(self, ipv6_snmp_client):
+        assert isinstance(ipv6_snmp_client.udp_transport_target, Udp6TransportTarget)
+
+    def test_when_device_address_is_ipv4_then_udp_transport_should_be_returned(self, snmp_client):
+        assert isinstance(snmp_client.udp_transport_target, UdpTransportTarget)


### PR DESCRIPTION
The `zino.snmp.SNMP` class did not support talking to devices over IPv6.  While the Zino 1 codebase doesn't support this, adding that support to Zino 2 is easy, and has been supported in the config file since the first commit of the config parser.

This was tested to work against devices actually running on IPv6.