### PR TITLE
 Implement a generic trap dispatcher framework in `zino.trapd.TrapReceiver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,26 @@ like so:
 ```shell
 pre-commit install
 ```
+
+
+### Test trap examples
+
+Running Zino during development might look like this (listening for traps on
+the non-privileged port 1162):
+
+```shell
+zino --trap-port 1162
+```
+
+To send an example trap (`BGP4-MIB::bgpBackwardTransition`, which Zino ignores
+by default), you can use a command like:
+
+```shell
+snmptrap -v2c -c public \
+    127.0.0.1:1162 \
+    '' \
+    BGP4-MIB::bgpBackwardTransition \
+    BGP4-MIB::bgpPeerRemoteAddr a 192.168.42.42 \
+    BGP4-MIB::bgpPeerLastError x 4242 \
+    BGP4-MIB::bgpPeerState i 2
+```

--- a/README.md
+++ b/README.md
@@ -136,15 +136,18 @@ at this point you can test that the `zino` command is available to run:
 
 ```console
 $ zino --help
-usage: zino [-h] [--polldevs PATH] [--debug] [--stop-in N]
+usage: zino [-h] [--polldevs PATH] [--debug] [--stop-in N] [--trap-port PORT] [--user USER]
 
 Zino is not OpenView
 
 options:
-  -h, --help       show this help message and exit
-  --polldevs PATH  Path to polldevs.cf
-  --debug          Set global log level to DEBUG. Very chatty!
-  --stop-in N      Stop zino after N seconds.
+  -h, --help        show this help message and exit
+  --polldevs PATH   Path to polldevs.cf
+  --debug           Set global log level to DEBUG. Very chatty!
+  --stop-in N       Stop zino after N seconds.
+  --trap-port PORT  Which UDP port to listen for traps on. Default value is 162. Any value below 1024 requires root privileges. Setting to 0
+                    disables SNMP trap monitoring.
+  --user USER       Switch to this user immediately after binding to privileged ports
 ```
 
 Even if the Python virtual environment hasn't been activated in your shell, you
@@ -153,6 +156,19 @@ can still run Zino directly from inside this environment, like so:
 ```shell
 ./zino-env/bin/zino --help
 ```
+
+By default, Zino will listen for incoming SNMP traps on UDP port `162`.  This
+port is privileged (less than 1024), however, which means that Zino *needs to
+be started as `root`* if you want to receive traps.  In order to avoid running
+continuously with `root` privileges, the `--user` option can be used to tell
+Zino to switch to running as a less privileged user as soon as port `162` has
+been acquired.
+
+Alternately, you can tell Zino to listen for traps on a non-privileged port,
+e.g. by adding `--trap-port 1162` to the command line arguments, but this only
+works if you can configure your SNMP agents to send traps to this non-standard
+port.  In any case, you can also tell Zino to skip listening for traps by
+specifying `--trap-port 0`.
 
 ### Configuring Zino
 

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -40,6 +40,7 @@ def _get_engine():
         _local.snmp_engine = SnmpEngine()
         mib_builder = _local.snmp_engine.getMibBuilder()
         mib_builder.addMibSources(builder.DirMibSource(MIB_SOURCE_DIR))
+        mib_builder.loadModules()
     return _local.snmp_engine
 
 

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -37,11 +37,17 @@ MIB_SOURCE_DIR = os.path.join(os.path.dirname(__file__), "mibdumps")
 
 def _get_engine():
     if not getattr(_local, "snmp_engine", None):
-        _local.snmp_engine = SnmpEngine()
-        mib_builder = _local.snmp_engine.getMibBuilder()
-        mib_builder.addMibSources(builder.DirMibSource(MIB_SOURCE_DIR))
-        mib_builder.loadModules()
+        _local.snmp_engine = get_new_snmp_engine()
     return _local.snmp_engine
+
+
+def get_new_snmp_engine() -> SnmpEngine:
+    """Returns a new SnmpEngine object with Zino's directory of MIB modules loaded"""
+    snmp_engine = SnmpEngine()
+    mib_builder = snmp_engine.getMibBuilder()
+    mib_builder.addMibSources(builder.DirMibSource(MIB_SOURCE_DIR))
+    mib_builder.loadModules()
+    return snmp_engine
 
 
 @dataclass

--- a/src/zino/trapd.py
+++ b/src/zino/trapd.py
@@ -174,6 +174,12 @@ class TrapReceiver:
             _logger.error("Trap from %s did not contain a snmpTrapOID value, ignoring", router.name)
             return
 
+        if "sysUpTime" not in trap.variables:
+            _logger.error("Trap from %s did not contain a sysUpTime value, ignoring", router.name)
+            return
+
+        # TODO do some time calculations, but ask Håvard what the deal is with RestartTime vs. BootTime
+
         try:
             trap.mib, trap.name, _ = self._resolve_object_name(trap.variables["snmpTrapOID"].raw_value)
         except Exception as error:  # noqa

--- a/src/zino/trapd.py
+++ b/src/zino/trapd.py
@@ -12,12 +12,7 @@ from pysnmp.proto.rfc1902 import ObjectName
 from pysnmp.smi import view
 
 from zino.oid import OID
-from zino.snmp import (
-    MibNotFoundError,
-    PysnmpMibNotFoundError,
-    _mib_value_to_python,
-    get_new_snmp_engine,
-)
+from zino.snmp import _mib_value_to_python, get_new_snmp_engine
 from zino.state import ZinoState
 from zino.statemodels import DeviceState, IPAddress
 
@@ -175,11 +170,7 @@ class TrapReceiver:
 
         # TODO do some time calculations, but ask Håvard what the deal is with RestartTime vs. BootTime
 
-        try:
-            trap.mib, trap.name, _ = self._resolve_object_name(trap.variables["snmpTrapOID"].raw_value)
-        except Exception as error:  # noqa
-            _logger.error("Could not resolve trap %s to symbolic name (%s)", raw_value.prettyPrint(), error)
-
+        trap.mib, trap.name, _ = self._resolve_object_name(trap.variables["snmpTrapOID"].raw_value)
         self.dispatch_trap(trap)
 
     @staticmethod
@@ -217,15 +208,12 @@ class TrapReceiver:
 
     def _resolve_object_name(self, object_name: ObjectName) -> tuple[str, str, OID]:
         """Raises MibNotFoundError if oid in `object_name` can not be found"""
-        try:
-            engine = self.snmp_engine
-            controller = engine.getUserContext("mibViewController")
-            if not controller:
-                controller = view.MibViewController(engine.getMibBuilder())
-            mib, label, instance = controller.getNodeLocation(object_name)
-            return mib, label, OID(instance) if instance else None
-        except PysnmpMibNotFoundError as error:
-            raise MibNotFoundError(error)
+        engine = self.snmp_engine
+        controller = engine.getUserContext("mibViewController")
+        if not controller:
+            controller = view.MibViewController(engine.getMibBuilder())
+        mib, label, instance = controller.getNodeLocation(object_name)
+        return mib, label, OID(instance) if instance else None
 
 
 def ignore_trap(trap: TrapMessage, loop: Optional[asyncio.AbstractEventLoop] = None) -> Optional[bool]:

--- a/src/zino/trapd.py
+++ b/src/zino/trapd.py
@@ -15,8 +15,8 @@ from zino.oid import OID
 from zino.snmp import (
     MibNotFoundError,
     PysnmpMibNotFoundError,
-    _get_engine,
     _mib_value_to_python,
+    get_new_snmp_engine,
 )
 from zino.state import ZinoState
 from zino.statemodels import DeviceState, IPAddress
@@ -101,7 +101,7 @@ class TrapReceiver:
         self.port = port
         self.loop = loop if loop else asyncio.get_event_loop()
         self.state = state or ZinoState()
-        self.snmp_engine = _get_engine()
+        self.snmp_engine = get_new_snmp_engine()
         self._communities = set()
         self._observers: dict[TrapType, List[TrapObserver]] = {}
 

--- a/src/zino/trapd.py
+++ b/src/zino/trapd.py
@@ -5,9 +5,10 @@ from ipaddress import ip_address
 from typing import Optional
 
 from pysnmp.carrier.asyncio.dgram import udp
-from pysnmp.entity import config, engine
+from pysnmp.entity import config
 from pysnmp.entity.rfc3413 import ntfrcv
 
+from zino.snmp import _get_engine
 from zino.state import ZinoState
 from zino.statemodels import DeviceState, IPAddress
 
@@ -29,7 +30,7 @@ class TrapReceiver:
         self.port = port
         self.loop = loop if loop else asyncio.get_event_loop()
         self.state = state or ZinoState()
-        self.snmp_engine = engine.SnmpEngine()
+        self.snmp_engine = _get_engine()
         self._communities = set()
 
     async def open(self):

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -41,7 +41,7 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
         loop = asyncio.get_event_loop()
 
     if args.trap_port:
-        trap_receiver = TrapReceiver(port=args.trap_port, loop=loop)
+        trap_receiver = TrapReceiver(port=args.trap_port, loop=loop, state=state.state)
         trap_receiver.add_community("public")
         trap_receiver.add_community("secret")
         try:

--- a/tests/trapd_test.py
+++ b/tests/trapd_test.py
@@ -63,6 +63,25 @@ class TestTrapReceiverExternally:
             assert "ValueError" in caplog.text
             assert "mocked exception" in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_when_trap_from_ignore_list_is_received_it_should_be_ignored(self, localhost_receiver):
+        late_observer = Mock()
+        localhost_receiver.observe(late_observer, ("BGP4-MIB", "bgpBackwardTransition"))
+        bgp_backward_transition_trap = [
+            ".1.3.6.1.2.1.15.7.2",
+            ".1.3.6.1.2.1.15.3.1.7",
+            "a",
+            "192.168.42.42",
+            ".1.3.6.1.2.1.15.3.1.14",
+            "x",
+            "4242",
+            ".1.3.6.1.2.1.15.3.1.2",
+            "i",
+            "2",
+        ]
+        await send_trap_externally(*bgp_backward_transition_trap)
+        assert not late_observer.called
+
 
 @pytest.fixture
 def state_with_localhost():


### PR DESCRIPTION
This PR aims to create a generic framework for dispatching incoming traps in the `TrapReceiver` class.  Features that are planned:

- [x] Do the "generic" work of preprocessing a trap: 
  - [x] Map it to a known poll device, otherwise drop it.  
  - [x] Translate names and data on incoming varbinds.
  - [x] Drop the trap if it is missing required fields (like trap-OID or sysUpTime, see `trap.tcl` in Zino 1 for details)
- [x] Provide a method to register functions that are interested in handling specific traps
- [x] Dispatch traps to registered trap handlers
- [x] Log the contents of traps that weren't dispatched to any handlers.
- [x] Ignore same set of traps as ignored by Zino 1