### PR TITLE
Add pytest-timeout to tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     pytest
     pytest-asyncio<0.22.0
     pytest-cov
+    pytest-timeout
     snmpsim
     pyasn1<0.5.0
     retry


### PR DESCRIPTION
This was probably forgotten in #164. Because currently when running those tests I get the warning

```
tests/api/legacy_test.py:105
  /home/johanna/zino/tests/api/legacy_test.py:105: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?
```