### PR TITLE
 Implement line buffering in data_received() 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-asyncio<0.22.0",
+    "pytest-timeout",
     "retry",
     "ruff",
     "snmpsim",

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -92,12 +92,24 @@ class TestZino1BaseServerProtocol:
 
     @pytest.mark.timeout(5)
     @pytest.mark.asyncio
-    async def test_data_received_should_break_down_multiline_input_packets(self):
+    async def test_data_received_should_break_down_multiline_input_packets_with_cr_and_lf(self):
         protocol = Zino1BaseServerProtocol()
         fake_transport = Mock()
         protocol.connection_made(fake_transport)
         future = protocol._read_multiline()
         protocol.data_received(b"line one\r\nline two\r\n.\r\n")
+        data = await future
+
+        assert data == ["line one", "line two"]
+
+    @pytest.mark.timeout(5)
+    @pytest.mark.asyncio
+    async def test_data_received_should_break_down_multiline_input_packets_with_just_lf(self):
+        protocol = Zino1BaseServerProtocol()
+        fake_transport = Mock()
+        protocol.connection_made(fake_transport)
+        future = protocol._read_multiline()
+        protocol.data_received(b"line one\nline two\n.\n")
         data = await future
 
         assert data == ["line one", "line two"]

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -90,6 +90,18 @@ class TestZino1BaseServerProtocol:
 
         assert data == ["line one", "line two"]
 
+    @pytest.mark.timeout(5)
+    @pytest.mark.asyncio
+    async def test_data_received_should_break_down_multiline_input_packets(self):
+        protocol = Zino1BaseServerProtocol()
+        fake_transport = Mock()
+        protocol.connection_made(fake_transport)
+        future = protocol._read_multiline()
+        protocol.data_received(b"line one\r\nline two\r\n.\r\n")
+        data = await future
+
+        assert data == ["line one", "line two"]
+
     def test_when_command_is_unknown_then_dispatcher_should_respond_with_error(self):
         protocol = Zino1BaseServerProtocol()
         fake_transport = Mock()


### PR DESCRIPTION
While manually testing the protocol implementation using simple tools like telnet or netcat, `data_received()` will usually receive full text lines from the transport, as these tools typically send a packet once Enter is pressed.

However, `Protocol.data_received()` will in fact receive any old piece of binary data, which can potentially come in arbitrarily sized packets, depending on the client.  As demonstrated by the legacy cuRitz client, which will for example dispatch the text data associated with a `ADDHIST` command as one large, multiline packet: This causes the naive implementation of `data_received()` to fail and hang forever, as the multiline input mode will be waiting for a single packet containing `b'.\r\n'` before it's satisfied that input has ended.

This reworks `data_received()` to employ a simple bytearray buffer of incoming data, and moves most of the message parsing logic to a new method `message_received()`.  The latter will only receive single, full lines of protocol data as string objects, with newlines and carriage returns stripped.