### PR TITLE
Remove duplicate `DeviceState.boot_time` attribute

### DIFF
--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -105,7 +105,6 @@ class DeviceState(BaseModel):
     name: str
     addresses: set[IPAddress] = set()
     enterprise_id: Optional[int] = None
-    boot_time: Optional[int] = None
     ports: Dict[int, Port] = {}
     alarms: Optional[Dict[AlarmType, int]] = None
     boot_time: Optional[datetime.datetime] = None


### PR DESCRIPTION
This was discovered in a code-review a while back.  This removes the incorrect duplicate from `DeviceState`. The latter definition is correct, and would override the first, thanks to how Python works, so this doesn't change anything, it just cleans up.