### PR TITLE
Add default authentication failure message

### DIFF
--- a/src/zino/api/auth.py
+++ b/src/zino/api/auth.py
@@ -58,4 +58,5 @@ def read_users(filename: Optional[Union[Path, str]] = "secrets") -> dict[str, st
 
 
 class AuthenticationFailure(Exception):
-    pass
+    def __init__(self, message="Authentication failure"):
+        super().__init__(message)


### PR DESCRIPTION
The current API implementation unintentionally responds with an empty "500" message when a user authentication fails (i.e. the user exists, but the challenge response is incorrect).  The correct response, according to Zino 1 codebase is "Authentication failure", not an empty string.