### PR TITLE
Add Python 3.11 to project classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: System :: Networking :: Monitoring",
 ]
 dependencies = [


### PR DESCRIPTION
We test on Python 3.11, so why wouldn't we have this classifier?