### PR TITLE
Remove unnecessary log dumps of state

### DIFF
--- a/src/zino/state.py
+++ b/src/zino/state.py
@@ -4,7 +4,6 @@ __all__ = ["polldevs", "ZinoState"]
 
 import json
 import logging
-import pprint
 from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
@@ -28,9 +27,6 @@ class ZinoState(BaseModel):
 
     devices: DeviceStates = Field(default_factory=DeviceStates)
     events: Events = Field(default_factory=Events)
-
-    def dump_state_to_log(self):
-        _log.debug("Dumping state to log:\n%s", pprint.pformat(self.model_dump(exclude_none=True)))
 
     def dump_state_to_file(self, filename: str = STATE_FILENAME):
         """Dumps the full state to a file in JSON format"""

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -33,7 +33,6 @@ def init_event_loop(args: argparse.Namespace):
         next_run_time=datetime.now(),
     )
     scheduler.add_job(func=state.state.dump_state_to_file, trigger="interval", seconds=30)
-    scheduler.add_job(func=state.state.dump_state_to_log, trigger="interval", seconds=30)
 
     loop = asyncio.get_event_loop()
     server = loop.create_server(lambda: ZinoTestProtocol(state=state.state), "127.0.0.1", 8001)

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -1,18 +1,10 @@
 import json
-import logging
 import os
 from json import JSONDecodeError
 
 import pytest
 
 from zino.state import ZinoState
-
-
-def test_dump_state_to_log_should_dump_to_log(caplog):
-    with caplog.at_level(logging.DEBUG):
-        state = ZinoState()
-        state.dump_state_to_log()
-    assert "Dumping state" in caplog.text
 
 
 def test_dump_state_to_file_should_dump_valid_json_to_file(tmp_path):


### PR DESCRIPTION
Debug logging of the complete Zino server state on a set interval was only needed before the state dump/retrieval to/from disk was completed.  Now, this intermittent full state dump to the log is more annoying and noisy than anything else.

This removes all of it.