### PR TITLE
Add missing event commit in ADDHIST command

### DIFF
--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -280,8 +280,10 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         self._respond(302, "please provide new history entry, terminate with '.'")
         data = await self._read_multiline()
         message = f"{self.user}\n" + "\n".join(line.strip() for line in data)
-        event.add_history(message)
-        _logger.debug("id %s history added: %r", event.id, message)
+        out_event = self._state.events.checkout(event.id)
+        out_event.add_history(message)
+        self._state.events.commit(out_event)
+        _logger.debug("id %s history added: %r", out_event.id, message)
 
         self._respond_ok()
 

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -382,7 +382,8 @@ class TestZino1ServerProtocolAddhistCommand:
         with patch.object(authenticated_protocol, "_read_multiline", mock_multiline):
             pre_count = len(event.history)
             await authenticated_protocol.do_addhist(event.id)
-            assert len(event.history) > pre_count
+            committed_event = state.events[event.id]
+            assert len(committed_event.history) > pre_count
 
     @pytest.mark.asyncio
     async def test_should_prefix_history_message_with_username(self, authenticated_protocol, event_loop):
@@ -397,7 +398,8 @@ class TestZino1ServerProtocolAddhistCommand:
 
         with patch.object(authenticated_protocol, "_read_multiline", mock_multiline):
             await authenticated_protocol.do_addhist(event.id)
-            entry = event.history[-1]
+            committed_event = state.events[event.id]
+            entry = committed_event.history[-1]
             assert entry.message.startswith(authenticated_protocol.user)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
The ADDHIST API command makes event modifications, but changing the implementation to commit the changes once the event commit framework was built was forgotten.  This adds the proper changes.