### PR TITLE
Initial implementation of the GETATTRS API command

### DIFF
--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -195,6 +195,21 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
             self._respond_raw(str(event_id))
         self._respond_raw(".")
 
+    @requires_authentication
+    async def do_getattrs(self, case_id: Union[str, int]):
+        try:
+            case_id = int(case_id)
+            event = self._state.events[case_id]
+        except (ValueError, KeyError):
+            return self._respond_error(f'event "{case_id}" does not exist')
+
+        self._respond(303, "simple attributes follow, terminated with '.'")
+        attrs = event.model_dump_simple_attrs()
+        for attr, value in attrs.items():
+            self._respond_raw(f"{attr}: {value}")
+
+        self._respond_raw(".")
+
 
 class ZinoTestProtocol(Zino1ServerProtocol):
     """Extended Zino 1 server protocol with test commands added in"""

--- a/tests/statemodels_test.py
+++ b/tests/statemodels_test.py
@@ -2,7 +2,13 @@ import datetime
 
 import pytest
 
-from zino.statemodels import DeviceState, DeviceStates, EventState, ReachabilityEvent
+from zino.statemodels import (
+    DeviceState,
+    DeviceStates,
+    Event,
+    EventState,
+    ReachabilityEvent,
+)
 
 
 class TestEvent:
@@ -13,6 +19,34 @@ class TestEvent:
     def test_add_history_should_set_proper_timestamp(self, fake_event):
         log = fake_event.add_history("test")
         assert isinstance(log.timestamp, datetime.datetime)
+
+    def test_model_dump_simple_attrs_should_return_dict_of_only_string_values(self, fake_event):
+        attrs = fake_event.model_dump_simple_attrs()
+
+        assert all(isinstance(val, str) for val in attrs.values())
+
+    def test_model_dump_simple_attrs_should_not_return_dict_with_log_or_history(self, fake_event):
+        attrs = fake_event.model_dump_simple_attrs()
+
+        assert "log" not in attrs
+        assert "history" not in attrs
+
+    def test_zinoify_value_when_value_is_enum_it_should_return_its_real_value(self):
+        assert Event.zinoify_value(EventState.OPEN) == "open"
+
+    def test_zinoify_value_when_value_is_int_it_should_return_a_str(self):
+        assert Event.zinoify_value(42) == "42"
+
+    def test_zinoify_value_when_value_is_datetime_it_should_return_a_unix_timestamp_as_a_str(self):
+        timestamp = datetime.datetime(2023, 10, 18, 11, 53, 37, tzinfo=datetime.timezone.utc)
+        assert Event.zinoify_value(timestamp) == "1697630017"
+
+    def test_zinoify_value_when_value_is_anything_its_str_should_be_returned(self):
+        class Throwaway:
+            def __str__(self):
+                return "foo"
+
+        assert Event.zinoify_value(Throwaway()) == "foo"
 
 
 class TestDeviceState:
@@ -42,5 +76,5 @@ class TestDeviceStates:
 
 
 @pytest.fixture
-def fake_event():
-    yield ReachabilityEvent(id=42, router="example-gw.example.org", state=EventState.OPEN)
+def fake_event() -> ReachabilityEvent:
+    return ReachabilityEvent(id=42, router="example-gw.example.org", state=EventState.OPEN)


### PR DESCRIPTION
This adds a new serializer method to the `Event` statemodel, in order to be able to get the event model into a format that matches the original Zino 1 server protocol.

Pydantic seems to provide hooks to write your own serializers for specific fields, but it is unclear to me how this can be utilized when we in fact have two different serialization formats we wish to support (one pure JSON format for persistent state storage, and one legacy server protocol format).  Until someone can point out a better way, this PR includes a new serialization method to `Event` that builds on Pydantic's existing `model_dump()` call.

Closes #99. 

Depends on #95 being merged first.