### PR TITLE
Do not include event ids of closed events in CASEIDS command

### DIFF
--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -3,6 +3,7 @@
 The Legacy API from the Tcl-based Zino 1.0 is a 'vaguely SMTP-esque line-based text protocol'.  This module
 implements this protocol using asyncio semantics.
 """
+
 import asyncio
 import inspect
 import logging
@@ -233,8 +234,10 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
     @requires_authentication
     async def do_caseids(self):
         self._respond(304, "list of active cases follows, terminated with '.'")
-        for event_id in sorted(self._state.events.events):
-            self._respond_raw(str(event_id))
+        events = self._state.events.events
+        for event_id, event in sorted(events.items()):
+            if event.state != EventState.CLOSED:
+                self._respond_raw(str(event_id))
         self._respond_raw(".")
 
     def _translate_case_id_to_event(responder: callable):  # noqa

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -372,6 +372,21 @@ class TestZino1ServerProtocolCaseidsCommand:
         assert f"{event1.id}\r\n".encode() in output
         assert f"{event2.id}\r\n".encode() in output
 
+    @pytest.mark.asyncio
+    async def test_should_output_a_list_of_only_ids_of_non_closed_events(self, authenticated_protocol):
+        state = authenticated_protocol._state
+        event1 = state.events.create_event("foo", None, ReachabilityEvent)
+        state.events.commit(event1)
+        event2 = state.events.create_event("bar", None, ReachabilityEvent)
+        event2.state = EventState.CLOSED
+        state.events.commit(event2)
+
+        await authenticated_protocol.message_received("CASEIDS")
+
+        output = authenticated_protocol.transport.data_buffer.getvalue()
+        assert f"{event1.id}\r\n".encode() in output
+        assert f"{event2.id}\r\n".encode() not in output
+
 
 class TestZino1ServerProtocolVersionCommand:
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #187.

Needs to be first checked if this is the same behavior as with Zino 1.0.