### PR TITLE
Add initial trap receiver functionality to Zino

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "tox<4" tox-gh-actions coverage
+          sudo apt-get install -y --no-install-recommends snmp
 
       - name: Test with tox
         run: tox

--- a/src/zino/trapd.py
+++ b/src/zino/trapd.py
@@ -1,0 +1,48 @@
+"""SNMP trap 'daemon' for Zino 2"""
+import asyncio
+import logging
+
+from pysnmp.carrier.asyncio.dgram import udp
+from pysnmp.entity import config, engine
+from pysnmp.entity.rfc3413 import ntfrcv
+
+_logger = logging.getLogger(__name__)
+
+
+class TrapReceiver:
+    """Zino Adapter for SNMP trap reception using PySNMP"""
+
+    def __init__(self, address: str = "0.0.0.0", port: int = 162, loop=None):
+        self.transport = None
+        self.address = address
+        self.port = port
+        self.loop = loop if loop else asyncio.get_event_loop()
+        self.snmp_engine = engine.SnmpEngine()
+        self._communities = set()
+
+    async def open(self):
+        self.transport = udp.UdpTransport(loop=self.loop).openServerMode((self.address, self.port))
+        # This attribute needs to be awaited to ensure the socket is really opened,
+        # unsure of why PySNMP doesn't do this, or how else it's supposed to be achieved
+        await self.transport._lport
+        _logger.info("Listening for incoming SNMP traps on %r", (self.address, self.port))
+        config.addTransport(self.snmp_engine, udp.domainName + (1,), self.transport)
+
+        ntfrcv.NotificationReceiver(self.snmp_engine, self.trap_received)
+        self.snmp_engine.transportDispatcher.jobStarted(1)  # this job would never finish
+
+    def add_community(self, community: str):
+        """Adds a new community string that will be accepted on incoming packets"""
+        if community in self._communities:
+            return
+        self._communities.add(community)
+        config.addV1System(self.snmp_engine, str(len(self._communities)), community)
+
+    def trap_received(self, snmp_engine, state_reference, context_engine_id, context_name, var_binds, callback_context):
+        _logger.info(
+            'Trap from ContextEngineId "%s", ContextName "%s"',
+            context_engine_id.prettyPrint(),
+            context_name.prettyPrint(),
+        )
+        for name, val in var_binds:
+            _logger.info("%s = %s", name.prettyPrint(), val.prettyPrint())

--- a/src/zino/trapd.py
+++ b/src/zino/trapd.py
@@ -19,7 +19,7 @@ class TrapReceiver:
     """
 
     def __init__(self, address: str = "0.0.0.0", port: int = 162, loop=None):
-        self.transport = None
+        self.transport: udp.UdpTransport = None
         self.address = address
         self.port = port
         self.loop = loop if loop else asyncio.get_event_loop()
@@ -37,6 +37,11 @@ class TrapReceiver:
 
         ntfrcv.NotificationReceiver(self.snmp_engine, self.trap_received)
         self.snmp_engine.transportDispatcher.jobStarted(1)  # this job would never finish
+
+    def close(self):
+        """Closes the running SNMP engine and its associated ports"""
+        self.snmp_engine.transportDispatcher.closeDispatcher()
+        self.transport.closeTransport()
 
     def add_community(self, community: str):
         """Adds a new community string that will be accepted on incoming packets"""

--- a/src/zino/trapd.py
+++ b/src/zino/trapd.py
@@ -10,7 +10,13 @@ _logger = logging.getLogger(__name__)
 
 
 class TrapReceiver:
-    """Zino Adapter for SNMP trap reception using PySNMP"""
+    """Zino Adapter for SNMP trap reception using PySNMP.
+
+    A major difference to Zino 1 is that this receiver must explicitly be configured with SNMP community strings that
+    will be accepted.  Zino 1 accepts traps with any community string, as long as their origin is any one of the
+    devices configured in `polldevs.cf`.  However, PySNMP places heavy emphasis on being standards compliant,
+    and will not even pass on traps to our callbacks unless they match the authorization config for the SNMP engine.
+    """
 
     def __init__(self, address: str = "0.0.0.0", port: int = 162, loop=None):
         self.transport = None
@@ -21,6 +27,7 @@ class TrapReceiver:
         self._communities = set()
 
     async def open(self):
+        """Opens the UDP transport socket and starts receiving traps"""
         self.transport = udp.UdpTransport(loop=self.loop).openServerMode((self.address, self.port))
         # This attribute needs to be awaited to ensure the socket is really opened,
         # unsure of why PySNMP doesn't do this, or how else it's supposed to be achieved
@@ -39,6 +46,7 @@ class TrapReceiver:
         config.addV1System(self.snmp_engine, str(len(self._communities)), community)
 
     def trap_received(self, snmp_engine, state_reference, context_engine_id, context_name, var_binds, callback_context):
+        """Callback function that receives all matched trap messages on PySNMP's incoming transport socket"""
         _logger.info(
             'Trap from ContextEngineId "%s", ContextName "%s"',
             context_engine_id.prettyPrint(),

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -7,6 +7,7 @@ import logging
 import os
 import pwd
 import sys
+from asyncio import AbstractEventLoop
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -35,8 +36,9 @@ def main():
     init_event_loop(args)
 
 
-def init_event_loop(args: argparse.Namespace):
-    loop = asyncio.get_event_loop()
+def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] = None):
+    if not loop:
+        loop = asyncio.get_event_loop()
 
     if args.trap_port:
         trap_receiver = TrapReceiver(port=args.trap_port, loop=loop)

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -50,9 +50,8 @@ def init_event_loop(args: argparse.Namespace):
                 args.trap_port,
             )
             sys.exit(errno.EACCES)
-        else:
-            if args.user:
-                switch_to_user(args.user)
+    if args.user:
+        switch_to_user(args.user)
 
     scheduler = get_scheduler()
     scheduler.start()

--- a/tests/trapd_test.py
+++ b/tests/trapd_test.py
@@ -1,0 +1,36 @@
+import asyncio
+import logging
+import shutil
+
+import pytest
+
+from zino.trapd import TrapReceiver
+
+
+class TestTrapReceiver:
+    def test_add_community_should_accept_same_community_multiple_times(self):
+        receiver = TrapReceiver()
+        receiver.add_community("public")
+        receiver.add_community("public")
+        assert len(receiver._communities) == 1
+
+    @pytest.mark.skipif(not shutil.which("snmptrap"), reason="Cannot find snmptrap command line program")
+    @pytest.mark.asyncio
+    async def test_should_log_incoming_trap(self, event_loop, caplog):
+        receiver = TrapReceiver(address="127.0.0.1", port=1162, loop=event_loop)
+        receiver.add_community("public")
+        try:
+            await receiver.open()
+
+            cold_start = ".1.3.6.1.6.3.1.1.5.1"
+            sysname_0 = ".1.3.6.1.2.1.1.5.0"
+            with caplog.at_level(logging.DEBUG):
+                proc = await asyncio.create_subprocess_shell(
+                    f"snmptrap -v 2c -c public localhost:1162 '' {cold_start} {sysname_0} s 'MockDevice'"
+                )
+                await proc.communicate()
+                assert proc.returncode == 0, "snmptrap command exited with error"
+
+                assert "1.3.6.1.2.1.1.5.0 = MockDevice" in caplog.text
+        finally:
+            receiver.close()

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -23,7 +23,15 @@ def test_zino_should_not_crash_right_away(polldevs_conf_with_no_routers):
     """This tests that the main function runs Zino for at least 2 seconds"""
     seconds_to_run_for = 2
     subprocess.check_call(
-        ["zino", "--stop-in", str(seconds_to_run_for), "--polldevs", str(polldevs_conf_with_no_routers)]
+        [
+            "zino",
+            "--stop-in",
+            str(seconds_to_run_for),
+            "--polldevs",
+            str(polldevs_conf_with_no_routers),
+            "--trap-port",
+            "1162",
+        ]
     )
 
 

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -8,6 +8,8 @@ from argparse import Namespace
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
+import pytest
+
 from zino import zino
 from zino.scheduler import get_scheduler
 from zino.time import now
@@ -43,6 +45,23 @@ def test_zino_should_not_crash_right_away(polldevs_conf_with_no_routers):
 def test_zino_argparser_works(polldevs_conf):
     parser = zino.parse_args(["--polldevs", str(polldevs_conf)])
     assert isinstance(parser, Namespace)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="cannot test while being root")
+def test_when_unprivileged_user_asks_for_privileged_port_zino_should_exit_with_error(polldevs_conf_with_no_routers):
+    seconds_to_run_for = 5
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(
+            [
+                "zino",
+                "--stop-in",
+                str(seconds_to_run_for),
+                "--polldevs",
+                str(polldevs_conf_with_no_routers),
+                "--trap-port",
+                "162",
+            ]
+        )
 
 
 class TestZinoRescheduleDumpStateOnCommit:

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -64,6 +64,26 @@ def test_when_unprivileged_user_asks_for_privileged_port_zino_should_exit_with_e
         )
 
 
+@pytest.mark.asyncio
+@patch("zino.zino.switch_to_user")
+def test_when_args_specify_user_zino_init_event_loop_should_attempt_to_switch_users(switch_to_user, event_loop):
+    """Detect attempt to user switching by patching in a mock exception.  This is to avoid setting up the full Zino
+    daemon and mucking up the event loop and state, by ensuring we exit as soon as switch_to_user is called.
+    """
+
+    class MockError(Exception):
+        pass
+
+    zino.switch_to_user.side_effect = MockError()
+    with pytest.raises(MockError):
+        try:
+            zino.init_event_loop(args=Mock(trap_port=0, user="nobody"), loop=event_loop)
+        except MockError:
+            raise
+        except Exception:
+            pass
+
+
 class TestZinoRescheduleDumpStateOnCommit:
     def test_when_more_than_10_seconds_remains_until_next_dump_it_should_reschedule(self):
         scheduler = get_scheduler()


### PR DESCRIPTION
This adds a simple framework for receiving and logging incoming traps, nothing more.

It also adds command line options to enable selection of trap port (optionally switching off traps entirely), and to drop privileges to a specific user if running as root.
