### PR TITLE
Use correct value for error handling

### DIFF
--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -125,7 +125,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, query)
+        self._raise_errors(error_indication, error_status, error_index, *var_binds)
         return self._object_type_to_mib_object(var_binds[0])
 
     def _raise_errors(
@@ -183,7 +183,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, object_type)
+        self._raise_errors(error_indication, error_status, error_index, *var_binds)
         # var_binds should be a sequence of sequences with one inner sequence that contains the result.
         return var_binds[0][0]
 
@@ -221,7 +221,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, *variables)
+        self._raise_errors(error_indication, error_status, error_index, *var_bind_table)
         # The table should contain only one set of results for our query
         return var_bind_table[0]
 
@@ -280,7 +280,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, object_type)
+        self._raise_errors(error_indication, error_status, error_index, *var_binds)
         return var_binds[0]
 
     async def getbulk2(self, *variables: Sequence[str], max_repetitions: int = 10) -> Sequence[Sequence[SNMPVarBind]]:
@@ -320,7 +320,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, *variables)
+        self._raise_errors(error_indication, error_status, error_index, *var_bind_table)
         return var_bind_table
 
     async def bulkwalk(self, *oid: str, max_repetitions: int = 10) -> list[MibObject]:

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -125,7 +125,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, *var_binds)
+        self._raise_errors(error_indication, error_status, error_index, var_binds)
         return self._object_type_to_mib_object(var_binds[0])
 
     def _raise_errors(
@@ -133,7 +133,7 @@ class SNMP:
         error_indication: Union[str, errind.ErrorIndication],
         error_status: str,
         error_index: int,
-        *query: ObjectType,
+        query: Sequence[ObjectType],
     ):
         """Raises a relevant exception if an error has occurred"""
         # Local errors (timeout, config errors etc)
@@ -183,7 +183,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, *var_binds)
+        self._raise_errors(error_indication, error_status, error_index, var_binds)
         # var_binds should be a sequence of sequences with one inner sequence that contains the result.
         return var_binds[0][0]
 
@@ -221,7 +221,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, *var_bind_table)
+        self._raise_errors(error_indication, error_status, error_index, var_bind_table)
         # The table should contain only one set of results for our query
         return var_bind_table[0]
 
@@ -280,7 +280,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, *var_binds)
+        self._raise_errors(error_indication, error_status, error_index, var_binds)
         return var_binds[0]
 
     async def getbulk2(self, *variables: Sequence[str], max_repetitions: int = 10) -> Sequence[Sequence[SNMPVarBind]]:
@@ -320,7 +320,7 @@ class SNMP:
             )
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
-        self._raise_errors(error_indication, error_status, error_index, *var_bind_table)
+        self._raise_errors(error_indication, error_status, error_index, var_bind_table)
         return var_bind_table
 
     async def bulkwalk(self, *oid: str, max_repetitions: int = 10) -> list[MibObject]:

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -133,7 +133,7 @@ class SNMP:
         error_indication: Union[str, errind.ErrorIndication],
         error_status: str,
         error_index: int,
-        query: Sequence[ObjectType],
+        var_binds: Sequence[ObjectType],
     ):
         """Raises a relevant exception if an error has occurred"""
         # Local errors (timeout, config errors etc)
@@ -146,7 +146,7 @@ class SNMP:
         # Remote errors from SNMP entity.
         # if nonzero error_status, error_index point will point to the ariable-binding in query that caused the error.
         if error_status:
-            error_object = self._object_type_to_mib_object(query[error_index - 1])
+            error_object = self._object_type_to_mib_object(var_binds[error_index - 1])
             error_name = errorStatus.getNamedValues()[int(error_status)]
             if error_name == "noSuchName":
                 raise NoSuchNameError(f"Could not find object at {error_object.oid}")


### PR DESCRIPTION
Fixes #81 

Uses the `var_binds` return value from SNMP operations instead of the query input. See #81 for the reason why.
