### PR TITLE
Define subindex for PortStateEvent as ifindex

### DIFF
--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -304,7 +304,7 @@ class PortStateEvent(Event):
 
     @property
     def subindex(self) -> SubIndex:
-        return self.port
+        return self.ifindex
 
 
 class BGPEvent(Event):


### PR DESCRIPTION
Subindex for PortStateEvent was set to the wrong value for some reason. The correct index to use is ifindex, so this fixes that