### PR TITLE
Rename BGP event attributes to follow Zino1 protocol

### DIFF
--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -309,7 +309,7 @@ class PortStateEvent(Event):
 
 class BGPEvent(Event):
     type: Literal["bgp"] = "bgp"
-    remote_address: Optional[IPAddress] = None
+    remote_addr: Optional[IPAddress] = None
     remote_as: Optional[int] = None
     peer_uptime: Optional[int] = None
     operational_state: Optional[BGPOperState] = None
@@ -318,7 +318,7 @@ class BGPEvent(Event):
 
     @property
     def subindex(self) -> SubIndex:
-        return self.remote_address
+        return self.remote_addr
 
 
 class BFDEvent(Event):

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -313,7 +313,7 @@ class BGPEvent(Event):
     remote_as: Optional[int] = None
     peer_uptime: Optional[int] = None
     bgpos: Optional[BGPOperState] = None
-    admin_status: Optional[BGPAdminStatus] = None
+    bgpas: Optional[BGPAdminStatus] = None
     lastevent: Optional[str] = None
 
     @property

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -312,7 +312,7 @@ class BGPEvent(Event):
     remote_addr: Optional[IPAddress] = None
     remote_as: Optional[int] = None
     peer_uptime: Optional[int] = None
-    operational_state: Optional[BGPOperState] = None
+    bgpos: Optional[BGPOperState] = None
     admin_status: Optional[BGPAdminStatus] = None
     lastevent: Optional[str] = None
 

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -314,6 +314,7 @@ class BGPEvent(Event):
     peer_uptime: Optional[int] = None
     operational_state: Optional[BGPOperState] = None
     admin_status: Optional[BGPAdminStatus] = None
+    lastevent: Optional[str] = None
 
     @property
     def subindex(self) -> SubIndex:

--- a/src/zino/tasks/bgpstatemonitortask.py
+++ b/src/zino/tasks/bgpstatemonitortask.py
@@ -345,7 +345,8 @@ class BGPStateMonitorTask(Task):
     def _bgp_admin_up(self, data: BaseBGPRow):
         event = self.state.events.get_or_create_event(self.device.name, data.peer_remote_address, BGPEvent)
 
-        if event.admin_status == data.peer_admin_status:
+        # No previous event, so no need to notify or event already up to date
+        if event.id is None or event.admin_status == data.peer_admin_status:
             return
 
         copied_data = replace(data, peer_fsm_established_time=0)

--- a/src/zino/tasks/bgpstatemonitortask.py
+++ b/src/zino/tasks/bgpstatemonitortask.py
@@ -327,7 +327,7 @@ class BGPStateMonitorTask(Task):
     def _bgp_admin_down(self, data: BaseBGPRow):
         event = self.state.events.get_or_create_event(self.device.name, data.peer_remote_address, BGPEvent)
 
-        if event.admin_status == data.peer_admin_status:
+        if event.bgpas == data.peer_admin_status:
             return
 
         copied_data = replace(data, peer_state="down", peer_fsm_established_time=0)
@@ -346,7 +346,7 @@ class BGPStateMonitorTask(Task):
         event = self.state.events.get_or_create_event(self.device.name, data.peer_remote_address, BGPEvent)
 
         # No previous event, so no need to notify or event already up to date
-        if event.id is None or event.admin_status == data.peer_admin_status:
+        if event.id is None or event.bgpas == data.peer_admin_status:
             return
 
         copied_data = replace(data, peer_fsm_established_time=0)
@@ -383,7 +383,7 @@ class BGPStateMonitorTask(Task):
         """Updates a given BGP event with the given BGP data"""
 
         event.bgpos = data.peer_state
-        event.admin_status = data.peer_admin_status
+        event.bgpas = data.peer_admin_status
         event.remote_addr = data.peer_remote_address
         event.remote_as = data.peer_remote_as
         event.peer_uptime = data.peer_fsm_established_time

--- a/src/zino/tasks/bgpstatemonitortask.py
+++ b/src/zino/tasks/bgpstatemonitortask.py
@@ -384,7 +384,7 @@ class BGPStateMonitorTask(Task):
 
         event.operational_state = data.peer_state
         event.admin_status = data.peer_admin_status
-        event.remote_address = data.peer_remote_address
+        event.remote_addr = data.peer_remote_address
         event.remote_as = data.peer_remote_as
         event.peer_uptime = data.peer_fsm_established_time
         event.polladdr = self.device.address

--- a/src/zino/tasks/bgpstatemonitortask.py
+++ b/src/zino/tasks/bgpstatemonitortask.py
@@ -279,7 +279,7 @@ class BGPStateMonitorTask(Task):
             _logger.debug(f"Noted external reset for {self.device_state.name}: {data.peer_remote_address}")
         else:
             event = self.state.events.get(self.device.name, data.peer_remote_address, BGPEvent)
-            if event and event.operational_state != "established":
+            if event and event.bgpos != "established":
                 self._bgp_external_reset(data)
                 _logger.debug(f"BGP session up for {self.device_state.name}: {data.peer_remote_address}")
 
@@ -364,7 +364,7 @@ class BGPStateMonitorTask(Task):
     def _bgp_oper_down(self, data: BaseBGPRow):
         event = self.state.events.get_or_create_event(self.device.name, data.peer_remote_address, BGPEvent)
 
-        if event.operational_state == "down":
+        if event.bgpos == "down":
             return
 
         copied_data = replace(data, peer_state="down")
@@ -382,7 +382,7 @@ class BGPStateMonitorTask(Task):
     def _update_bgp_event(self, event: BGPEvent, data: BaseBGPRow, last_event: str) -> BGPEvent:
         """Updates a given BGP event with the given BGP data"""
 
-        event.operational_state = data.peer_state
+        event.bgpos = data.peer_state
         event.admin_status = data.peer_admin_status
         event.remote_addr = data.peer_remote_address
         event.remote_as = data.peer_remote_as

--- a/tests/tasks/test_bgpstatemonitortask.py
+++ b/tests/tasks/test_bgpstatemonitortask.py
@@ -51,7 +51,7 @@ class TestBGPStateMonitorTask:
         # check that the correct event has been created
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
-        assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
+        assert event.bgpas in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
         assert event.bgpos == BGPOperState.ESTABLISHED
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
@@ -70,7 +70,7 @@ class TestBGPStateMonitorTask:
             device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent
         )
         event.bgpos = BGPOperState.DOWN
-        event.admin_status = BGPAdminStatus.STOP
+        event.bgpas = BGPAdminStatus.STOP
         event.remote_addr = PEER_ADDRESS
         event.remote_as = DEFAULT_REMOTE_AS
         event.peer_uptime = 0
@@ -84,7 +84,7 @@ class TestBGPStateMonitorTask:
         # check that the correct event has been created
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
-        assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
+        assert event.bgpas in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
         assert event.bgpos == BGPOperState.ESTABLISHED
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
@@ -111,7 +111,7 @@ class TestBGPStateMonitorTask:
         # check that the correct event has been created
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
-        assert event.admin_status in [BGPAdminStatus.HALTED, BGPAdminStatus.STOP]
+        assert event.bgpas in [BGPAdminStatus.HALTED, BGPAdminStatus.STOP]
         assert event.bgpos == BGPOperState.DOWN
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
@@ -138,7 +138,7 @@ class TestBGPStateMonitorTask:
             device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent
         )
         event.bgpos = BGPOperState.DOWN
-        event.admin_status = BGPAdminStatus.STOP
+        event.bgpas = BGPAdminStatus.STOP
         event.remote_addr = PEER_ADDRESS
         event.remote_as = DEFAULT_REMOTE_AS
         event.peer_uptime = 0
@@ -151,7 +151,7 @@ class TestBGPStateMonitorTask:
         # check that the correct event has been created
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
-        assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
+        assert event.bgpas in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
         assert event.bgpos == BGPOperState.IDLE
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
@@ -177,7 +177,7 @@ class TestBGPStateMonitorTask:
         # check that the correct event has been created
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
-        assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
+        assert event.bgpas in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
         assert event.bgpos == BGPOperState.DOWN
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS

--- a/tests/tasks/test_bgpstatemonitortask.py
+++ b/tests/tasks/test_bgpstatemonitortask.py
@@ -133,6 +133,17 @@ class TestBGPStateMonitorTask:
                 oper_state=BGPOperState.IDLE,
             )
         }
+        # create admin down event
+        event = task.state.events.get_or_create_event(
+            device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent
+        )
+        event.operational_state = BGPOperState.DOWN
+        event.admin_status = BGPAdminStatus.STOP
+        event.remote_address = PEER_ADDRESS
+        event.remote_as = DEFAULT_REMOTE_AS
+        event.peer_uptime = 0
+        task.state.events.commit(event=event)
+
         await task.run()
         # check if state has been updated to reflect state defined in .snmprec
         assert task.device_state.bgp_peers[PEER_ADDRESS].admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]

--- a/tests/tasks/test_bgpstatemonitortask.py
+++ b/tests/tasks/test_bgpstatemonitortask.py
@@ -52,7 +52,7 @@ class TestBGPStateMonitorTask:
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
         assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
-        assert event.operational_state == BGPOperState.ESTABLISHED
+        assert event.bgpos == BGPOperState.ESTABLISHED
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == DEFAULT_UPTIME
@@ -69,7 +69,7 @@ class TestBGPStateMonitorTask:
         event = task.state.events.get_or_create_event(
             device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent
         )
-        event.operational_state = BGPOperState.DOWN
+        event.bgpos = BGPOperState.DOWN
         event.admin_status = BGPAdminStatus.STOP
         event.remote_addr = PEER_ADDRESS
         event.remote_as = DEFAULT_REMOTE_AS
@@ -85,7 +85,7 @@ class TestBGPStateMonitorTask:
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
         assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
-        assert event.operational_state == BGPOperState.ESTABLISHED
+        assert event.bgpos == BGPOperState.ESTABLISHED
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == DEFAULT_UPTIME
@@ -112,7 +112,7 @@ class TestBGPStateMonitorTask:
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
         assert event.admin_status in [BGPAdminStatus.HALTED, BGPAdminStatus.STOP]
-        assert event.operational_state == BGPOperState.DOWN
+        assert event.bgpos == BGPOperState.DOWN
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == 0
@@ -137,7 +137,7 @@ class TestBGPStateMonitorTask:
         event = task.state.events.get_or_create_event(
             device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent
         )
-        event.operational_state = BGPOperState.DOWN
+        event.bgpos = BGPOperState.DOWN
         event.admin_status = BGPAdminStatus.STOP
         event.remote_addr = PEER_ADDRESS
         event.remote_as = DEFAULT_REMOTE_AS
@@ -152,7 +152,7 @@ class TestBGPStateMonitorTask:
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
         assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
-        assert event.operational_state == BGPOperState.IDLE
+        assert event.bgpos == BGPOperState.IDLE
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == 0
@@ -178,7 +178,7 @@ class TestBGPStateMonitorTask:
         event = task.state.events.get(device_name=task.device.name, subindex=PEER_ADDRESS, event_class=BGPEvent)
         assert event
         assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
-        assert event.operational_state == BGPOperState.DOWN
+        assert event.bgpos == BGPOperState.DOWN
         assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == 1000000

--- a/tests/tasks/test_bgpstatemonitortask.py
+++ b/tests/tasks/test_bgpstatemonitortask.py
@@ -53,7 +53,7 @@ class TestBGPStateMonitorTask:
         assert event
         assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
         assert event.operational_state == BGPOperState.ESTABLISHED
-        assert event.remote_address == PEER_ADDRESS
+        assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == DEFAULT_UPTIME
 
@@ -71,7 +71,7 @@ class TestBGPStateMonitorTask:
         )
         event.operational_state = BGPOperState.DOWN
         event.admin_status = BGPAdminStatus.STOP
-        event.remote_address = PEER_ADDRESS
+        event.remote_addr = PEER_ADDRESS
         event.remote_as = DEFAULT_REMOTE_AS
         event.peer_uptime = 0
         task.state.events.commit(event=event)
@@ -86,7 +86,7 @@ class TestBGPStateMonitorTask:
         assert event
         assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
         assert event.operational_state == BGPOperState.ESTABLISHED
-        assert event.remote_address == PEER_ADDRESS
+        assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == DEFAULT_UPTIME
 
@@ -113,7 +113,7 @@ class TestBGPStateMonitorTask:
         assert event
         assert event.admin_status in [BGPAdminStatus.HALTED, BGPAdminStatus.STOP]
         assert event.operational_state == BGPOperState.DOWN
-        assert event.remote_address == PEER_ADDRESS
+        assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == 0
 
@@ -139,7 +139,7 @@ class TestBGPStateMonitorTask:
         )
         event.operational_state = BGPOperState.DOWN
         event.admin_status = BGPAdminStatus.STOP
-        event.remote_address = PEER_ADDRESS
+        event.remote_addr = PEER_ADDRESS
         event.remote_as = DEFAULT_REMOTE_AS
         event.peer_uptime = 0
         task.state.events.commit(event=event)
@@ -153,7 +153,7 @@ class TestBGPStateMonitorTask:
         assert event
         assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
         assert event.operational_state == BGPOperState.IDLE
-        assert event.remote_address == PEER_ADDRESS
+        assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == 0
 
@@ -179,7 +179,7 @@ class TestBGPStateMonitorTask:
         assert event
         assert event.admin_status in [BGPAdminStatus.RUNNING, BGPAdminStatus.START]
         assert event.operational_state == BGPOperState.DOWN
-        assert event.remote_address == PEER_ADDRESS
+        assert event.remote_addr == PEER_ADDRESS
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == 1000000
 


### PR DESCRIPTION
I used this as an opportunity to also fix #171, which made the rest of the task much easier.

While I was working on that an comparing between Zino1 and my code I realized that I forgot the part that admin up will only update existing event, not create new events. That is also added here. 

This difference between how BGP events look in Zino1 and Zino2 was so nicely pointed out to me by @runborg.