### PR TITLE
Mock timeouts in SNMP tests

### DIFF
--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -29,7 +29,7 @@ def unreachable_snmp_client():
     future.set_result(mock_results)
     timeout_mock = Mock(return_value=future)
     with patch.multiple("zino.snmp", getCmd=timeout_mock, nextCmd=timeout_mock, bulkCmd=timeout_mock):
-        device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666, timeout=1, retries=0)
+        device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666)
         yield SNMP(device)
 
 

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -22,7 +22,7 @@ def ipv6_snmp_client(snmpsim, snmp_test_port) -> SNMP:
     return SNMP(device)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def unreachable_snmp_client():
     mock_results = errind.RequestTimedOut(), None, None, []
     future = asyncio.Future()


### PR DESCRIPTION
Fixes #118 

Mocks the pysnmp operations `getCmd`, `getBulk` and  `getNext` to give return values that are realistic for when a timeout happens, without actually having to wait for a timeout