### PR TITLE
Add initial ADDHIST API command implementation

### DIFF
--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -249,6 +249,22 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
 
         self._respond_raw(".")
 
+    @requires_authentication
+    async def do_addhist(self, case_id: Union[str, int]):
+        try:
+            case_id = int(case_id)
+            event = self._state.events[case_id]
+        except (ValueError, KeyError):
+            return self._respond_error(f'event "{case_id}" does not exist')
+
+        self._respond(302, "please provide new history entry, terminate with '.'")
+        data = await self._read_multiline()
+        message = f"{self.user}\n" + "\n".join(line.strip() for line in data)
+        event.add_history(message)
+        _logger.debug("id %s history added: %r", event.id, message)
+
+        self._respond_ok()
+
 
 class ZinoTestProtocol(Zino1ServerProtocol):
     """Extended Zino 1 server protocol with test commands added in"""

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -253,6 +253,28 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
     @requires_authentication
     @_translate_case_id_to_event
     async def do_addhist(self, event: Event):
+        """Implements the ADDHIST API command.
+
+        ADDHIST lets a user add a multi-line message to the event history.  The stored messaged will be prefixed
+        by the authenticated user's name on a single line.  Example session for the user `ford`:
+
+        ```
+        ADDHIST 160448
+        302 please provide new history entry, terminate with '.'
+        time is an illusion,
+        lunchtime doubly so
+        .
+        200 ok
+        GETHIST 160448
+        301 history follows, terminated with '.'
+        1697635024 state change embryonic -> open (monitor)
+        1697637757 ford
+         time is an illusion,
+         lunchtime doubly so
+
+        .
+        ```
+        """
         self._respond(302, "please provide new history entry, terminate with '.'")
         data = await self._read_multiline()
         message = f"{self.user}\n" + "\n".join(line.strip() for line in data)

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -120,7 +120,7 @@ class TestZino1BaseServerProtocol:
         protocol = TestProtocol()
         fake_transport = Mock()
         protocol.connection_made(fake_transport)
-        protocol._authenticated = True  # Fake authentication
+        protocol.user = "fake"
         fake_transport.write = Mock()
         await protocol.data_received(b"FOO\r\n")
 
@@ -367,7 +367,7 @@ class TestZino1TestProtocol:
         protocol = ZinoTestProtocol()
         fake_transport = Mock()
         protocol.connection_made(fake_transport)
-        protocol._authenticated = True  # Fake authentication
+        protocol.user = "foo"
         fake_transport.write = Mock()
         await protocol.data_received(b"AUTHTEST\r\n")
 
@@ -416,5 +416,5 @@ def authenticated_protocol(buffered_fake_transport) -> Zino1ServerProtocol:
     """Returns a pre-authenticated Zino1ServerProtocol instance with a `buffered_fake_transport`"""
     protocol = Zino1ServerProtocol()
     protocol.connection_made(buffered_fake_transport)
-    protocol._authenticated = True
-    return protocol
+    protocol.user = "fake"
+    yield protocol


### PR DESCRIPTION
It might have been better to break up this PR even further, but the chain of dependent API-related PRs is already becoming too long.  Essentially, these are the changes:

- It changes the `Zino1BaseServerProtocol` to keep track not just of the boolean state of authentication, but also keep track of the username of the logged in user
- It implements the `GETHIST` command, which needs to know said username.
- It factors out the redundant `case_id` verification code that was repeated in all the command responders that take a `case_id` argument.

Closes #106 
Depends on #105 to be merged first.