### PR TITLE
Use checkout/commit logic for all event creation/retrieval from the index

### DIFF
--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -82,8 +82,6 @@ class Events(BaseModel):
             id=event_id,
             router=device_name,
             port=port,
-            state=EventState.EMBRYONIC,
-            opened=now(),
         )
         _log.debug("created event %r", event)
 

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -14,7 +14,6 @@ from zino.statemodels import (
     PortStateEvent,
     ReachabilityEvent,
 )
-from zino.time import now
 
 EventIndex = namedtuple("EventIndex", "router port type")
 
@@ -96,7 +95,7 @@ class Events(BaseModel):
         """Checks out a copy of an event that can be freely modified without being persisted"""
         return self[event_id].model_copy(deep=True)
 
-    def commit(self, event: Event):
+    def commit(self, event: Event, user: str = "monitor"):
         """Commits an Event object to the state, replacing any existing event by the same id.
 
         If the event does not have an id, it is considered a new event and is assigned a new id value before it is
@@ -106,8 +105,7 @@ class Events(BaseModel):
         has modified, as that will break the index.
         """
         if event.state == EventState.EMBRYONIC:
-            event.state = EventState.OPEN
-            event.opened = now()
+            event.set_state(EventState.OPEN, user)
 
         is_new = not event.id
         if is_new:

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -1,6 +1,6 @@
 import logging
 from collections import namedtuple
-from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 from pydantic.main import BaseModel
 
@@ -53,41 +53,38 @@ class Events(BaseModel):
         device_name: str,
         port: Optional[PortOrIPAddress],
         event_class: Type[Event],
-    ) -> Tuple[Event, bool]:
-        """Creates a new event for the given event identifiers, or, if one matching this identifier already exists,
-        returns that.
+    ) -> Event:
+        """Creates and returns a new event for the given event identifiers, or, if an event matching this identifier
+        already exists in the index, returns that.
 
-        :returns: (Event, created) where Event is the existing or newly created Event object, while created is a boolean
-                  indicating whether the returned object was just created by this method or if it existed from before.
+        A new event is not immediately committed to the event index; this must be done by explicitly calling the
+        `commit()` method.  I.e. the caller can assume that when the returned `Event` object's `id` value is `None`,
+        it is a new event.
 
+        If a matching event already exists, the return value is a checkout copy, as if the `checkout()` method had been
+        used.  The assumption is that the caller is looking to make changes to the fetched event.
         """
         try:
-            return self.create_event(device_name, port, event_class), True
+            return self.create_event(device_name, port, event_class)
         except EventExistsError:
-            return self.get(device_name, port, event_class), False
+            event = self.get(device_name, port, event_class)
+            return self.checkout(event.id)
 
     def create_event(self, device_name: str, port: Optional[PortOrIPAddress], event_class: Type[Event]) -> Event:
         """Creates a new event for the given event identifiers. If an event already exists for this combination of
         identifiers, an EventExistsError is raised.
 
+        The event is not committed to the event registry; this must be done by explicitly calling the `commit()` method.
         """
         index = EventIndex(device_name, port, event_class)
         if index in self._events_by_index:
             raise EventExistsError(f"Event for {index} already exists")
 
-        event_id = self.last_event_id + 1
-        self.last_event_id = event_id
-
         event = event_class(
-            id=event_id,
             router=device_name,
             port=port,
         )
-        _log.debug("created event %r", event)
-
-        self.events[event_id] = event
-        self._events_by_index[index] = event
-        _log.debug("created %r", event)
+        _log.debug("created embryonic event %r", event)
         return event
 
     def get(self, device_name: str, port: Optional[PortOrIPAddress], event_class: Type[Event]) -> Event:
@@ -102,23 +99,33 @@ class Events(BaseModel):
     def commit(self, event: Event):
         """Commits an Event object to the state, replacing any existing event by the same id.
 
-        If the event, for some reason, does not replace an existing event, indexes are rebuilt. This assumes the
-        committer does not change the identifying index attributes of a modified event.
+        If the event does not have an id, it is considered a new event and is assigned a new id value before it is
+        placed in the event index.
+
+        This all assumes the committer does not change the identifying index attributes of an existing event that it
+        has modified, as that will break the index.
         """
         if event.state == EventState.EMBRYONIC:
             event.state = EventState.OPEN
             event.opened = now()
 
-        is_new = event.id not in self
-        self.events[event.id] = event
+        is_new = not event.id
         if is_new:
-            self._rebuild_indexes()
+            event.id = self.get_next_available_event_id()
+            index = EventIndex(event.router, event.port, type(event))
+            self._events_by_index[index] = event
+        self.events[event.id] = event
 
         self._call_observers_for(event)
 
     def add_event_observer(self, func: callable):
         """Adds an observer function that will be called with the ID of any committed event as its argument"""
         self._observers.append(func)
+
+    def get_next_available_event_id(self):
+        """Returns the next available event id"""
+        self.last_event_id += 1
+        return self.last_event_id
 
     def _call_observers_for(self, event: Event):
         for observer in self._observers:

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -183,7 +183,7 @@ class Event(BaseModel):
     router: str
     port: Optional[PortOrIPAddress] = None
     type: Literal["Event"] = "Event"
-    state: EventState
+    state: EventState = EventState.EMBRYONIC
     opened: datetime.datetime = Field(default_factory=now)
     updated: Optional[datetime.datetime] = None
     priority: int = 100

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -207,6 +207,8 @@ class Event(BaseModel):
             return
 
         old_state, self.state = self.state, new_state
+        if (old_state, new_state) == (EventState.EMBRYONIC, EventState.OPEN):
+            self.opened = now()
         self.add_history(f"state change {old_state.value} -> {new_state.value} ({user})")
         _logger.debug("id %s state %s -> %s by %s", self.id, old_state.value, new_state.value, user)
 

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -178,7 +178,7 @@ class ReachabilityState(Enum):
 class Event(BaseModel):
     """Keeps track of event state"""
 
-    id: int
+    id: Optional[int] = None
 
     router: str
     port: Optional[PortOrIPAddress] = None

--- a/src/zino/tasks/bfdtask.py
+++ b/src/zino/tasks/bfdtask.py
@@ -4,14 +4,7 @@ from typing import Dict, Literal
 
 from zino.scheduler import get_scheduler
 from zino.snmp import SNMP, SparseWalkResponse
-from zino.statemodels import (
-    BFDEvent,
-    BFDSessState,
-    BFDState,
-    EventState,
-    IPAddress,
-    Port,
-)
+from zino.statemodels import BFDEvent, BFDSessState, BFDState, IPAddress, Port
 from zino.tasks.task import Task
 
 _log = logging.getLogger(__name__)
@@ -52,10 +45,7 @@ class BFDTask(Task):
         port.bfd_state = new_state
 
     def _create_or_update_event(self, port: Port, new_state: BFDState):
-        event, created = self.state.events.get_or_create_event(self.device.name, port.ifindex, BFDEvent)
-        if created:
-            event.state = EventState.OPEN
-            event.add_history("Change state to Open")
+        event = self.state.events.get_or_create_event(self.device.name, port.ifindex, BFDEvent)
 
         event.bfdstate = new_state.session_state
         event.bfdix = new_state.session_index

--- a/src/zino/tasks/juniperalarmtask.py
+++ b/src/zino/tasks/juniperalarmtask.py
@@ -2,7 +2,7 @@ import logging
 from typing import Literal
 
 from zino.snmp import SNMP
-from zino.statemodels import AlarmEvent, EventState
+from zino.statemodels import AlarmEvent
 from zino.tasks.task import Task
 
 _logger = logging.getLogger(__name__)
@@ -61,14 +61,11 @@ class JuniperAlarmTask(Task):
         return yellow_alarm_count, red_alarm_count
 
     def create_alarm_event(self, color: Literal["yellow", "red"], alarm_count: int):
-        alarm_event, created = self.state.events.get_or_create_event(
+        alarm_event = self.state.events.get_or_create_event(
             device_name=self.device.name,
             port=color,
             event_class=AlarmEvent,
         )
-        if created:
-            alarm_event.state = EventState.OPEN
-            alarm_event.add_history("Change state to Open")
 
         old_alarm_count = alarm_event.alarm_count
         alarm_event.alarm_count = alarm_count

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -7,7 +7,7 @@ from typing import Any
 from zino.oid import OID
 from zino.scheduler import get_scheduler
 from zino.snmp import SNMP, SparseWalkResponse
-from zino.statemodels import EventState, InterfaceState, Port, PortStateEvent
+from zino.statemodels import InterfaceState, Port, PortStateEvent
 from zino.tasks.task import Task
 
 _logger = logging.getLogger(__name__)
@@ -108,10 +108,7 @@ class LinkStateTask(Task):
         port.state = state
 
     def _make_or_update_state_event(self, port: Port, new_state: InterfaceState, last_change: int):
-        event, created = self.state.events.get_or_create_event(self.device.name, port.ifindex, PortStateEvent)
-        if created:
-            event.state = EventState.OPEN
-            event.add_history("Change state to Open")
+        event = self.state.events.get_or_create_event(self.device.name, port.ifindex, PortStateEvent)
 
         event.portstate = new_state
         event.ifindex = port.ifindex

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -4,7 +4,7 @@ from apscheduler.jobstores.base import JobLookupError
 
 from zino.scheduler import get_scheduler
 from zino.snmp import SNMP
-from zino.statemodels import EventState, ReachabilityEvent, ReachabilityState
+from zino.statemodels import ReachabilityEvent, ReachabilityState
 from zino.tasks.task import Task
 
 _logger = logging.getLogger(__name__)
@@ -25,10 +25,7 @@ class ReachableTask(Task):
             await self._get_sysuptime()
         except TimeoutError:
             _logger.debug("Device %s is not reachable", self.device.name)
-            event, created = self.state.events.get_or_create_event(self.device.name, None, ReachabilityEvent)
-            if created:
-                event.state = EventState.OPEN
-                event.add_history("Change state to Open")
+            event = self.state.events.get_or_create_event(self.device.name, None, ReachabilityEvent)
             if event.reachability != ReachabilityState.NORESPONSE:
                 event.reachability = ReachabilityState.NORESPONSE
                 event.add_log(f"{self.device.name} no-response")

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -266,7 +266,9 @@ class TestZino1ServerProtocolCaseidsCommand:
     async def test_should_output_a_list_of_known_event_ids(self, authenticated_protocol):
         state = authenticated_protocol._state
         event1 = state.events.create_event("foo", None, ReachabilityEvent)
+        state.events.commit(event1)
         event2 = state.events.create_event("bar", None, ReachabilityEvent)
+        state.events.commit(event2)
 
         await authenticated_protocol.data_received(b"CASEIDS\r\n")
 
@@ -293,6 +295,7 @@ class TestZino1ServerProtocolGetattrsCommand:
     async def test_should_output_correct_attrs(self, authenticated_protocol):
         state = authenticated_protocol._state
         event1 = state.events.create_event("foo", None, ReachabilityEvent)
+        state.events.commit(event1)
 
         await authenticated_protocol.data_received(f"GETATTRS {event1.id}\r\n".encode())
 
@@ -316,6 +319,7 @@ class TestZino1ServerProtocolGethistCommand:
         event = state.events.create_event("foo", None, ReachabilityEvent)
         event.add_history("line one\nline two\nline three")
         event.add_history("another line one\nanother line two\nanother line")
+        state.events.commit(event)
 
         await authenticated_protocol.data_received(f"GETHIST {event.id}\r\n".encode())
 
@@ -323,7 +327,7 @@ class TestZino1ServerProtocolGethistCommand:
 
         output = output[output.find("301 history follows") :]
         lines = output.splitlines()
-        assert len(lines) == 8
+        assert len(lines) == 9
         assert lines[-1] == "."
         assert all(line[0].isdigit() or line.startswith(" ") for line in lines[:-1])
 
@@ -342,6 +346,7 @@ class TestZino1ServerProtocolGetlogCommand:
         event = state.events.create_event("foo", None, ReachabilityEvent)
         event.add_log("line one\nline two\nline three")
         event.add_log("another line one\nanother line two\nanother line")
+        state.events.commit(event)
 
         await authenticated_protocol.data_received(f"GETLOG {event.id}\r\n".encode())
 
@@ -366,6 +371,7 @@ class TestZino1ServerProtocolAddhistCommand:
     async def test_should_add_history_entry_to_event(self, authenticated_protocol, event_loop):
         state = authenticated_protocol._state
         event = state.events.create_event("foo", None, ReachabilityEvent)
+        state.events.commit(event)
 
         def mock_multiline():
             future = event_loop.create_future()
@@ -381,6 +387,7 @@ class TestZino1ServerProtocolAddhistCommand:
     async def test_should_prefix_history_message_with_username(self, authenticated_protocol, event_loop):
         state = authenticated_protocol._state
         event = state.events.create_event("foo", None, ReachabilityEvent)
+        state.events.commit(event)
 
         def mock_multiline():
             future = event_loop.create_future()

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -15,17 +15,18 @@ class TestEvents:
         events = Events()
         event = events.create_event("foobar", None, ReachabilityEvent)
 
-        assert event.id > 0
+        assert isinstance(event, ReachabilityEvent)
 
-    def test_event_registry_should_contain_one_event_when_first_event_is_created(self):
+    def test_event_registry_should_not_contain_newly_created_event(self):
         events = Events()
         events.create_event("foobar", None, ReachabilityEvent)
 
-        assert len(events) == 1
+        assert len(events) == 0
 
     def test_adding_two_identical_events_should_raise(self):
         events = Events()
-        events.create_event("foobar", None, ReachabilityEvent)
+        event = events.create_event("foobar", None, ReachabilityEvent)
+        events.commit(event)
 
         with pytest.raises(EventExistsError):
             events.create_event("foobar", None, ReachabilityEvent)
@@ -33,34 +34,38 @@ class TestEvents:
     def test_event_should_be_gettable_by_id(self):
         events = Events()
         event = events.create_event("foobar", None, ReachabilityEvent)
+        events.commit(event)
 
         assert events[event.id] == event
 
     def test_get_or_create_event_should_return_new_event(self):
         events = Events()
-        event, created = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        event = events.get_or_create_event("foobar", None, ReachabilityEvent)
 
-        assert created
+        assert event.id is None
         assert isinstance(event, Event)
 
     def test_get_or_create_event_should_return_existing_event_on_same_index(self):
         events = Events()
-        event1, _ = events.get_or_create_event("foobar", None, ReachabilityEvent)
-        event2, _ = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        event1 = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        events.commit(event1)
+        event2 = events.get_or_create_event("foobar", None, ReachabilityEvent)
 
-        assert event2 is event1
+        assert event2 == event1
 
     def test_checkout_should_return_copy(self):
         events = Events()
-        original_event, _ = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        original_event = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        events.commit(original_event)
         copy = events.checkout(original_event.id)
 
         assert original_event is not copy
 
     def test_checkout_should_return_deep_log_copy(self):
         events = Events()
-        original_event, _ = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        original_event = events.get_or_create_event("foobar", None, ReachabilityEvent)
         original_event.add_log("first log")
+        events.commit(original_event)
 
         copy = events.checkout(original_event.id)
         copy.add_log("second log")
@@ -69,17 +74,19 @@ class TestEvents:
 
     def test_commit_should_replace_event(self):
         events = Events()
-        original_event, _ = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        original_event = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        events.commit(original_event)
+
         copy = events.checkout(original_event.id)
         copy.add_log("this is the successor event")
 
         events.commit(copy)
 
-        assert events.get("foobar", None, ReachabilityEvent) is copy
+        assert events[copy.id] is copy
 
     def test_commit_should_open_embryonic_event(self):
         events = Events()
-        event, _ = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        event = events.get_or_create_event("foobar", None, ReachabilityEvent)
         assert event.state == EventState.EMBRYONIC
         events.commit(event)
         assert event.state == EventState.OPEN
@@ -88,7 +95,7 @@ class TestEvents:
         events = Events()
         observer = Mock()
         events.add_event_observer(observer.observe)
-        event, _ = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        event = events.get_or_create_event("foobar", None, ReachabilityEvent)
 
         events.commit(event)
         assert observer.observe.called

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -17,7 +17,7 @@ class TestEvents:
 
         assert isinstance(event, ReachabilityEvent)
 
-    def test_event_registry_should_not_contain_newly_created_event(self):
+    def test_event_registry_should_not_contain_uncommited_event(self):
         events = Events()
         events.create_event("foobar", None, ReachabilityEvent)
 

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -55,7 +55,30 @@ def valid_state_file(tmp_path):
             "devices": {}
           },
           "events": {
-            "events": {},
+            "events": {
+              "1": {
+                "id": 1,
+                "router": "example-gw1",
+                "type": "reachability",
+                "state": "open",
+                "opened": "2023-12-06T17:03:38.73336Z",
+                "updated": "2023-12-06T17:03:38.733633Z",
+                "priority": 100,
+                "log": [
+                  {
+                    "timestamp": "2023-12-06T17:03:38.733633Z",
+                    "message": "example-gw1 no-response"
+                  }
+                ],
+                "history": [
+                  {
+                    "timestamp": "2023-12-06T17:03:38.733615Z",
+                    "message": "Change state to Open"
+                  }
+                ],
+                "reachability": "no-response"
+              }
+            },
             "last_event_id": 42
           }
         }

--- a/tests/statemodels_test.py
+++ b/tests/statemodels_test.py
@@ -49,6 +49,30 @@ class TestEvent:
 
         assert Event.zinoify_value(Throwaway()) == "foo"
 
+    def test_when_set_state_is_called_it_should_change_state(self, fake_event):
+        fake_event.set_state(EventState.CLOSED, user="nobody")
+        assert fake_event.state == EventState.CLOSED
+
+    def test_when_state_is_changed_set_state_should_add_history_entry(self, fake_event):
+        history_count_before = len(fake_event.history)
+        fake_event.set_state(EventState.CLOSED, user="nobody")
+        history_count_after = len(fake_event.history)
+        assert history_count_after > history_count_before
+
+    def test_when_state_is_changed_set_state_should_add_history_entry_with_details(self, fake_event):
+        old_state = fake_event.state
+        fake_event.set_state(EventState.CLOSED, user="zaphod")
+        last_history_entry = fake_event.history[-1]
+
+        for detail in (old_state.value, EventState.CLOSED.value, "zaphod"):
+            assert detail in last_history_entry.message
+
+    def test_when_state_is_unchanged_set_state_should_not_add_history_entry(self, fake_event):
+        history_count_before = len(fake_event.history)
+        fake_event.set_state(fake_event.state, user="nobody")
+        history_count_after = len(fake_event.history)
+        assert history_count_after == history_count_before
+
 
 class TestLogEntryModelDumpLegacy:
     def test_should_be_prefixed_by_timestamp(self):

--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -4,7 +4,7 @@ import pytest
 
 from zino.config.models import PollDevice
 from zino.state import ZinoState
-from zino.statemodels import EventState, ReachabilityEvent, ReachabilityState
+from zino.statemodels import ReachabilityEvent, ReachabilityState
 from zino.tasks.reachabletask import ReachableTask
 
 
@@ -58,7 +58,6 @@ class TestReachableTask:
     async def test_run_should_update_event_to_reachable_when_device_is_reachable(self, reachable_task):
         task = reachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
-        event.state = EventState.OPEN
         event.reachability = ReachabilityState.NORESPONSE
         assert (await task.run()) is None
         assert event.reachability == ReachabilityState.REACHABLE
@@ -67,7 +66,6 @@ class TestReachableTask:
     async def test_run_should_update_event_to_noresponse_when_device_is_unreachable(self, unreachable_task):
         task = unreachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
-        event.state = EventState.OPEN
         event.reachability = ReachabilityState.REACHABLE
         assert (await task.run()) is None
         assert event.reachability == ReachabilityState.NORESPONSE
@@ -76,7 +74,6 @@ class TestReachableTask:
     async def test_run_extra_job_should_update_event_to_reachable_when_device_is_reachable(self, reachable_task):
         task = reachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
-        event.state = EventState.OPEN
         event.reachability = ReachabilityState.NORESPONSE
         assert (await task._run_extra_job()) is None
         assert event.reachability == ReachabilityState.REACHABLE
@@ -85,7 +82,6 @@ class TestReachableTask:
     async def test_run_extra_job_should_not_update_event_when_device_is_unreachable(self, unreachable_task):
         task = unreachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
-        event.state = EventState.OPEN
         event.reachability = ReachabilityState.NORESPONSE
         assert (await task._run_extra_job()) is None
         assert event.reachability == ReachabilityState.NORESPONSE

--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -59,24 +59,33 @@ class TestReachableTask:
         task = reachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
         event.reachability = ReachabilityState.NORESPONSE
+        task.state.events.commit(event)
+
         assert (await task.run()) is None
-        assert event.reachability == ReachabilityState.REACHABLE
+        updated_event = task.state.events[event.id]
+        assert updated_event.reachability == ReachabilityState.REACHABLE
 
     @pytest.mark.asyncio
     async def test_run_should_update_event_to_noresponse_when_device_is_unreachable(self, unreachable_task):
         task = unreachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
         event.reachability = ReachabilityState.REACHABLE
+        task.state.events.commit(event)
+
         assert (await task.run()) is None
-        assert event.reachability == ReachabilityState.NORESPONSE
+        updated_event = task.state.events[event.id]
+        assert updated_event.reachability == ReachabilityState.NORESPONSE
 
     @pytest.mark.asyncio
     async def test_run_extra_job_should_update_event_to_reachable_when_device_is_reachable(self, reachable_task):
         task = reachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
         event.reachability = ReachabilityState.NORESPONSE
+        task.state.events.commit(event)
+
         assert (await task._run_extra_job()) is None
-        assert event.reachability == ReachabilityState.REACHABLE
+        updated_event = task.state.events[event.id]
+        assert updated_event.reachability == ReachabilityState.REACHABLE
 
     @pytest.mark.asyncio
     async def test_run_extra_job_should_not_update_event_when_device_is_unreachable(self, unreachable_task):


### PR DESCRIPTION
This reworks the workflow for creating new events or changing existing ones, to be more inline with the *commit* workflow introduced by #136.

The new workflow is mostly concerned with changes to the `Events` index class:

* The `create()` method will not place a created `Event` object in the index.  The returned object **must** be explicitly committed to the index afterwards, using the `Events.commit()` method.
* The `get_or_create()` method follows the same logic, but also: When an existing `Event` is found and returned, it performs a `checkout()` on this event.  This means the caller is always expected to run `Events.commit()` for any `Event` object returned by this call in order to make sure any event changes are made "official".
* The `get_or_create()` method no longer returns a tuple where the second value is a `created` boolean.  Rather, a new `Event` can be now be distinguished by the fact that *it's `id` attribute is `None`.  A new `Event` will have its `id` attribute assigned by the `Events` index on the first call to `commit()` it.


Additionally, this fixes #137 by adding a `set_state()` method to the `Event` class, which encapsulates the typical operations of changing an event's state and logging this change to the event's history, including the username of the user who made the change.  It also removes all code instances that explicitly set the event state to `OPEN` when it discovered it had created a new event.

* The `Events.commit()` method is updated to use the new `set_state()` when embryonic events are commited.  It is also updated to take an optional `user` (a username) argument, which can be used by the API to ensure changes made by specific users are logged with that user's username.  If omitted, it will default to use `monitor` username, which is what the original Tcl code does.