### PR TITLE
Include new and old event references in event observer functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,10 @@ exclude = [
 [tool.isort]
 profile = "black"
 src_paths = ["src", "tests"]
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_also = [
+    # Don't need coverage for ellipsis used for type annotations
+    "...",
+]

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -1,6 +1,6 @@
 import logging
 from collections import namedtuple
-from typing import Any, Callable, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Protocol, Type, Union
 
 from pydantic.main import BaseModel
 
@@ -18,6 +18,13 @@ from zino.statemodels import (
 EventIndex = namedtuple("EventIndex", "router port type")
 
 _log = logging.getLogger(__name__)
+
+
+class EventObserver(Protocol):
+    """Defines a valid protocol for event observer functions"""
+
+    def __call__(self, new_event: Event, old_event: Optional[Event] = None) -> None:
+        ...
 
 
 class Events(BaseModel):

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -36,17 +36,19 @@ class TestZinoRescheduleDumpStateOnCommit:
     def test_when_more_than_10_seconds_remains_until_next_dump_it_should_reschedule(self):
         scheduler = get_scheduler()
         mock_job = Mock(next_run_time=now() + timedelta(minutes=5))
+        mock_event = Mock(id=42)
 
         with patch.object(scheduler, "get_job") as get_job:
             get_job.return_value = mock_job
-            zino.reschedule_dump_state_on_commit(42)
+            zino.reschedule_dump_state_on_commit(mock_event)
             assert mock_job.modify.called
 
     def test_when_less_than_10_seconds_remains_until_next_dump_it_should_not_reschedule(self):
         scheduler = get_scheduler()
         mock_job = Mock(next_run_time=now() + timedelta(seconds=5))
+        mock_event = Mock(id=42)
 
         with patch.object(scheduler, "get_job") as get_job:
             get_job.return_value = mock_job
-            zino.reschedule_dump_state_on_commit(42)
+            zino.reschedule_dump_state_on_commit(mock_event)
             assert not mock_job.modify.called


### PR DESCRIPTION
This facilitates a change in the event observer interface that is necessary for the implementation of #149 to move forward.

An event observer function needs more than just the ID of a changed event to be able to do many useful things, especially if that event observer needs to inspect which attributes of an event changed and to queue notifications as a result of this.

This PR changes the event observer interface to include the full old and new event objects as arguments to observer functions (where the old object is optional, since there isn't one the first time an event is committed).
