### PR TITLE
Fix workflow syntax and only publish test results on Uninett repo

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -10,7 +10,8 @@ jobs:
   publish-test-results:
     name: "Publish test results"
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion != 'skipped'
+    if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
+
 
     steps:
       - name: Download and Extract Artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
         run: tox
 
       - name: "Upload coverage to Codecov"
-        if: "github.repository_owner == 'Uninett'"
+        if: github.repository_owner == 'Uninett'
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
My editor Github workflow extension complained about the quotes, which is why I removed them.

And I always get an error for the "Publish test results" workflow, when pushing to the master branch of my fork, which is why I'm restricting this part to workflows on the Uninett repo.