### PR TITLE
Replace overloaded `port` concept for indexing of events

### DIFF
--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -1,6 +1,5 @@
 import logging
-from collections import namedtuple
-from typing import Dict, Optional, Protocol, Type, Union
+from typing import Dict, NamedTuple, Optional, Protocol, Type, Union
 
 from pydantic.main import BaseModel
 
@@ -15,9 +14,13 @@ from zino.statemodels import (
     SubIndex,
 )
 
-EventIndex = namedtuple("EventIndex", "router port type")
-
 _log = logging.getLogger(__name__)
+
+
+class EventIndex(NamedTuple):
+    router: str
+    port: SubIndex
+    type: Type
 
 
 class EventObserver(Protocol):

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -72,6 +72,10 @@ class Events(BaseModel):
 
         If a matching event already exists, the return value is a checkout copy, as if the `checkout()` method had been
         used.  The assumption is that the caller is looking to make changes to the fetched event.
+
+        Please note that what kind of event attribute subindex represents will vary between event classes.  This method
+        will therefore not be able to set this attribute on a newly created event object, and the caller is responsible
+        for doing so.
         """
         try:
             return self.create_event(device_name, subindex, event_class)
@@ -84,6 +88,10 @@ class Events(BaseModel):
         identifiers, an EventExistsError is raised.
 
         The event is not committed to the event registry; this must be done by explicitly calling the `commit()` method.
+
+        Please note that what kind of event attribute subindex represents will vary between event classes.  This method
+        will therefore not be able to set this attribute on the newly created event object, and the caller is
+        responsible for doing so.
         """
         index = EventIndex(device_name, subindex, event_class)
         if index in self._events_by_index:

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -19,7 +19,7 @@ _log = logging.getLogger(__name__)
 
 class EventIndex(NamedTuple):
     router: str
-    port: SubIndex
+    subindex: SubIndex
     type: Type
 
 
@@ -60,7 +60,7 @@ class Events(BaseModel):
     def get_or_create_event(
         self,
         device_name: str,
-        port: SubIndex,
+        subindex: SubIndex,
         event_class: Type[Event],
     ) -> Event:
         """Creates and returns a new event for the given event identifiers, or, if an event matching this identifier
@@ -74,18 +74,18 @@ class Events(BaseModel):
         used.  The assumption is that the caller is looking to make changes to the fetched event.
         """
         try:
-            return self.create_event(device_name, port, event_class)
+            return self.create_event(device_name, subindex, event_class)
         except EventExistsError:
-            event = self.get(device_name, port, event_class)
+            event = self.get(device_name, subindex, event_class)
             return self.checkout(event.id)
 
-    def create_event(self, device_name: str, port: SubIndex, event_class: Type[Event]) -> Event:
+    def create_event(self, device_name: str, subindex: SubIndex, event_class: Type[Event]) -> Event:
         """Creates a new event for the given event identifiers. If an event already exists for this combination of
         identifiers, an EventExistsError is raised.
 
         The event is not committed to the event registry; this must be done by explicitly calling the `commit()` method.
         """
-        index = EventIndex(device_name, port, event_class)
+        index = EventIndex(device_name, subindex, event_class)
         if index in self._events_by_index:
             raise EventExistsError(f"Event for {index} already exists")
 
@@ -95,9 +95,9 @@ class Events(BaseModel):
         _log.debug("created embryonic event %r", event)
         return event
 
-    def get(self, device_name: str, port: SubIndex, event_class: Type[Event]) -> Event:
+    def get(self, device_name: str, subindex: SubIndex, event_class: Type[Event]) -> Event:
         """Returns an event based on its identifiers, None if no match was found"""
-        index = EventIndex(device_name, port, event_class)
+        index = EventIndex(device_name, subindex, event_class)
         return self._events_by_index.get(index)
 
     def checkout(self, event_id: int) -> Event:

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -53,7 +53,7 @@ class Events(BaseModel):
         """
         new_index: Dict[EventIndex, Event] = {}
         for event in self.events.values():
-            key = EventIndex(event.router, event.port, type(event))
+            key = EventIndex(event.router, event.subindex, type(event))
             new_index[key] = event
         self._events_by_index = new_index
 
@@ -91,7 +91,6 @@ class Events(BaseModel):
 
         event = event_class(
             router=device_name,
-            port=port,
         )
         _log.debug("created embryonic event %r", event)
         return event
@@ -123,7 +122,7 @@ class Events(BaseModel):
             event.id = self.get_next_available_event_id()
         else:
             old_event = self.events[event.id]
-        index = EventIndex(event.router, event.port, type(event))
+        index = EventIndex(event.router, event.subindex, type(event))
         self._events_by_index[index] = event
         self.events[event.id] = event
 

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -10,9 +10,9 @@ from zino.statemodels import (
     BGPEvent,
     Event,
     EventState,
-    PortOrIPAddress,
     PortStateEvent,
     ReachabilityEvent,
+    SubIndex,
 )
 
 EventIndex = namedtuple("EventIndex", "router port type")
@@ -57,7 +57,7 @@ class Events(BaseModel):
     def get_or_create_event(
         self,
         device_name: str,
-        port: Optional[PortOrIPAddress],
+        port: SubIndex,
         event_class: Type[Event],
     ) -> Event:
         """Creates and returns a new event for the given event identifiers, or, if an event matching this identifier
@@ -76,7 +76,7 @@ class Events(BaseModel):
             event = self.get(device_name, port, event_class)
             return self.checkout(event.id)
 
-    def create_event(self, device_name: str, port: Optional[PortOrIPAddress], event_class: Type[Event]) -> Event:
+    def create_event(self, device_name: str, port: SubIndex, event_class: Type[Event]) -> Event:
         """Creates a new event for the given event identifiers. If an event already exists for this combination of
         identifiers, an EventExistsError is raised.
 
@@ -93,7 +93,7 @@ class Events(BaseModel):
         _log.debug("created embryonic event %r", event)
         return event
 
-    def get(self, device_name: str, port: Optional[PortOrIPAddress], event_class: Type[Event]) -> Event:
+    def get(self, device_name: str, port: SubIndex, event_class: Type[Event]) -> Event:
         """Returns an event based on its identifiers, None if no match was found"""
         index = EventIndex(device_name, port, event_class)
         return self._events_by_index.get(index)

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -12,7 +12,7 @@ from zino.time import now
 
 IPAddress = Union[IPv4Address, IPv6Address]
 AlarmType = Literal["yellow", "red"]
-PortOrIPAddress = Union[int, IPAddress, AlarmType]
+SubIndex = Union[None, int, IPAddress, AlarmType]
 
 _logger = logging.getLogger(__name__)
 
@@ -186,7 +186,7 @@ class Event(BaseModel):
     id: Optional[int] = None
 
     router: str
-    port: Optional[PortOrIPAddress] = None
+    port: SubIndex = None
     type: Literal["Event"] = "Event"
     state: EventState = EventState.EMBRYONIC
     opened: datetime.datetime = Field(default_factory=now)

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -186,7 +186,6 @@ class Event(BaseModel):
     id: Optional[int] = None
 
     router: str
-    port: SubIndex = None
     type: Literal["Event"] = "Event"
     state: EventState = EventState.EMBRYONIC
     opened: datetime.datetime = Field(default_factory=now)
@@ -202,6 +201,16 @@ class Event(BaseModel):
     ac_down: Optional[datetime.timedelta] = None
 
     polladdr: Optional[IPAddress] = None
+
+    @property
+    def subindex(self) -> SubIndex:
+        """Returns an identifier of a router subcomponent that this event refers to.
+
+        This value is used to index an event uniquely, and the property itself is usually only called if the event index
+        class needs to re-index all existing events - something that usually only happens when loading serialized
+        state from disk.
+        """
+        return None
 
     def set_state(self, new_state: EventState, user: str = "monitor"):
         """Sets a new event state value, logging the change to the event history with a username"""
@@ -249,9 +258,14 @@ class Event(BaseModel):
 
 class PortStateEvent(Event):
     type: Literal["portstate"] = "portstate"
+    port: Optional[str] = ""
     ifindex: Optional[int] = None
     portstate: Optional[InterfaceState] = None
     descr: Optional[str] = None
+
+    @property
+    def subindex(self) -> SubIndex:
+        return self.port
 
 
 class BGPEvent(Event):
@@ -260,13 +274,22 @@ class BGPEvent(Event):
     remote_as: Optional[int] = None
     peer_uptime: Optional[int] = None
 
+    @property
+    def subindex(self) -> SubIndex:
+        return self.remote_addr
+
 
 class BFDEvent(Event):
     type: Literal["bfd"] = "bfd"
+    ifindex: Optional[int] = None
     bfdstate: Optional[BFDSessState] = None
     bfdix: Optional[int] = None
     bfddiscr: Optional[int] = None
     bfdaddr: Optional[IPAddress] = None
+
+    @property
+    def subindex(self) -> SubIndex:
+        return self.ifindex
 
 
 class ReachabilityEvent(Event):
@@ -276,4 +299,9 @@ class ReachabilityEvent(Event):
 
 class AlarmEvent(Event):
     type: Literal["alarm"] = "alarm"
+    alarm_type: Optional[AlarmType] = None
     alarm_count: Optional[int] = None
+
+    @property
+    def subindex(self) -> SubIndex:
+        return self.alarm_type

--- a/src/zino/tasks/bfdtask.py
+++ b/src/zino/tasks/bfdtask.py
@@ -66,6 +66,7 @@ class BFDTask(Task):
     def _create_or_update_event(self, port: Port, new_state: BFDState):
         event = self.state.events.get_or_create_event(self.device.name, port.ifindex, BFDEvent)
 
+        event.ifindex = port.ifindex
         event.bfdstate = new_state.session_state
         event.bfdix = new_state.session_index
         event.bfddiscr = new_state.session_discr

--- a/src/zino/tasks/bfdtask.py
+++ b/src/zino/tasks/bfdtask.py
@@ -67,6 +67,8 @@ class BFDTask(Task):
         event = self.state.events.get_or_create_event(self.device.name, port.ifindex, BFDEvent)
 
         event.ifindex = port.ifindex
+        event.polladdr = self.device.address
+        event.priority = self.device.priority
         event.bfdstate = new_state.session_state
         event.bfdix = new_state.session_index
         event.bfddiscr = new_state.session_discr

--- a/src/zino/tasks/juniperalarmtask.py
+++ b/src/zino/tasks/juniperalarmtask.py
@@ -65,6 +65,7 @@ class JuniperAlarmTask(Task):
         )
 
         old_alarm_count = alarm_event.alarm_count
+        alarm_event.alarm_type = color
         alarm_event.alarm_count = alarm_count
         alarm_event.add_log(f"{self.device.name} {color} alarms went from {old_alarm_count} to {alarm_count}")
         self.state.events.commit(alarm_event)

--- a/src/zino/tasks/juniperalarmtask.py
+++ b/src/zino/tasks/juniperalarmtask.py
@@ -60,7 +60,7 @@ class JuniperAlarmTask(Task):
     def create_alarm_event(self, color: AlarmType, alarm_count: int):
         alarm_event = self.state.events.get_or_create_event(
             device_name=self.device.name,
-            port=color,
+            subindex=color,
             event_class=AlarmEvent,
         )
 

--- a/src/zino/tasks/juniperalarmtask.py
+++ b/src/zino/tasks/juniperalarmtask.py
@@ -1,7 +1,6 @@
 import logging
-from typing import Literal
 
-from zino.statemodels import AlarmEvent
+from zino.statemodels import AlarmEvent, AlarmType
 from zino.tasks.task import Task
 
 _logger = logging.getLogger(__name__)
@@ -58,7 +57,7 @@ class JuniperAlarmTask(Task):
 
         return yellow_alarm_count, red_alarm_count
 
-    def create_alarm_event(self, color: Literal["yellow", "red"], alarm_count: int):
+    def create_alarm_event(self, color: AlarmType, alarm_count: int):
         alarm_event = self.state.events.get_or_create_event(
             device_name=self.device.name,
             port=color,

--- a/src/zino/tasks/juniperalarmtask.py
+++ b/src/zino/tasks/juniperalarmtask.py
@@ -68,4 +68,6 @@ class JuniperAlarmTask(Task):
         alarm_event.alarm_type = color
         alarm_event.alarm_count = alarm_count
         alarm_event.add_log(f"{self.device.name} {color} alarms went from {old_alarm_count} to {alarm_count}")
+        alarm_event.polladdr = self.device.address
+        alarm_event.priority = self.device.priority
         self.state.events.commit(alarm_event)

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -115,7 +115,7 @@ class LinkStateTask(Task):
         event.ifindex = port.ifindex
         event.polladdr = self.device.address
         event.priority = self.device.priority
-        event.descr = port.ifdescr
+        event.descr = port.ifalias
 
         uptime = self.sysuptime or last_change
         event_time = datetime.datetime.now() - datetime.timedelta(seconds=(uptime - last_change) / 100)

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -111,6 +111,7 @@ class LinkStateTask(Task):
         event = self.state.events.get_or_create_event(self.device.name, port.ifindex, PortStateEvent)
 
         event.portstate = new_state
+        event.port = port.ifdescr
         event.ifindex = port.ifindex
         event.polladdr = self.device.address
         event.priority = self.device.priority

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -28,6 +28,8 @@ class ReachableTask(Task):
             if event.reachability != ReachabilityState.NORESPONSE:
                 event.reachability = ReachabilityState.NORESPONSE
                 event.add_log(f"{self.device.name} no-response")
+            event.polladdr = self.device.address
+            event.priority = self.device.priority
             self.state.events.commit(event)
             self._schedule_extra_job()
             raise DeviceUnreachableError

--- a/tests/tasks/test_bfdtask.py
+++ b/tests/tasks/test_bfdtask.py
@@ -75,7 +75,7 @@ async def test_event_should_not_be_made_the_first_time_a_port_is_polled(task, de
     assert device_port.bfd_state
     event = task.state.events.get(
         device_name=task.device.name,
-        port=device_port.ifindex,
+        subindex=device_port.ifindex,
         event_class=BFDEvent,
     )
     assert not event
@@ -88,7 +88,7 @@ async def test_state_changing_should_create_event(task, device_port, bfd_state):
     device_port.bfd_state = down_state
     await task.run()
     assert device_port.bfd_state != down_state
-    event = task.state.events.get(device_name=task.device.name, port=device_port.ifindex, event_class=BFDEvent)
+    event = task.state.events.get(device_name=task.device.name, subindex=device_port.ifindex, event_class=BFDEvent)
     assert event
 
 
@@ -98,7 +98,7 @@ async def test_state_not_changing_should_not_create_event(task, device_port, bfd
     device_port.bfd_state = bfd_state
     await task.run()
     assert device_port.bfd_state == bfd_state
-    event = task.state.events.get(device_name=task.device.name, port=device_port.ifindex, event_class=BFDEvent)
+    event = task.state.events.get(device_name=task.device.name, subindex=device_port.ifindex, event_class=BFDEvent)
     assert not event
 
 

--- a/tests/tasks/test_juniperalarmtask.py
+++ b/tests/tasks/test_juniperalarmtask.py
@@ -107,11 +107,13 @@ class TestJuniperalarmTask:
         yellow_event = task.state.events.get_or_create_event(
             device_name=task.device.name, port="yellow", event_class=AlarmEvent
         )
+        yellow_event.alarm_type = "yellow"
         yellow_event.alarm_count = 2
         task.state.events.commit(yellow_event)
         red_event = task.state.events.get_or_create_event(
             device_name=task.device.name, port="red", event_class=AlarmEvent
         )
+        red_event.alarm_type = "red"
         red_event.alarm_count = 3
         task.state.events.commit(red_event)
 

--- a/tests/tasks/test_juniperalarmtask.py
+++ b/tests/tasks/test_juniperalarmtask.py
@@ -72,8 +72,8 @@ class TestJuniperalarmTask:
 
         await task.run()
 
-        yellow_event = task.state.events.get(device_name=task.device.name, port="yellow", event_class=AlarmEvent)
-        red_event = task.state.events.get(device_name=task.device.name, port="red", event_class=AlarmEvent)
+        yellow_event = task.state.events.get(device_name=task.device.name, subindex="yellow", event_class=AlarmEvent)
+        red_event = task.state.events.get(device_name=task.device.name, subindex="red", event_class=AlarmEvent)
 
         assert yellow_event
         assert red_event
@@ -92,8 +92,8 @@ class TestJuniperalarmTask:
 
         await task.run()
 
-        yellow_event = task.state.events.get(device_name=task.device.name, port="yellow", event_class=AlarmEvent)
-        red_event = task.state.events.get(device_name=task.device.name, port="red", event_class=AlarmEvent)
+        yellow_event = task.state.events.get(device_name=task.device.name, subindex="yellow", event_class=AlarmEvent)
+        red_event = task.state.events.get(device_name=task.device.name, subindex="red", event_class=AlarmEvent)
 
         assert not yellow_event
         assert red_event
@@ -105,13 +105,13 @@ class TestJuniperalarmTask:
         device_state = task.state.devices.get(device_name=task.device.name)
         device_state.enterprise_id = 2636
         yellow_event = task.state.events.get_or_create_event(
-            device_name=task.device.name, port="yellow", event_class=AlarmEvent
+            device_name=task.device.name, subindex="yellow", event_class=AlarmEvent
         )
         yellow_event.alarm_type = "yellow"
         yellow_event.alarm_count = 2
         task.state.events.commit(yellow_event)
         red_event = task.state.events.get_or_create_event(
-            device_name=task.device.name, port="red", event_class=AlarmEvent
+            device_name=task.device.name, subindex="red", event_class=AlarmEvent
         )
         red_event.alarm_type = "red"
         red_event.alarm_count = 3
@@ -135,8 +135,8 @@ class TestJuniperalarmTask:
 
         await task.run()
 
-        yellow_event = task.state.events.get(device_name=task.device.name, port="yellow", event_class=AlarmEvent)
-        red_event = task.state.events.get(device_name=task.device.name, port="red", event_class=AlarmEvent)
+        yellow_event = task.state.events.get(device_name=task.device.name, subindex="yellow", event_class=AlarmEvent)
+        red_event = task.state.events.get(device_name=task.device.name, subindex="red", event_class=AlarmEvent)
 
         assert not yellow_event
         assert not red_event
@@ -155,8 +155,8 @@ class TestJuniperalarmTask:
         device_state.enterprise_id = 2636
         await task.run()
 
-        yellow_event = task.state.events.get(device_name=task.device.name, port="yellow", event_class=AlarmEvent)
-        red_event = task.state.events.get(device_name=task.device.name, port="red", event_class=AlarmEvent)
+        yellow_event = task.state.events.get(device_name=task.device.name, subindex="yellow", event_class=AlarmEvent)
+        red_event = task.state.events.get(device_name=task.device.name, subindex="red", event_class=AlarmEvent)
 
         assert not yellow_event
         assert not red_event


### PR DESCRIPTION
The original Zino 1 Tcl code used `port` as one of three components used to uniquely index events.  However, it greatly overloaded the meaning of `port`.  

For reachability events, `port` would be an empty value, since the event would pertain to the router itself, and not to a sub-component of the router.  For actual port state events, it would be the `ifindex` value of the port in question.  For BGP events, it would be the IP address of the BGP peer, and so forth.

We took this concept and ran with it in the initial stages of porting the code to Python, but the concept leaked into the attributes of the `Event` base class, causing all event types to have a `port` attribute, which made no sense.  This became rather apparent when writing a converter for Zino 1 state to Zino 2 state.

So, this is the time to get rid of this concept and be more explicit about an index value being an index value, and not a port name or identifier.

Each event type, with the notable exception of reachability events, has some attribute that uniquely identifies it among events of the same type for the same router.  This attribute is named differently for the different event types.  Since some of the existing event types relied on its inherited `port` attribute for this, this PR adds new attributes to these event types (to match the names given in the Zino 1 API), and replaces the concept of `port` for indexing with a generic `subindex` term.

The pre-existing `PortOrIPAddress` compound type annotation was mean to represent these index values, but was badly named (as it encompassed more than just ports and IP addresses).  This was renamed and repurposed into a `SubIndex` compound type, which can now be extended if new event types are ever added.

The PR also fixes a few small bugs and issues with how event attributes were set (or not set) by the various implemented tasks.