### PR TITLE
Fix strange bug in translation of caseids to Event objects in API commands

### DIFF
--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -238,7 +238,10 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
                 case_id = int(case_id)
                 event = self._state.events[case_id]
             except (ValueError, KeyError):
-                return self._respond_error(f'event "{case_id}" does not exist')
+                self._respond_error(f'event "{case_id}" does not exist')
+                response = asyncio.get_running_loop().create_future()
+                response.set_result(None)
+                return response
             return responder(self, event, *args, **kwargs)
 
         return _verify


### PR DESCRIPTION
A magic decorator is used to allow API command responders that operate on Events to have its caseid argument automatically translated to a proper `Event` object.  The decorator also ensures the command responder is never run if the incoming caseid is non-existent.

However, there was a slight bug in the error handler:  Command responders are async functions. Async functions are always awaitable (i.e. they return `Future` objects).  When the caseid is non-existent, the decorator would return a plain value, `None` in most cases, which is not awaitable.  This would result in strange tracebacks in the logs, and also an additional "500 internal error" line being output to API clients (after the initial 500 message about the invalid caseid).

This was found by running a legacy client against the Zino 2 API implementation.  Regression tests are added.