### PR TITLE
Factor out codecov upload

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -30,7 +30,7 @@ jobs:
            done
 
       - name: "Publish test results"
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: "Test results"

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -35,6 +35,15 @@ jobs:
           check_name: "Test results"
           files: artifacts/**/*-results.xml
 
+      - name: Read PR number file
+        if: ${{ hashFiles('artifacts/pr_number/pr_number') != '' }}
+        run: |
+          pr_number=$(cat artifacts/pr_number/pr_number)
+          re='^[0-9]+$'
+          if [[ $pr_number =~ $re ]] ; then
+            echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
+          fi
+
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -43,3 +52,4 @@ jobs:
           verbose: true
           override_branch: ${{ github.event.workflow_run.head_branch}}
           override_commit: ${{ github.event.workflow_run.head_sha}}
+          override_pr: ${{ env.PR_NUMBER }}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -41,3 +41,5 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+          override_branch: ${{ github.event.workflow_run.head_branch}}
+          override_commit: ${{ github.event.workflow_run.head_sha}}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,4 +1,4 @@
-name: Publish test results
+name: Publish test and coverage results
 
 on:
   workflow_run:
@@ -8,10 +8,9 @@ on:
 
 jobs:
   publish-test-results:
-    name: "Publish test results"
+    name: "Publish test and coverage results"
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
-
+    if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
       - name: Download and Extract Artifacts
@@ -35,3 +34,10 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: "Test results"
           files: artifacts/**/*-results.xml
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: ~/.cache/pip
@@ -38,7 +38,7 @@ jobs:
 
 
       - name: "Set up Python ${{ matrix.python-version }}"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,13 +51,6 @@ jobs:
       - name: Test with tox
         run: tox
 
-      - name: "Upload coverage to Codecov"
-        if: github.repository_owner == 'Uninett'
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-
       - name: Upload test reports (${{ matrix.python-version }})
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,8 +60,8 @@ jobs:
 
       - name: Upload test reports (${{ matrix.python-version }})
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: reports
+          name: reports-${{ matrix.python-version }}
           path: |
             reports/**/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,3 +58,20 @@ jobs:
           name: reports-${{ matrix.python-version }}
           path: |
             reports/**/*
+
+  upload-pr-number:
+    name: Save PR number in artifact
+    runs-on: ubuntu-latest
+    if: ${{ github.event.number && always() }}
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+    steps:
+      - name: Make PR number file
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - name: Upload PR number file
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr/


### PR DESCRIPTION
Closes #216.

Since upgrading the codecov action to version 4 uploading coverage reports without a token (so when creating a PR from a fork) is severely rate limited, which resulted often enough in our tests seemingly failing, even though it was only the coverage upload failing. (Reference: https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov)

Workflows that are triggered by other workflows are always run within the context of the main repository, instead of within the fork (which workflows triggered by pull requests for example can be). This means that that way we can have access to the secret `CODECOV_TOKEN` and avoid the rate limitations.

Since we already upload our coverage results as artifacts in the `Upload test reports` step of the `tests` workflow, we decided to move the uploading coverage step to the same workflow where we publish the test results: `publish-test-results`. This workflow is triggered by the completion of the `tests` workflow, which means it is run within the context of the main repository. 

Moving the uploading coverage step to the `publish-test-results` worked great in the way that we have access to the `CODECOV_TOKEN`, but due to the context switch codecov could not properly tell anymore which branch, commit and pull request that coverage information belongs to. 

That is why we override the pull request, commit and branch information. 

Getting the associated pull request number is quite a bit more complicated and it involves saving that number in a file, then uploading it as an artifact, then downloading that artifact and after validation setting that as the pull request number for codecov. 

I have tested this with four different scenarios:
1. Push against main, no associated pull request number ([tests](https://github.com/johannaengland/testing/actions/runs/9268837792), [upload](https://github.com/johannaengland/testing/actions/runs/9268845086))
2. Pull request with passing tests ([tests](https://github.com/johannaengland/testing/actions/runs/9268749420), [upload](https://github.com/johannaengland/testing/actions/runs/9268760548))
3. Pull request with failing tests ([tests](https://github.com/johannaengland/testing/actions/runs/9268759054), [upload](https://github.com/johannaengland/testing/actions/runs/9268768227))
4. Pull request that overrides the variable written to the file that will be uploaded ([tests](https://github.com/johannaengland/testing/actions/runs/9268765102), [upload](https://github.com/johannaengland/testing/actions/runs/9268778645))

This also upgrades various actions used in these workflows. 
Reference for why we need to rename the artifacts after upgrading the upload artifacts action: https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/