### PR TITLE
Initial implementation of GETHIST and GETLOG API commands

### DIFF
--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -225,6 +225,21 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
 
         self._respond_raw(".")
 
+    @requires_authentication
+    async def do_getlog(self, case_id: Union[str, int]):
+        try:
+            case_id = int(case_id)
+            event = self._state.events[case_id]
+        except (ValueError, KeyError):
+            return self._respond_error(f'event "{case_id}" does not exist')
+
+        self._respond(300, "log follows, terminated with '.'")
+        for log in event.log:
+            for line in log.model_dump_legacy():
+                self._respond_raw(line)
+
+        self._respond_raw(".")
+
 
 class ZinoTestProtocol(Zino1ServerProtocol):
     """Extended Zino 1 server protocol with test commands added in"""

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -210,6 +210,21 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
 
         self._respond_raw(".")
 
+    @requires_authentication
+    async def do_gethist(self, case_id: Union[str, int]):
+        try:
+            case_id = int(case_id)
+            event = self._state.events[case_id]
+        except (ValueError, KeyError):
+            return self._respond_error(f'event "{case_id}" does not exist')
+
+        self._respond(301, "history follows, terminated with '.'")
+        for history in event.history:
+            for line in history.model_dump_legacy():
+                self._respond_raw(line)
+
+        self._respond_raw(".")
+
 
 class ZinoTestProtocol(Zino1ServerProtocol):
     """Extended Zino 1 server protocol with test commands added in"""

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -135,6 +135,13 @@ class LogEntry(BaseModel):
     timestamp: datetime.datetime = Field(default_factory=now)
     message: str
 
+    def model_dump_legacy(self) -> List[str]:
+        """Returns the contents of this log entry in the text format expected on the Zino legacy server protocol"""
+        unix_timestamp = int(self.timestamp.timestamp())
+        lines = [f" {line}" for line in self.message.splitlines()]
+        lines[0] = f"{unix_timestamp}{lines[0]}"
+        return lines
+
 
 class EventState(Enum):
     """The set of allowable event states"""

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -136,7 +136,20 @@ class LogEntry(BaseModel):
     message: str
 
     def model_dump_legacy(self) -> List[str]:
-        """Returns the contents of this log entry in the text format expected on the Zino legacy server protocol"""
+        """Returns the contents of this log entry as a sequence of text lines.
+
+        This sequence of text lines are formatted as expected in a multi-line response in the Zino legacy server
+        protocol:
+
+        The first line starts with a UNIX integer timestamp, followed by a space and then the first line of the entry
+        text.  Each subsequent line of the entry text is prefixed by a space, which in the protocol signifies a
+        continuation line.
+
+        Example:
+        >>> LogEntry(message="This is a\\nmulti-line entry").model_dump_legacy()
+        ['1701171730 This is a', ' multiline entry']
+        >>>
+        """
         unix_timestamp = int(self.timestamp.timestamp())
         lines = [f" {line}" for line in self.message.splitlines()]
         lines[0] = f"{unix_timestamp}{lines[0]}"

--- a/tests/statemodels_test.py
+++ b/tests/statemodels_test.py
@@ -7,6 +7,7 @@ from zino.statemodels import (
     DeviceStates,
     Event,
     EventState,
+    LogEntry,
     ReachabilityEvent,
 )
 
@@ -47,6 +48,34 @@ class TestEvent:
                 return "foo"
 
         assert Event.zinoify_value(Throwaway()) == "foo"
+
+
+class TestLogEntryModelDumpLegacy:
+    def test_should_be_prefixed_by_timestamp(self):
+        entry = LogEntry(message="foobar")
+        lines = entry.model_dump_legacy()
+        timestamp, message = lines[0].split(" ")
+
+        assert timestamp.isdigit()
+        assert message == "foobar"
+
+    def test_when_message_is_single_line_it_should_return_a_single_line(self):
+        entry = LogEntry(message="foobar")
+        lines = entry.model_dump_legacy()
+
+        assert len(lines) == 1
+
+    def test_when_message_is_multi_line_it_should_return_the_correct_number_of_lines(self):
+        entry = LogEntry(message="one\ntwo\nthree")
+        lines = entry.model_dump_legacy()
+
+        assert len(lines) == 3
+
+    def test_when_message_is_multi_line_continuation_lines_should_be_prefixed_by_space(self):
+        entry = LogEntry(message="one\ntwo\nthree")
+        lines = entry.model_dump_legacy()
+
+        assert all(line.startswith(" ") for line in lines[1:])
 
 
 class TestDeviceState:


### PR DESCRIPTION
This implements a simple serialization method for `LogEntry` and utilizes this in the implementation of a `GETLOG` and a `GETHIST` protocol implementation.

Closes #102.
Closes #103.
Depends on #100 to merged first.
