### PR TITLE
Abort other tasks if device is unreachable

### DIFF
--- a/src/zino/tasks/__init__.py
+++ b/src/zino/tasks/__init__.py
@@ -1,11 +1,11 @@
 import logging
 
+from zino.tasks.errors import DeviceUnreachableError
+
 _log = logging.getLogger(__name__)
 
 
 async def run_all_tasks(device, state):
-    from zino.tasks.reachabletask import DeviceUnreachableError
-
     for task_class in get_registered_tasks():
         task = task_class(device, state)
         try:

--- a/src/zino/tasks/__init__.py
+++ b/src/zino/tasks/__init__.py
@@ -6,13 +6,16 @@ _log = logging.getLogger(__name__)
 
 
 async def run_all_tasks(device, state):
+    try:
+        await run_registered_tasks(device, state)
+    except DeviceUnreachableError:
+        _log.debug(f"Device {device.name} could not be reached. Any remaining tasks have been cancelled.")
+
+
+async def run_registered_tasks(device, state):
     for task_class in get_registered_tasks():
         task = task_class(device, state)
-        try:
-            await task.run()
-        except DeviceUnreachableError:
-            _log.debug(f"Device {device.name} could not be reached. Cancelling other tasks.")
-            break
+        await task.run()
 
 
 def get_registered_tasks():

--- a/src/zino/tasks/__init__.py
+++ b/src/zino/tasks/__init__.py
@@ -1,7 +1,18 @@
+import logging
+
+_log = logging.getLogger(__name__)
+
+
 async def run_all_tasks(device, state):
+    from zino.tasks.reachabletask import DeviceUnreachableError
+
     for task_class in get_registered_tasks():
         task = task_class(device, state)
-        await task.run()
+        try:
+            await task.run()
+        except DeviceUnreachableError:
+            _log.debug(f"Device {device.name} could not be reached. Cancelling other tasks.")
+            break
 
 
 def get_registered_tasks():

--- a/src/zino/tasks/errors.py
+++ b/src/zino/tasks/errors.py
@@ -1,0 +1,2 @@
+class DeviceUnreachableError(Exception):
+    pass

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -4,13 +4,10 @@ from apscheduler.jobstores.base import JobLookupError
 
 from zino.scheduler import get_scheduler
 from zino.statemodels import ReachabilityEvent, ReachabilityState
+from zino.tasks.errors import DeviceUnreachableError
 from zino.tasks.task import Task
 
 _logger = logging.getLogger(__name__)
-
-
-class DeviceUnreachableError(Exception):
-    pass
 
 
 class ReachableTask(Task):

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -27,7 +27,6 @@ class ReachableTask(Task):
         try:
             await self._get_uptime()
         except TimeoutError:
-            _logger.debug("Device %s is not reachable", self.device.name)
             event = self.state.events.get_or_create_event(self.device.name, None, ReachabilityEvent)
             if event.reachability != ReachabilityState.NORESPONSE:
                 event.reachability = ReachabilityState.NORESPONSE

--- a/tests/tasks/conftest.py
+++ b/tests/tasks/conftest.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+import pytest
+
+from zino.config.models import PollDevice
+from zino.state import ZinoState
+from zino.tasks.reachabletask import ReachableTask
+
+
+@pytest.fixture()
+def reachable_task(snmpsim, snmp_test_port):
+    device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port)
+    state = ZinoState()
+    task = ReachableTask(device, state)
+    yield task
+    task._deschedule_extra_job()
+
+
+@pytest.fixture()
+def unreachable_task():
+    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666)
+    state = ZinoState()
+    task = ReachableTask(device, state)
+    with patch("zino.tasks.task.SNMP.get") as get_mock:
+        get_mock.side_effect = TimeoutError
+        yield task
+    task._deschedule_extra_job()

--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -1,31 +1,8 @@
-from unittest.mock import patch
-
 import pytest
 
-from zino.config.models import PollDevice
-from zino.state import ZinoState
 from zino.statemodels import ReachabilityEvent, ReachabilityState
 from zino.tasks.reachabletask import ReachableTask
 from zino.tasks.errors import DeviceUnreachableError
-
-@pytest.fixture()
-def reachable_task(snmpsim, snmp_test_port):
-    device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port)
-    state = ZinoState()
-    task = ReachableTask(device, state)
-    yield task
-    task._deschedule_extra_job()
-
-
-@pytest.fixture()
-def unreachable_task():
-    device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666)
-    state = ZinoState()
-    task = ReachableTask(device, state)
-    with patch("zino.tasks.task.SNMP.get") as get_mock:
-        get_mock.side_effect = TimeoutError
-        yield task
-    task._deschedule_extra_job()
 
 
 class TestReachableTask:

--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -1,7 +1,6 @@
 import pytest
 
 from zino.statemodels import ReachabilityEvent, ReachabilityState
-from zino.tasks.reachabletask import ReachableTask
 from zino.tasks.errors import DeviceUnreachableError
 
 

--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -5,8 +5,8 @@ import pytest
 from zino.config.models import PollDevice
 from zino.state import ZinoState
 from zino.statemodels import ReachabilityEvent, ReachabilityState
-from zino.tasks.reachabletask import DeviceUnreachableError, ReachableTask
-
+from zino.tasks.reachabletask import ReachableTask
+from zino.tasks.errors import DeviceUnreachableError
 
 @pytest.fixture()
 def reachable_task(snmpsim, snmp_test_port):

--- a/tests/tasks/test_run_all_tasks.py
+++ b/tests/tasks/test_run_all_tasks.py
@@ -1,13 +1,29 @@
+from unittest.mock import Mock, patch
+
 import pytest
 
+from zino.state import ZinoState
 from zino.tasks import run_all_tasks, run_registered_tasks
 from zino.tasks.errors import DeviceUnreachableError
+from zino.tasks.task import Task
 
 
 class TestRunAllTasks:
     @pytest.mark.asyncio
     async def test_does_not_raise_error_if_device_is_unreachable(self, unreachable_task):
         assert (await run_all_tasks(unreachable_task.device, unreachable_task.state)) is None
+
+    @pytest.mark.asyncio
+    async def test_when_one_task_raises_device_unreachable_it_should_not_run_further_tasks(
+        self, raising_task, non_raising_task
+    ):
+        mock_device = Mock()
+        state = ZinoState()
+        with patch("zino.tasks.get_registered_tasks") as get_registered_tasks:
+            get_registered_tasks.return_value = [raising_task, non_raising_task]
+            await run_all_tasks(mock_device, state)
+            assert raising_task.was_run
+            assert not non_raising_task.was_run
 
 
 class TestRunRegisteredTasks:
@@ -16,3 +32,27 @@ class TestRunRegisteredTasks:
         """The rest of the registered tasks are cancelled as a result of this"""
         with pytest.raises(DeviceUnreachableError):
             await run_registered_tasks(unreachable_task.device, unreachable_task.state)
+
+
+@pytest.fixture()
+def raising_task():
+    class RaisingTask(Task):
+        was_run = False
+
+        async def run(self):
+            RaisingTask.was_run = True
+            raise DeviceUnreachableError("just testing")
+
+    return RaisingTask
+
+
+@pytest.fixture()
+def non_raising_task():
+    class NonRaisingTask(Task):
+        was_run = False
+
+        async def run(self):
+            NonRaisingTask.was_run = True
+            return True
+
+    return NonRaisingTask

--- a/tests/tasks/test_run_all_tasks.py
+++ b/tests/tasks/test_run_all_tasks.py
@@ -1,0 +1,18 @@
+import pytest
+
+from zino.tasks import run_all_tasks, run_registered_tasks
+from zino.tasks.errors import DeviceUnreachableError
+
+
+class TestRunAllTasks:
+    @pytest.mark.asyncio
+    async def test_does_not_raise_error_if_device_is_unreachable(self, unreachable_task):
+        assert (await run_all_tasks(unreachable_task.device, unreachable_task.state)) is None
+
+
+class TestRunRegisteredTasks:
+    @pytest.mark.asyncio
+    async def test_raises_error_if_device_is_unreachable(self, unreachable_task):
+        """The rest of the registered tasks are cancelled as a result of this"""
+        with pytest.raises(DeviceUnreachableError):
+            await run_registered_tasks(unreachable_task.device, unreachable_task.state)


### PR DESCRIPTION
Fixes #108 

If a box is unreachable, theres no reason for other tasks to run. `ReachableTask` checks if a box is reachable, so running this task first and based on the result we cancel the process or continue.

Question is, how to get info from `ReachableTask` if a device is reachable or not? the `Task` class is generic, so defining the `run` function to return if a box is reachable or not would be weird. Raising a `TimeoutError` or something similar would work, but if `ReachableTask.run() `raised an exception, this would signify that the function was not able to complete its function properly, so it would be hard to trust that it had actually done everything it should (schedule extra jobs for instance), so I don't think that's a good solution either.

So I did something different by moving all the logic previously in `run` into a separate function `check_availability` that is called instead of `run`, but I am not entirely confident in this solution either, so I would like a review before taking this out of draft.