### PR TITLE
Fix crashbug for OID responses

### DIFF
--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -458,7 +458,7 @@ def _mib_value_to_python(value: SupportedTypes) -> Union[str, int, OID]:
             value = value.prettyPrint()
         else:
             value = str(value)
-    elif isinstance(value, ObjectIdentity):
+    elif isinstance(value, (ObjectIdentity, univ.ObjectIdentifier)):
         value = OID(str(value))
     else:
         raise ValueError(f"Could not convert unknown type {type(value)}")


### PR DESCRIPTION
There appears to be several ways that an OID value may be represented by PySNMP.  `ObjectIdentity` was supported by the value converter, but `ObjectIdentifier` would make it raise an exception.

This was triggered by the BGP task running on a device that isn't a router and doesn't support any of the BGP MIB implementations it's looking for.  It gets some out-of-table response on a GET-NEXT operation where the value is formatted as `ObjectIdentifier`, which was enough for the task to crash the entire collection job.