### PR TITLE
Add notification protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,4 +107,6 @@ src_paths = ["src", "tests"]
 exclude_also = [
     # Don't need coverage for ellipsis used for type annotations
     "...",
+    # Don't complain about lines excluded unless type checking
+    "if TYPE_CHECKING:",
 ]

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -59,7 +59,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
         self._secrets_file = secrets_file
 
     @property
-    def peer_name(self) -> str:
+    def peer_name(self) -> Optional[str]:
         return self.transport.get_extra_info("peername") if self.transport else None
 
     @property

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -337,7 +337,7 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         """Implements the NTIE command that ties together this session with a notification channel."""
         try:
             channel = self.server.notification_channels[nonce]
-        except KeyError:
+        except (AttributeError, KeyError):
             return self._respond_error("Could not find your notify socket")
 
         self.notification_channel = channel

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -41,6 +41,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
     ):
         """Initializes a protocol instance.
 
+        :param server: An optional instance of `ZinoServer`.
         :param state: An optional reference to a running Zino state that this server should be based on.  If omitted,
                       this protocol will create and work on an empty state object.
         :param secrets_file: An optional alternative path to the file containing users and their secrets.

--- a/src/zino/api/notify.py
+++ b/src/zino/api/notify.py
@@ -6,7 +6,7 @@ the server.
 """
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 from zino.api import auth
 from zino.state import ZinoState
@@ -16,6 +16,14 @@ if TYPE_CHECKING:
     from zino.api.server import ZinoServer
 
 _logger = logging.getLogger(__name__)
+
+
+class Notification(NamedTuple):
+    """Represents the contents of a single notification"""
+
+    event_id: int
+    change_type: str
+    value: Any
 
 
 class Zino1NotificationProtocol(asyncio.Protocol):
@@ -64,8 +72,9 @@ class Zino1NotificationProtocol(asyncio.Protocol):
     def tied_to(self, client: "Zino1ServerProtocol") -> None:
         self._tied_to = client
 
-    def _notify(self, event_id: int, change_type: str, value: Any):
-        self._respond_raw(f"{event_id} {change_type} {value}")
+    def notify(self, notification: Notification):
+        """Sends a notification to the connected client"""
+        self._respond_raw(f"{notification.event_id} {notification.change_type} {notification.value}")
 
     def _respond_raw(self, message: str):
         """Encodes and sends a response line to the connected client"""

--- a/src/zino/api/notify.py
+++ b/src/zino/api/notify.py
@@ -1,0 +1,57 @@
+"""Notification channel implementation for Zino 2.0.
+
+Notification channels are currently part of the legacy API from the Tcl-based Zino 1.0, and is a simple text-based,
+line-oriented protocol.  Clients are not expected to send any data to a notification channel, only receive data from
+the server.
+"""
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+from zino.api import auth
+from zino.state import ZinoState
+
+if TYPE_CHECKING:
+    from zino.api.server import ZinoServer
+
+_logger = logging.getLogger(__name__)
+
+
+class Zino1NotificationProtocol(asyncio.Protocol):
+    """Basic implementation of the Zino 1 notification protocol"""
+
+    def __init__(self, server: Optional["ZinoServer"] = None, state: Optional[ZinoState] = None):
+        """Initializes a protocol instance.
+
+        :param state: An optional reference to a running Zino state that this server should be based on.  If omitted,
+                      this protocol will create and work on an empty state object.
+        """
+        self.server = server
+        self.transport: Optional[asyncio.Transport] = None
+        self.nonce: Optional[str] = None
+
+        self._state = state if state is not None else ZinoState()
+
+    @property
+    def peer_name(self) -> str:
+        return self.transport.get_extra_info("peername") if self.transport else None
+
+    def connection_made(self, transport: asyncio.Transport):
+        self.transport = transport
+        _logger.debug("New notification channel from %s", self.peer_name)
+        self.nonce = auth.get_challenge()  # Challenges are also useful as nonces
+        if self.server:
+            self.server.notification_channels[self.nonce] = self
+        self._respond_raw(self.nonce)
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:
+        _logger.info("Lost connection from %s: %s", self.peer_name, exc)
+        if self.server:
+            del self.server.notification_channels[self.nonce]
+
+    def _notify(self, event_id: int, change_type: str, value: Any):
+        self._respond_raw(f"{event_id} {change_type} {value}")
+
+    def _respond_raw(self, message: str):
+        """Encodes and sends a response line to the connected client"""
+        self.transport.write(f"{message}\r\n".encode("utf-8"))

--- a/src/zino/api/notify.py
+++ b/src/zino/api/notify.py
@@ -1,6 +1,6 @@
 """Notification channel implementation for Zino 2.0.
 
-Notification channels are currently part of the legacy API from the Tcl-based Zino 1.0, and is a simple text-based,
+Notification channels are currently part of the legacy API from the Tcl-based Zino 1.0.  They are a simple text-based,
 line-oriented protocol.  Clients are not expected to send any data to a notification channel, only receive data from
 the server.
 """

--- a/src/zino/api/notify.py
+++ b/src/zino/api/notify.py
@@ -45,7 +45,7 @@ class Zino1NotificationProtocol(asyncio.Protocol):
         self._tied_to: "Zino1ServerProtocol" = None
 
     @property
-    def peer_name(self) -> str:
+    def peer_name(self) -> Optional[str]:
         return self.transport.get_extra_info("peername") if self.transport else None
 
     def connection_made(self, transport: asyncio.Transport):

--- a/src/zino/api/notify.py
+++ b/src/zino/api/notify.py
@@ -33,6 +33,7 @@ class Zino1NotificationProtocol(asyncio.Protocol):
     def __init__(self, server: Optional["ZinoServer"] = None, state: Optional[ZinoState] = None):
         """Initializes a protocol instance.
 
+        :param server: An optional instance of `ZinoServer`.
         :param state: An optional reference to a running Zino state that this server should be based on.  If omitted,
                       this protocol will create and work on an empty state object.
         """

--- a/src/zino/api/notify.py
+++ b/src/zino/api/notify.py
@@ -6,10 +6,11 @@ the server.
 """
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Iterator, NamedTuple, Optional
 
 from zino.api import auth
 from zino.state import ZinoState
+from zino.statemodels import Event, EventState
 
 if TYPE_CHECKING:
     from zino.api.legacy import Zino1ServerProtocol
@@ -79,3 +80,38 @@ class Zino1NotificationProtocol(asyncio.Protocol):
     def _respond_raw(self, message: str):
         """Encodes and sends a response line to the connected client"""
         self.transport.write(f"{message}\r\n".encode("utf-8"))
+
+    @classmethod
+    def build_and_send_notifications(
+        cls, server: "ZinoServer", new_event: Event, old_event: Optional[Event] = None
+    ) -> None:
+        """Prepares and sends notifications for all changes between old_event and new_event to all connected and tied
+        notification channels.
+        """
+        notifications = list(cls.build_notifications(new_event, old_event))
+        tied_channels = [channel for channel in server.notification_channels.values() if channel.tied_to]
+        _logger.debug("Sending %s notifications to %s tied channels", len(notifications), len(tied_channels))
+
+        for notification in notifications:
+            for channel in tied_channels:
+                channel.notify(notification)
+
+    @classmethod
+    def build_notifications(cls, new_event: Event, old_event: Optional[Event] = None) -> Iterator[Notification]:
+        """Generates a sequence of Notification objects from the changes detected between old_event and new_event.
+
+        If `old_event` is `None`, it is assumed the event is brand new, and only the state change from EMBRYONIC
+        matters.
+        """
+        changed = new_event.get_changed_fields(old_event) if old_event else ["state"]
+
+        for attr in changed:
+            if attr == "state":
+                old_state = EventState.EMBRYONIC if not old_event else old_event.state
+                yield Notification(new_event.id, attr, f"{old_state.value} {new_event.state.value}")
+
+            elif attr in ("log", "history"):
+                yield Notification(new_event.id, attr, 1)
+
+            else:
+                yield Notification(new_event.id, "attr", attr)

--- a/src/zino/api/server.py
+++ b/src/zino/api/server.py
@@ -1,0 +1,40 @@
+import logging
+from asyncio import AbstractEventLoop
+
+from zino.api.legacy import Zino1ServerProtocol, ZinoTestProtocol
+from zino.api.notify import Zino1NotificationProtocol
+from zino.state import ZinoState
+
+_logger = logging.getLogger(__name__)
+
+
+class ZinoServer:
+    """Represents the two asyncio servers that work in tandem to implement the Zino 1 legacy API:
+
+    Port 8001 is the text-based command interface.
+    Port 8002 is the text-based notification interface.
+    """
+
+    API_PORT = 8001
+    NOTIFY_PORT = 8002
+
+    def __init__(self, loop: AbstractEventLoop, state: ZinoState):
+        self._loop = loop
+        self.state: ZinoState = state
+        self.active_clients: set[Zino1ServerProtocol] = set()
+        self.notification_channels: dict[str, Zino1NotificationProtocol] = {}
+        self.notify_server = self.api_server = None
+
+    def serve(self, address: str = "127.0.0.1"):
+        """Sets up the two asyncio servers to serve in tandem 'forever'"""
+        api_coroutine = self._loop.create_server(
+            lambda: ZinoTestProtocol(server=self, state=self.state), address, self.API_PORT
+        )
+        self.api_server = self._loop.run_until_complete(api_coroutine)
+        _logger.info("Serving API on %r", self.api_server.sockets[0].getsockname())
+
+        notify_coroutine = self._loop.create_server(
+            lambda: Zino1NotificationProtocol(server=self, state=self.state), address, self.NOTIFY_PORT
+        )
+        self.notify_server = self._loop.run_until_complete(notify_coroutine)
+        _logger.info("Serving notifications on %r", self.notify_server.sockets[0].getsockname())

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -246,6 +246,10 @@ class Event(BaseModel):
             return str(int(value.timestamp()))
         return str(value)
 
+    def get_changed_fields(self, other: "Event") -> List[str]:
+        """Compares this Event to another Event and returns a list of names of attributes that are different"""
+        return [field for field in self.model_fields if getattr(other, field) != getattr(self, field)]
+
 
 class PortStateEvent(Event):
     type: Literal["portstate"] = "portstate"

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -8,7 +8,7 @@ from typing import Optional
 import tzlocal
 
 from zino import state
-from zino.api.legacy import ZinoTestProtocol
+from zino.api.server import ZinoServer
 from zino.config.models import DEFAULT_INTERVAL_MINUTES
 from zino.scheduler import get_scheduler, load_and_schedule_polldevs
 from zino.statemodels import Event
@@ -47,9 +47,8 @@ def init_event_loop(args: argparse.Namespace):
     state.state.events.add_event_observer(reschedule_dump_state_on_commit)
 
     loop = asyncio.get_event_loop()
-    server = loop.create_server(lambda: ZinoTestProtocol(state=state.state), "127.0.0.1", 8001)
-    server_setup_result = loop.run_until_complete(server)
-    _log.info("Serving on %r", server_setup_result.sockets[0].getsockname())
+    server = ZinoServer(loop=loop, state=state.state)
+    server.serve()
 
     if args.stop_in:
         _log.info("Instructed to stop in %s seconds", args.stop_in)

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -21,9 +21,9 @@ class TestZino1BaseServerProtocol:
     def test_should_init_without_error(self):
         assert Zino1BaseServerProtocol()
 
-    def test_when_unconnected_then_peer_name_should_be_none(self):
+    def test_when_not_connected_then_peer_name_should_be_none(self):
         protocol = Zino1BaseServerProtocol()
-        assert not protocol.peer_name
+        assert protocol.peer_name is None
 
     def test_when_connected_then_peer_name_should_be_available(self):
         expected = "foobar"

--- a/tests/api/notify_test.py
+++ b/tests/api/notify_test.py
@@ -1,0 +1,50 @@
+from unittest.mock import Mock
+
+from zino.api.notify import Zino1NotificationProtocol
+from zino.api.server import ZinoServer
+from zino.state import ZinoState
+
+
+class TestZino1NotificationProtocol:
+    def test_init_should_succeed(self):
+        assert Zino1NotificationProtocol()
+
+    def test_when_unconnected_then_peer_name_should_be_none(self):
+        protocol = Zino1NotificationProtocol()
+        assert not protocol.peer_name
+
+    def test_when_connected_then_peer_name_should_be_available(self):
+        expected = "foobar"
+        protocol = Zino1NotificationProtocol()
+        fake_transport = Mock()
+        fake_transport.get_extra_info.return_value = expected
+        protocol.connection_made(fake_transport)
+
+        assert protocol.peer_name == expected
+
+    def test_when_connected_it_should_register_instance_in_server(self, event_loop):
+        server = ZinoServer(loop=event_loop, state=ZinoState())
+        protocol = Zino1NotificationProtocol(server=server)
+        fake_transport = Mock()
+        protocol.connection_made(fake_transport)
+
+        assert protocol.nonce in server.notification_channels
+        assert server.notification_channels[protocol.nonce] is protocol
+
+    def test_when_disconnected_it_should_deregister_instance_from_server(self, event_loop):
+        server = ZinoServer(loop=event_loop, state=ZinoState())
+        protocol = Zino1NotificationProtocol(server=server)
+        fake_transport = Mock()
+        protocol.connection_made(fake_transport)
+        protocol.connection_lost(exc=None)
+
+        assert protocol.nonce not in server.notification_channels
+
+    def test_notify_should_output_text_line(self):
+        protocol = Zino1NotificationProtocol()
+        fake_transport = Mock()
+        protocol.connection_made(fake_transport)
+        protocol._notify(42, "test", "data")
+        assert fake_transport.write.called
+        response = fake_transport.write.call_args[0][0]
+        assert response.startswith(b"42 test data")

--- a/tests/api/notify_test.py
+++ b/tests/api/notify_test.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 
-from zino.api.notify import Zino1NotificationProtocol
+from zino.api.notify import Notification, Zino1NotificationProtocol
 from zino.api.server import ZinoServer
 from zino.state import ZinoState
 
@@ -44,7 +44,7 @@ class TestZino1NotificationProtocol:
         protocol = Zino1NotificationProtocol()
         fake_transport = Mock()
         protocol.connection_made(fake_transport)
-        protocol._notify(42, "test", "data")
+        protocol.notify(Notification(42, "test", "data"))
         assert fake_transport.write.called
         response = fake_transport.write.call_args[0][0]
         assert response.startswith(b"42 test data")

--- a/tests/api/notify_test.py
+++ b/tests/api/notify_test.py
@@ -1,8 +1,13 @@
+from datetime import timedelta
 from unittest.mock import Mock
+
+import pytest
 
 from zino.api.notify import Notification, Zino1NotificationProtocol
 from zino.api.server import ZinoServer
 from zino.state import ZinoState
+from zino.statemodels import EventState, ReachabilityEvent
+from zino.time import now
 
 
 class TestZino1NotificationProtocol:
@@ -48,3 +53,87 @@ class TestZino1NotificationProtocol:
         assert fake_transport.write.called
         response = fake_transport.write.call_args[0][0]
         assert response.startswith(b"42 test data")
+
+    def test_tied_to_should_be_settable_and_gettable(self, event_loop):
+        server = ZinoServer(loop=event_loop, state=ZinoState())
+        protocol = Zino1NotificationProtocol()
+
+        protocol.tied_to = server
+        assert protocol.tied_to == server
+
+    def test_goodbye_should_close_transport(self, event_loop):
+        server = ZinoServer(loop=event_loop, state=ZinoState())
+        protocol = Zino1NotificationProtocol(server=server)
+        fake_transport = Mock()
+        protocol.connection_made(fake_transport)
+        protocol.goodbye()
+        assert fake_transport.close.called
+
+
+class TestZino1NotificationProtocolBuildNotifications:
+    def test_should_make_notifications_for_regular_changed_attrs(self, fake_event):
+        protocol = Zino1NotificationProtocol()
+        event_copy = fake_event.model_copy(deep=True)
+        event_copy.updated = now() + timedelta(seconds=5)
+
+        notifications = list(protocol.build_notifications(new_event=event_copy, old_event=fake_event))
+        assert notifications == [Notification(event_id=42, change_type="attr", value="updated")]
+
+    def test_should_make_notifications_for_log_changes(self, fake_event):
+        protocol = Zino1NotificationProtocol()
+        event_copy = fake_event.model_copy(deep=True)
+        event_copy.add_log("foo")
+
+        notifications = list(protocol.build_notifications(new_event=event_copy, old_event=fake_event))
+        assert Notification(event_id=42, change_type="log", value=1) in notifications
+
+    def test_should_make_notifications_for_history_changes(self, fake_event):
+        protocol = Zino1NotificationProtocol()
+        event_copy = fake_event.model_copy(deep=True)
+        event_copy.add_history("foo")
+
+        notifications = list(protocol.build_notifications(new_event=event_copy, old_event=fake_event))
+        assert Notification(event_id=42, change_type="history", value=1) in notifications
+
+    def test_should_make_notifications_for_state_changes(self, fake_event):
+        protocol = Zino1NotificationProtocol()
+        event_copy = fake_event.model_copy(deep=True)
+        event_copy.state = EventState.IGNORED
+
+        old, new = fake_event.state.value, event_copy.state.value
+        expected = f"{old} {new}"
+
+        notifications = list(protocol.build_notifications(new_event=event_copy, old_event=fake_event))
+        assert Notification(event_id=42, change_type="state", value=expected) in notifications
+
+
+class TestZino1NotificationProtocolBuildAndSendNotifications:
+    def test_should_send_notifications_only_to_tied_channels(self, event_loop, fake_event, changed_fake_event):
+        server = ZinoServer(loop=event_loop, state=ZinoState())
+        channel1 = Mock()
+        channel2 = Mock()
+        mock_api = Mock()
+
+        channel1.tied_to = mock_api
+        channel2.tied_to = None
+
+        server.notification_channels["a"] = channel1
+        server.notification_channels["b"] = channel2
+
+        Zino1NotificationProtocol.build_and_send_notifications(
+            server, new_event=changed_fake_event, old_event=fake_event
+        )
+        assert channel1.notify.called
+        assert not channel2.notify.called
+
+
+@pytest.fixture
+def fake_event() -> ReachabilityEvent:
+    return ReachabilityEvent(id=42, router="example-gw.example.org", state=EventState.OPEN)
+
+
+@pytest.fixture
+def changed_fake_event(fake_event) -> ReachabilityEvent:
+    copy = fake_event.model_copy(deep=True)
+    copy.add_history("this fake event has been changed")
+    return copy

--- a/tests/api/notify_test.py
+++ b/tests/api/notify_test.py
@@ -14,9 +14,9 @@ class TestZino1NotificationProtocol:
     def test_init_should_succeed(self):
         assert Zino1NotificationProtocol()
 
-    def test_when_unconnected_then_peer_name_should_be_none(self):
+    def test_when_not_connected_then_peer_name_should_be_none(self):
         protocol = Zino1NotificationProtocol()
-        assert not protocol.peer_name
+        assert protocol.peer_name is None
 
     def test_when_connected_then_peer_name_should_be_available(self):
         expected = "foobar"

--- a/tests/api/server_test.py
+++ b/tests/api/server_test.py
@@ -1,0 +1,9 @@
+from zino.api.server import ZinoServer
+from zino.state import ZinoState
+
+
+def test_zinoserver_should_serve_without_error(event_loop):
+    server = ZinoServer(event_loop, ZinoState())
+    server.serve()
+    server.notify_server.close()
+    server.api_server.close()

--- a/tests/statemodels_test.py
+++ b/tests/statemodels_test.py
@@ -10,6 +10,7 @@ from zino.statemodels import (
     LogEntry,
     ReachabilityEvent,
 )
+from zino.time import now
 
 
 class TestEvent:
@@ -72,6 +73,14 @@ class TestEvent:
         fake_event.set_state(fake_event.state, user="nobody")
         history_count_after = len(fake_event.history)
         assert history_count_after == history_count_before
+
+    def test_get_changed_fields_should_correctly_detect_changed_fields(self, fake_event):
+        copy = fake_event.model_copy(deep=True)
+        copy.add_log("test")
+        copy.updated = now() + datetime.timedelta(seconds=3)
+
+        changed = fake_event.get_changed_fields(copy)
+        assert set(changed) == {"log", "updated"}
 
 
 class TestLogEntryModelDumpLegacy:


### PR DESCRIPTION
This adds a notification protocol implementation, as well as refactoring how the two protocol servers are set up when running Zino.

API protocol and notify protocol instances need to be able to look up each other's existence in order for notification channels to be properly authenticated, so this introduces a new `ZinoServer` class that takes the responsibility of setting up both asyncio servers and keeping track of which client sessions exist for both.

Each protocol instance now also takes a reference to the controlling `ZinoServer` object as an __init__ argument, so as to be able to register themselves, and to be able to look each other up when notification channels are being set up and associated.

`zino.zino.main` is refactored to delegate responsibility for setting up the servers to `ZinoServer`.

I potentially recommend reviewing this commit-by-commit.

Closes #147 