### PR TITLE
Add challenge/response auth mechanism to the API server protocol

### DIFF
--- a/src/zino/api/auth.py
+++ b/src/zino/api/auth.py
@@ -1,0 +1,61 @@
+"""Zino API authentication mechanisms.
+
+This only implements the authentication scheme of the legacy server protocol.
+"""
+import io
+import secrets
+from hashlib import sha1
+from pathlib import Path
+from typing import Optional, Union
+
+
+def authenticate(
+    user: str, response: str, challenge: Optional[str] = None, secrets_file: Optional[Union[Path, str]] = "secrets"
+) -> bool:
+    """Authenticates a user challenge response.
+
+    An unsuccessful authentication will raise an AuthenticationFailure, otherwise True is returned.
+
+    As per the original Zino specification, a newly connected user will be issued a challenge string, and must prove
+    they know the user's secret by responding to the challenge with something that corresponds to
+    `SHA1(challenge + " " + secret)`
+    """
+    users = read_users(secrets_file)
+    if user not in users:
+        raise AuthenticationFailure("no such user")
+
+    if not challenge:
+        # We do not support other authentication modes yet
+        raise AuthenticationFailure("only challenge-response authentication is supported right now")
+
+    cleartext = f"{challenge} {users[user]}".encode()
+    expected = sha1(cleartext).hexdigest()
+    if response == expected:
+        return True
+    else:
+        raise AuthenticationFailure()
+        # The original Zino code also supports fallback to cleartext and tacacs authentication, but only if enabled
+
+
+def get_challenge() -> str:
+    """Returns a new authentication challenge string"""
+    # The original Zino codebase uses a SHA1 hash of the current timestamp, but this is too predictable, so we use more
+    # randomness
+    string = secrets.token_bytes(40)
+    return sha1(string).hexdigest()
+
+
+def read_users(filename: Optional[Union[Path, str]] = "secrets") -> dict[str, str]:
+    """Reads the legacy users database and returns a dictionary of usernames and their secrets"""
+    secrets = {}
+    with io.open(filename, "r", encoding="utf-8") as users:
+        nonempty_lines = (ln.strip() for ln in users.readlines() if ln.strip())
+        for line in nonempty_lines:
+            user, secret = line.split(" ", maxsplit=1)
+            secrets[user] = secret
+
+    return secrets
+
+
+class AuthenticationFailure(Exception):
+    pass

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -10,6 +10,8 @@ import re
 import textwrap
 from typing import Callable, List, Optional
 
+from zino.api import auth
+
 _logger = logging.getLogger(__name__)
 
 
@@ -28,6 +30,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
         self._current_task: asyncio.Task = None
         self._multiline_future: asyncio.Future = None
         self._multiline_buffer: List[str] = []
+        self._authentication_challenge: Optional[str] = None
 
     @property
     def peer_name(self):
@@ -40,7 +43,8 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
     def connection_made(self, transport: asyncio.Transport):
         self.transport = transport
         _logger.debug("New server connection from %s", self.peer_name)
-        self._respond_ok("PLACEHOLDER-CHALLENGE Hello, there")
+        self._authentication_challenge = auth.get_challenge()
+        self._respond_ok(f"{self._authentication_challenge} Hello, there")
 
     def data_received(self, data):
         try:

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -149,11 +149,13 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         """Implements the USER command"""
         if self.is_authenticated:
             return self._respond_error("already authenticated")
-        if user == "foo" and response == "bar":
-            self._authenticated = True
-            return self._respond_ok("welcome")
+        try:
+            auth.authenticate(user=user, response=response, challenge=self._authentication_challenge)
+        except auth.AuthenticationFailure as error:
+            return self._respond_error(error)
         else:
-            return self._respond_error("bad auth")
+            self._authenticated = True
+            return self._respond_ok()
 
     async def do_quit(self):
         """Implements the QUIT command"""

--- a/tests/api/auth_test.py
+++ b/tests/api/auth_test.py
@@ -43,7 +43,11 @@ class TestAuthenticate:
 
 
 class TestGetChallenge:
-    def test_should_never_return_same_challenge(self):
+    def test_should_return_unique_challenges(self):
+        """Challenge strings are expected to be random.  Once in a million years this could fail because of the
+        nature of randomness, but it should also protect against the implementation being changed into something that
+        returns a constant value.
+        """
         count = 10
         challenges = set(get_challenge() for _ in range(count))
         assert len(challenges) == 10, "same challenge was produced more than once"

--- a/tests/api/auth_test.py
+++ b/tests/api/auth_test.py
@@ -1,0 +1,71 @@
+import pytest
+
+from zino.api.auth import AuthenticationFailure, authenticate, get_challenge, read_users
+
+
+class TestAuthenticate:
+    def test_when_challenge_response_is_ok_should_return_true(self, secrets_file):
+        assert authenticate(
+            "user1",
+            response="b3e9ba156949152c5c6f3334cf86333b1daabfe9",
+            challenge="a97fbebb3eef2dfcf167645229c0c5fa9e92e3da",
+            secrets_file=secrets_file,
+        )
+
+    def test_when_challenge_response_is_bad_should_raise_error(self, secrets_file):
+        with pytest.raises(AuthenticationFailure):
+            assert authenticate(
+                "user1",
+                response="b3e9ba156949152c5a6f3334df86333b1daabfe9",
+                challenge="a97fbebb3eef2dfcf167645229c0c5fa9e92e3da",
+                secrets_file=secrets_file,
+            )
+
+    def test_when_user_does_not_exist_should_raise_error(self, secrets_file):
+        with pytest.raises(AuthenticationFailure):
+            assert authenticate(
+                "nobody",
+                response="doesntmatter",
+                challenge="doesntmatter",
+                secrets_file=secrets_file,
+            )
+
+    def test_when_challenge_is_empty_should_raise_error(self, secrets_file):
+        """Can be removed when challenge-less auth is supported"""
+        with pytest.raises(AuthenticationFailure):
+            assert authenticate(
+                "user1",
+                response="doesntmatter",
+                secrets_file=secrets_file,
+            )
+
+
+class TestGetChallenge:
+    def test_should_never_return_same_challenge(self):
+        count = 10
+        challenges = set(get_challenge() for _ in range(count))
+        assert len(challenges) == 10, "same challenge was produced more than once"
+
+    def test_should_return_at_least_40_characters(self):
+        assert len(get_challenge()) >= 40
+
+
+def test_read_users_when_given_a_valid_file_then_a_proper_dict_should_be_returned(secrets_file):
+    users = read_users(secrets_file)
+    for user in ("user1", "user2", "user3"):
+        assert user in users
+        assert len(users[user]) == 40
+
+
+@pytest.fixture
+def secrets_file(tmp_path):
+    name = tmp_path.joinpath("secrets")
+    with open(name, "w") as conf:
+        conf.write(
+            """user1 3c55d3cdc19876dfc8c0bb49da8c927a0ddff26d
+            user2 eb6fb35f5fbba6a6e43d3c893ad7a77dc793ceba
+
+            user3 c8a0b250edb2eabd9616b7b05a46e0ad28226fc2
+            """
+        )
+    yield name

--- a/tests/api/auth_test.py
+++ b/tests/api/auth_test.py
@@ -55,17 +55,3 @@ def test_read_users_when_given_a_valid_file_then_a_proper_dict_should_be_returne
     for user in ("user1", "user2", "user3"):
         assert user in users
         assert len(users[user]) == 40
-
-
-@pytest.fixture
-def secrets_file(tmp_path):
-    name = tmp_path.joinpath("secrets")
-    with open(name, "w") as conf:
-        conf.write(
-            """user1 3c55d3cdc19876dfc8c0bb49da8c927a0ddff26d
-            user2 eb6fb35f5fbba6a6e43d3c893ad7a77dc793ceba
-
-            user3 c8a0b250edb2eabd9616b7b05a46e0ad28226fc2
-            """
-        )
-    yield name

--- a/tests/api/auth_test.py
+++ b/tests/api/auth_test.py
@@ -5,18 +5,20 @@ from zino.api.auth import AuthenticationFailure, authenticate, get_challenge, re
 
 class TestAuthenticate:
     def test_when_challenge_response_is_ok_should_return_true(self, secrets_file):
+        good_response = "b3e9ba156949152c5c6f3334cf86333b1daabfe9"
         assert authenticate(
             "user1",
-            response="b3e9ba156949152c5c6f3334cf86333b1daabfe9",
+            response=good_response,
             challenge="a97fbebb3eef2dfcf167645229c0c5fa9e92e3da",
             secrets_file=secrets_file,
         )
 
     def test_when_challenge_response_is_bad_should_raise_error(self, secrets_file):
+        bad_response = "aaa9ba156949152c5c6f3334cf86333b1daabbbb"
         with pytest.raises(AuthenticationFailure):
             assert authenticate(
                 "user1",
-                response="b3e9ba156949152c5a6f3334df86333b1daabfe9",
+                response=bad_response,
                 challenge="a97fbebb3eef2dfcf167645229c0c5fa9e92e3da",
                 secrets_file=secrets_file,
             )

--- a/tests/api/auth_test.py
+++ b/tests/api/auth_test.py
@@ -52,8 +52,15 @@ class TestGetChallenge:
         assert len(get_challenge()) >= 40
 
 
-def test_read_users_when_given_a_valid_file_then_a_proper_dict_should_be_returned(secrets_file):
-    users = read_users(secrets_file)
-    for user in ("user1", "user2", "user3"):
-        assert user in users
-        assert len(users[user]) == 40
+class TestReadUsers:
+    def test_result_should_match_input_file(self, secrets_file):
+        expected = {
+            "user1": "3c55d3cdc19876dfc8c0bb49da8c927a0ddff26d",
+            "user2": "eb6fb35f5fbba6a6e43d3c893ad7a77dc793ceba",
+            "user3": "c8a0b250edb2eabd9616b7b05a46e0ad28226fc2",
+        }
+        users = read_users(secrets_file)
+        assert users == expected
+
+    def test_should_not_crash_on_empty_lines_in_input(self, secrets_file_littered_with_empty_lines):
+        assert read_users(secrets_file_littered_with_empty_lines)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -8,6 +8,20 @@ def secrets_file(tmp_path):
         conf.write(
             """user1 3c55d3cdc19876dfc8c0bb49da8c927a0ddff26d
             user2 eb6fb35f5fbba6a6e43d3c893ad7a77dc793ceba
+            user3 c8a0b250edb2eabd9616b7b05a46e0ad28226fc2
+            """
+        )
+    yield name
+
+
+@pytest.fixture
+def secrets_file_littered_with_empty_lines(tmp_path):
+    name = tmp_path.joinpath("secrets")
+    with open(name, "w") as conf:
+        conf.write(
+            """user1 3c55d3cdc19876dfc8c0bb49da8c927a0ddff26d
+
+            user2 eb6fb35f5fbba6a6e43d3c893ad7a77dc793ceba
 
             user3 c8a0b250edb2eabd9616b7b05a46e0ad28226fc2
             """

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.fixture
+def secrets_file(tmp_path):
+    name = tmp_path.joinpath("secrets")
+    with open(name, "w") as conf:
+        conf.write(
+            """user1 3c55d3cdc19876dfc8c0bb49da8c927a0ddff26d
+            user2 eb6fb35f5fbba6a6e43d3c893ad7a77dc793ceba
+
+            user3 c8a0b250edb2eabd9616b7b05a46e0ad28226fc2
+            """
+        )
+    yield name


### PR DESCRIPTION
Closes #91 .

This does not add all the functionality of the original, as it has the option to configure aspects of authentication through a config file.  We have not yet added a config file feature, so we have added this update to the task list in #63