### PR TITLE
Add towncrier to produce changelog

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -1,0 +1,19 @@
+name: Check for changelog file
+
+on: [pull_request]
+
+jobs:
+  towncrier:
+    runs-on: ubuntu-latest
+    name: Towncrier check
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install towncrier
+      run: |
+        pip install -U pip
+        pip install towncrier
+    - name: Check for changelog file
+      run: towncrier check --compare-with origin/master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: mixed-line-ending
       - id: end-of-file-fixer
+        exclude: &exclude_pattern '^changelog.d/'
       - id: debug-statements
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,9 @@ repos:
     rev: v0.1.13
     hooks:
       - id: ruff
+  - repo: https://github.com/twisted/towncrier
+    rev: 23.11.0
+    hooks:
+      - id: towncrier-check
+        files: $changelog\.d/
+        args: [--compare-with origin/master]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Zino 2 is a full rewrite of the original Tcl-based Zino state monitor.  This
 changelog only details changes from Zino 2 on and out.
 
+This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/Uninett/zino/tree/master/changelog.d/>.
+
+<!-- towncrier release notes start -->
+
 ## [2.0.0-alpha.2] - 2024-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -288,3 +288,47 @@ snmptrap -v2c -c public \
     BGP4-MIB::bgpPeerLastError x 4242 \
     BGP4-MIB::bgpPeerState i 2
 ```
+
+### Using towncrier to automatically produce the changelog
+#### Before merging a pull request
+To be able to automatically produce the changelog for a release one file for each
+pull request (also called news fragment) needs to be added to the folder
+`changelog.d/`.
+
+The name of the file consists of three parts separated by a period:
+1. The identifier: the issue number
+or the pull request number. If we don't want to add a link to the resulting changelog
+entry then a `+` followed by a unique short description.
+2. The type of the change: we use `security`, `removed`, `deprecated`, `added`,
+`changed` and `fixed`.
+3. The file suffix, e.g. `.md`, towncrier does not care which suffix a fragment has.
+
+So an example for a file name related to an issue/pull request would be `214.added.md`
+or for a file without corresponding issue `+fixed-pagination-bug.fixed.md`.
+
+This file can either be created manually with a file name as specified above and the
+changelog text as content or one can use towncrier to create such a file as following:
+
+```console
+$ towncrier create -c "Changelog content" 214.added.md
+```
+
+When opening a pull request there will be a check to make sure that a news fragment is
+added and it will fail if it is missing.
+
+#### Before a release
+To add all content from the `changelog.d/` folder to the changelog file simply run
+```console
+$ towncrier build --version {version}
+```
+This will also delete all files in `changelog.d/`.
+
+To preview what the addition to the changelog file would look like add the flag
+`--draft`. This will not delete any files or change `CHANGELOG.md`. It will only output
+the preview in the terminal.
+
+A few other helpful flags:
+- `date DATE` - set the date of the release, default is today
+- `keep` - do not delete the files in `changelog.d/`
+
+More information about [towncrier](https://towncrier.readthedocs.io).

--- a/changelog.d/218.added.md
+++ b/changelog.d/218.added.md
@@ -1,0 +1,1 @@
+Added towncrier to automatically produce changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "retry",
     "ruff",
     "snmpsim",
+    "towncrier",
     "tox<4",
     "twine",
 ]
@@ -113,3 +114,43 @@ exclude_also = [
     # Don't complain about lines excluded unless type checking
     "if TYPE_CHECKING:",
 ]
+
+
+[tool.towncrier]
+directory = "changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+title_format = "## [{version}] - {project_date}"
+issue_format = "[#{issue}](https://github.com/Uninett/zino/issues/{issue})"
+wrap = true
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true


### PR DESCRIPTION
To avoid merge conflicts on direct changes to `CHANGELOG.md` for every PR.

Also adds towncrier to pre-commit and Github Actions.
