### PR TITLE
Ignore trailing garbage args on API commands

### DIFF
--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -121,9 +121,13 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
             return self._respond_error("Not authenticated")
 
         required_args = inspect.signature(responder).parameters
-        if len(args) != len(required_args):
+        if len(args) < len(required_args):
             arg_summary = " (" + ", ".join(required_args.keys()) + ")" if required_args else ""
             return self._respond_error(f"{command} needs {len(required_args)} parameters{arg_summary}")
+        elif len(args) > len(required_args):
+            garbage_args = args[len(required_args) :]
+            _logger.debug("client %s sent %r, ignoring garbage args at end: %r", self.peer_name, args, garbage_args)
+            args = args[: len(required_args)]
 
         self._current_task = asyncio.create_task(self._run_async_responder(command, responder, *args))
         return self._current_task


### PR DESCRIPTION
Apparently, legacy clients may attempt to send extra garbage arguments at the end of commands like the `USER` command, and Zino 1 was fine with this, while Zino 2 would respond with an error, causing the client to fail on login.

This changes the behavior of the legacy protocol implementation to allow, but ignoree and log extraneous command arguments.