### PR TITLE
Add an event commit mechanism to the event registry

### DIFF
--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -104,8 +104,8 @@ class Events(BaseModel):
     def commit(self, event: Event):
         """Commits an Event object to the state, replacing any existing event by the same id.
 
-        If the event, for some reason, does not replace an existing event, indexes are rebuilt. This entrusts the
-        committer to not change the identifying index attributes of a modified event.
+        If the event, for some reason, does not replace an existing event, indexes are rebuilt. This assumes the
+        committer does not change the identifying index attributes of a modified event.
         """
         if event.state == EventState.EMBRYONIC:
             event.state = EventState.OPEN

--- a/src/zino/tasks/bfdtask.py
+++ b/src/zino/tasks/bfdtask.py
@@ -64,6 +64,7 @@ class BFDTask(Task):
 
         log = f"Port {port.ifdescr} changed BFD state from {port.bfd_state.session_state} to {new_state.session_state}"
         event.add_log(log)
+        self.state.events.commit(event)
 
     async def _poll_juniper(self) -> BFDStates:
         bfd_rows = await self._snmp.sparsewalk(*self.JUNIPER_BFD_COLUMNS)

--- a/src/zino/tasks/juniperalarmtask.py
+++ b/src/zino/tasks/juniperalarmtask.py
@@ -73,3 +73,4 @@ class JuniperAlarmTask(Task):
         old_alarm_count = alarm_event.alarm_count
         alarm_event.alarm_count = alarm_count
         alarm_event.add_log(f"{self.device.name} {color} alarms went from {old_alarm_count} to {alarm_count}")
+        self.state.events.commit(alarm_event)

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -128,6 +128,7 @@ class LinkStateTask(Task):
         )
         _logger.info(log)
         event.add_log(log)
+        self.state.events.commit(event)
 
         self._schedule_verification_of_single_port(port.ifindex)
 

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -32,7 +32,7 @@ class ReachableTask(Task):
             if event.reachability != ReachabilityState.NORESPONSE:
                 event.reachability = ReachabilityState.NORESPONSE
                 event.add_log(f"{self.device.name} no-response")
-            # TODO we need a mechanism to "commit" event changes, to trigger notifications to clients
+            self.state.events.commit(event)
             self._schedule_extra_job()
         else:
             _logger.debug("Device %s is reachable", self.device.name)

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -2,12 +2,16 @@
 import argparse
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
+
+import tzlocal
 
 from zino import state
 from zino.api.legacy import ZinoTestProtocol
+from zino.config.models import DEFAULT_INTERVAL_MINUTES
 from zino.scheduler import get_scheduler, load_and_schedule_polldevs
 
+STATE_DUMP_JOB_ID = "zino.dump_state"
 _log = logging.getLogger("zino")
 
 
@@ -32,7 +36,11 @@ def init_event_loop(args: argparse.Namespace):
         minutes=1,
         next_run_time=datetime.now(),
     )
-    scheduler.add_job(func=state.state.dump_state_to_file, trigger="interval", seconds=30)
+    # Schedule state dumping every DEFAULT_INTERVAL_MINUTES and reschedule whenever events are committed
+    scheduler.add_job(
+        func=state.state.dump_state_to_file, trigger="interval", id=STATE_DUMP_JOB_ID, minutes=DEFAULT_INTERVAL_MINUTES
+    )
+    state.state.events.add_event_observer(reschedule_dump_state_on_commit)
     scheduler.add_job(func=state.state.dump_state_to_log, trigger="interval", seconds=30)
 
     loop = asyncio.get_event_loop()
@@ -45,6 +53,18 @@ def init_event_loop(args: argparse.Namespace):
         pass
 
     return True
+
+
+def reschedule_dump_state_on_commit(event_id: int, max_wait=timedelta(seconds=10)):
+    """Observer that reschedules the state dumper job whenever an event is committed and there's more than 10
+    seconds until the next schedule state dump.
+    """
+    scheduler = get_scheduler()
+    job = scheduler.get_job(job_id=STATE_DUMP_JOB_ID)
+    next_run = datetime.now(tz=tzlocal.get_localzone()) + max_wait
+    if job.next_run_time > next_run:
+        _log.debug("event %s committed, rescheduling state dump from %s to %s", event_id, job.next_run_time, next_run)
+        job.modify(next_run_time=next_run)
 
 
 def parse_args(arguments=None):

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -12,6 +12,8 @@ from zino.config.models import DEFAULT_INTERVAL_MINUTES
 from zino.scheduler import get_scheduler, load_and_schedule_polldevs
 
 STATE_DUMP_JOB_ID = "zino.dump_state"
+# Never try to dump state more often than this:
+MINIMUM_STATE_DUMP_INTERVAL = timedelta(seconds=10)
 _log = logging.getLogger("zino")
 
 
@@ -55,9 +57,9 @@ def init_event_loop(args: argparse.Namespace):
     return True
 
 
-def reschedule_dump_state_on_commit(event_id: int, max_wait=timedelta(seconds=10)):
-    """Observer that reschedules the state dumper job whenever an event is committed and there's more than 10
-    seconds until the next schedule state dump.
+def reschedule_dump_state_on_commit(event_id: int, max_wait: timedelta = MINIMUM_STATE_DUMP_INTERVAL):
+    """Observer that reschedules the state dumper job whenever an event is committed and there's more than `max_wait`
+    time until the next scheduled state dump.
     """
     scheduler = get_scheduler()
     job = scheduler.get_job(job_id=STATE_DUMP_JOB_ID)

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from zino.events import EventExistsError, Events
@@ -81,3 +83,12 @@ class TestEvents:
         assert event.state == EventState.EMBRYONIC
         events.commit(event)
         assert event.state == EventState.OPEN
+
+    def test_when_observer_is_added_it_should_be_called_on_commit(self):
+        events = Events()
+        observer = Mock()
+        events.add_event_observer(observer.observe)
+        event, _ = events.get_or_create_event("foobar", None, ReachabilityEvent)
+
+        events.commit(event)
+        assert observer.observe.called

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -1,7 +1,11 @@
 import subprocess
 from argparse import Namespace
+from datetime import timedelta
+from unittest.mock import Mock, patch
 
 from zino import zino
+from zino.scheduler import get_scheduler
+from zino.time import now
 
 
 def test_zino_version_should_be_available():
@@ -18,3 +22,23 @@ def test_zino_help_screen_should_not_crash():
 def test_zino_argparser_works(polldevs_conf):
     parser = zino.parse_args(["--polldevs", str(polldevs_conf)])
     assert isinstance(parser, Namespace)
+
+
+class TestZinoRescheduleDumpStateOnCommit:
+    def test_when_more_than_10_seconds_remains_until_next_dump_it_should_reschedule(self):
+        scheduler = get_scheduler()
+        mock_job = Mock(next_run_time=now() + timedelta(minutes=5))
+
+        with patch.object(scheduler, "get_job") as get_job:
+            get_job.return_value = mock_job
+            zino.reschedule_dump_state_on_commit(42)
+            assert mock_job.modify.called
+
+    def test_when_less_than_10_seconds_remains_until_next_dump_it_should_not_reschedule(self):
+        scheduler = get_scheduler()
+        mock_job = Mock(next_run_time=now() + timedelta(seconds=5))
+
+        with patch.object(scheduler, "get_job") as get_job:
+            get_job.return_value = mock_job
+            zino.reschedule_dump_state_on_commit(42)
+            assert not mock_job.modify.called


### PR DESCRIPTION
This is a work-in-progress to add a checkout/commit mechanism for events in the event state registry.

The mechanism enables "checking out" copies of event objects, which can subsequently changed and "committed" back to the event state registry.

This also adds an observer mechanism, so that observers can be notified about events being committed.  Observers can be used to trigger imminent state dumps or notifications to API clients that have active notification channels open.

Closes #52 