### PR TITLE
Add a task that automatically deletes closed events after a certain time

### DIFF
--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -57,8 +57,9 @@ class Events(BaseModel):
         """
         new_index: Dict[EventIndex, Event] = {}
         for event in self.events.values():
-            key = EventIndex(event.router, event.subindex, type(event))
-            new_index[key] = event
+            if event.state != EventState.CLOSED:
+                key = EventIndex(event.router, event.subindex, type(event))
+                new_index[key] = event
         self._events_by_index = new_index
 
     def get_or_create_event(

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 from typing import Dict, NamedTuple, Optional, Protocol, Type, Union
 
 from pydantic.main import BaseModel
@@ -16,6 +17,8 @@ from zino.statemodels import (
 from zino.time import now
 
 _log = logging.getLogger(__name__)
+
+EVENT_EXPIRY = timedelta(hours=8)
 
 
 class EventIndex(NamedTuple):
@@ -143,6 +146,28 @@ class Events(BaseModel):
             self._events_by_index[index] = event
 
         self._call_observers_for(new_event=event, old_event=old_event)
+
+    def _delete(self, event: Event):
+        """Removes a closed event from the events dict and notifies all observers"""
+        if event.state != EventState.CLOSED:
+            return
+
+        index = EventIndex(event.router, event.subindex, type(event))
+        if self._events_by_index.get(index) and event.id == self._events_by_index[index].id:
+            _log.info("Closed event %s was still in event index, removing it now", event.id)
+            del self._events_by_index[index]
+        try:
+            del self.events[event.id]
+        except KeyError:
+            pass
+        self._call_observers_for(new_event=event)
+
+    def delete_expired_events(self):
+        """Deletes all events that have been closed for a certain time"""
+        event_list = list(self.events.values())
+        for event in event_list:
+            if event.state == EventState.CLOSED and now() > (event.updated + EVENT_EXPIRY):
+                self._delete(event)
 
     def add_event_observer(self, observer: EventObserver):
         """Adds an observer function that will be called any time an event is committed"""

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -46,6 +46,13 @@ def init_event_loop(args: argparse.Namespace):
     )
     state.state.events.add_event_observer(reschedule_dump_state_on_commit)
 
+    # Schedule removing events that have been closed for a certain time
+    scheduler.add_job(
+        func=state.state.events.delete_expired_events,
+        trigger="interval",
+        minutes=30,
+    )
+
     loop = asyncio.get_event_loop()
     server = ZinoServer(loop=loop, state=state.state)
     server.serve()

--- a/tests/api/notify_test.py
+++ b/tests/api/notify_test.py
@@ -73,37 +73,49 @@ class TestZino1NotificationProtocol:
 class TestZino1NotificationProtocolBuildNotifications:
     def test_should_make_notifications_for_regular_changed_attrs(self, fake_event):
         protocol = Zino1NotificationProtocol()
+        protocol._state.events.events[fake_event.id] = fake_event
         event_copy = fake_event.model_copy(deep=True)
         event_copy.updated = now() + timedelta(seconds=5)
 
-        notifications = list(protocol.build_notifications(new_event=event_copy, old_event=fake_event))
+        notifications = list(
+            protocol.build_notifications(state=protocol._state, new_event=event_copy, old_event=fake_event)
+        )
         assert notifications == [Notification(event_id=42, change_type="attr", value="updated")]
 
     def test_should_make_notifications_for_log_changes(self, fake_event):
         protocol = Zino1NotificationProtocol()
+        protocol._state.events.events[fake_event.id] = fake_event
         event_copy = fake_event.model_copy(deep=True)
         event_copy.add_log("foo")
 
-        notifications = list(protocol.build_notifications(new_event=event_copy, old_event=fake_event))
+        notifications = list(
+            protocol.build_notifications(state=protocol._state, new_event=event_copy, old_event=fake_event)
+        )
         assert Notification(event_id=42, change_type="log", value=1) in notifications
 
     def test_should_make_notifications_for_history_changes(self, fake_event):
         protocol = Zino1NotificationProtocol()
+        protocol._state.events.events[fake_event.id] = fake_event
         event_copy = fake_event.model_copy(deep=True)
         event_copy.add_history("foo")
 
-        notifications = list(protocol.build_notifications(new_event=event_copy, old_event=fake_event))
+        notifications = list(
+            protocol.build_notifications(state=protocol._state, new_event=event_copy, old_event=fake_event)
+        )
         assert Notification(event_id=42, change_type="history", value=1) in notifications
 
     def test_should_make_notifications_for_state_changes(self, fake_event):
         protocol = Zino1NotificationProtocol()
+        protocol._state.events.events[fake_event.id] = fake_event
         event_copy = fake_event.model_copy(deep=True)
         event_copy.state = EventState.IGNORED
 
         old, new = fake_event.state.value, event_copy.state.value
         expected = f"{old} {new}"
 
-        notifications = list(protocol.build_notifications(new_event=event_copy, old_event=fake_event))
+        notifications = list(
+            protocol.build_notifications(state=protocol._state, new_event=event_copy, old_event=fake_event)
+        )
         assert Notification(event_id=42, change_type="state", value=expected) in notifications
 
 

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -125,6 +125,30 @@ class TestEvents:
         assert (now() - timedelta(minutes=1)) < event.updated < (now())
         assert event.updated != previous_updated
 
+    def test_delete_closed_events_should_delete_old_closed_event(self):
+        events = Events()
+        event = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        event.set_state(EventState.CLOSED)
+        events.commit(event)
+        event.updated = now() - timedelta(days=1)
+        events.delete_expired_events()
+        assert event.id not in events.events.keys()
+
+    def test_delete_closed_events_should_not_delete_just_closed_event(self):
+        events = Events()
+        event = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        event.set_state(EventState.CLOSED)
+        events.commit(event)
+        events.delete_expired_events()
+        assert event.id in events.events.keys()
+
+    def test_delete_closed_events_should_not_delete_open_event(self):
+        events = Events()
+        event = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        events.commit(event)
+        events.delete_expired_events()
+        assert event.id in events.events.keys()
+
     def test_when_observer_is_added_it_should_be_called_on_commit(self):
         events = Events()
         observer = Mock()
@@ -148,4 +172,18 @@ class TestEvents:
 
         events.add_event_observer(observer)
         events.commit(updated_event)
+        assert observer.called
+
+    def test_delete_should_call_observers_with_event_object(self):
+        events = Events()
+        event = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        event.set_state(EventState.CLOSED)
+        events.commit(event)
+
+        def observer(new_event: Event, old_event: Optional[Event] = None) -> None:
+            assert new_event is event
+            observer.called = True
+
+        events.add_event_observer(observer)
+        events._delete(event)
         assert observer.called


### PR DESCRIPTION
First part to fixing #182.

I modeled it pretty closely to what happens in Zino1 (as far as I understood it):
- remove an event from the index the moment it is closed
- completely delete a closed event 8 hours after it has been closed

Dumping the event before it's deleted is happening in #204.