### PR TITLE
Handle juniper devices that do not have an yellow/red alarm count

### DIFF
--- a/changelog.d/231.fixed.md
+++ b/changelog.d/231.fixed.md
@@ -1,0 +1,1 @@
+Add handling of juniper devices without red/yellow alarm count

--- a/src/zino/tasks/juniperalarmtask.py
+++ b/src/zino/tasks/juniperalarmtask.py
@@ -1,5 +1,6 @@
 import logging
 
+from zino.snmp import NoSuchNameError
 from zino.statemodels import AlarmEvent, AlarmType
 from zino.tasks.task import Task
 
@@ -15,7 +16,7 @@ class JuniperAlarmTask(Task):
 
         try:
             yellow_alarm_count, red_alarm_count = await self._get_juniper_alarms()
-        except TypeError:
+        except (TypeError, NoSuchNameError):
             return
 
         if not self.device_state.alarms:

--- a/src/zino/tasks/juniperalarmtask.py
+++ b/src/zino/tasks/juniperalarmtask.py
@@ -41,6 +41,11 @@ class JuniperAlarmTask(Task):
         if red_alarm_count:
             red_alarm_count = red_alarm_count.value
 
+        if (not yellow_alarm_count and not isinstance(yellow_alarm_count, int)) and (
+            not red_alarm_count and not isinstance(red_alarm_count, int)
+        ):
+            raise NoSuchNameError
+
         if not isinstance(yellow_alarm_count, int) or not isinstance(red_alarm_count, int):
             _logger.error(
                 "Device %s returns alarm count not of type int. "


### PR DESCRIPTION
First step to #212. 

This will make the task do nothing in case we get a `NoSuchNameError` from `snmp.get` and also do nothing in case the results are both falsy values that aren't `int` (`None` or `""`). This avoids a lot of error logging in case we have juniper devices that do not have yellow/red alarm counts. 

The rest of the issue needs to be fixed within the `snmp` module, such that when the object is not available an `NoSuchNameError` should be thrown. 