### PR TITLE
Implement link trap handling (without flapping algorithm)

### DIFF
--- a/changelog.d/+linktraps.added.md
+++ b/changelog.d/+linktraps.added.md
@@ -1,0 +1,1 @@
+Ported basic link trap handling from Zino 1

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -318,6 +318,7 @@ class PortStateEvent(Event):
     ifindex: Optional[int] = None
     portstate: Optional[InterfaceState] = None
     descr: Optional[str] = None
+    reason: Optional[str] = None
 
     @property
     def subindex(self) -> SubIndex:

--- a/src/zino/trapobservers/link_traps.py
+++ b/src/zino/trapobservers/link_traps.py
@@ -170,15 +170,11 @@ class LinkTrapObserver(TrapObserver):
         return False  # stub implementation, see Zino 1 `proc flapping`
 
     def get_watch_pattern(self, device: DeviceState) -> Optional[str]:
-        from zino.state import polldevs
-
-        if device.name not in polldevs:
+        if device.name not in self.polldevs:
             return None
-        return polldevs[device.name].watchpat
+        return self.polldevs[device.name].watchpat
 
     def get_ignore_pattern(self, device: DeviceState) -> Optional[str]:
-        from zino.state import polldevs
-
-        if device.name not in polldevs:
+        if device.name not in self.polldevs:
             return None
-        return polldevs[device.name].ignorepat
+        return self.polldevs[device.name].ignorepat

--- a/src/zino/trapobservers/link_traps.py
+++ b/src/zino/trapobservers/link_traps.py
@@ -1,0 +1,43 @@
+"""This module implements link trap handling"""
+
+import logging
+from typing import Optional
+
+from zino.statemodels import DeviceState, Port
+from zino.trapd import TrapMessage, TrapObserver
+
+_logger = logging.getLogger(__name__)
+
+
+class LinkTrapObserver(TrapObserver):
+    WANTED_TRAPS = {
+        ("IF-MIB", "linkUp"),
+        ("IF-MIB", "linkDown"),
+    }
+
+    def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
+        _logger.debug("%s: %s (vars: %s)", trap.agent.device.name, trap.name, ", ".join(trap.variables))
+
+        if "ifIndex" in trap.variables:
+            ifindex = trap.variables.get("ifIndex").value
+        else:
+            ifindex = -1
+        port = trap.agent.device.ports.get(ifindex) if ifindex > 0 else None
+
+        # TODO: The trap *might* contain an ifDescr value.  If present, Zino uses that for trap processing.
+        #  Otherwise, it fetches ifDescr from its own state and uses that for trap processing.  Either way,
+        #  there seems to be some redundancy. We should document why, or change the behavior in Zino 2
+
+        # The legacy Zino also looks for `locIfDescr` in the trap at this point, but this is an ancient
+        # Cisco-specific variable we no longer see.  It might have been replaced by `cieIfOperStatusCause`,
+        # but we have no more Cisco devices to test on, so this has been deliberately left out.
+
+        is_up = trap.name == "linkUp"
+        self.handle_link_transition(trap.agent.device, port, is_up)
+
+    def handle_link_transition(self, device: DeviceState, port: Port, is_up: bool, reason: Optional[str] = None):
+        """This method is called when a linkUp or linkDown trap is received, and updates event state accordingly -
+        including the logic for handling flapping states.
+        """
+
+        _logger.debug("handle_link_transition: device=%r port=%r is_up=%r", device, port, is_up)

--- a/src/zino/trapobservers/link_traps.py
+++ b/src/zino/trapobservers/link_traps.py
@@ -81,8 +81,9 @@ class LinkTrapObserver(TrapObserver):
             event.port = port.ifdescr
             event.ifindex = port.ifindex
             port.state = new_state
-            event.polladdr = device.address
-            event.priority = device.priority
+            if polldev := self.polldevs.get(device.name):
+                event.polladdr = polldev.address
+                event.priority = polldev.priority
             event.descr = port.ifalias  # or value received from trap? see ldescr from legacy Zino
 
             # TODO: If there is internal flapping state, log it in the event and clear internal state

--- a/src/zino/trapobservers/link_traps.py
+++ b/src/zino/trapobservers/link_traps.py
@@ -75,7 +75,7 @@ class LinkTrapObserver(TrapObserver):
             # TODO: When flapcount modulo 100 is zero, log a message with flapping stats
             pass
         else:
-            event = self.state.events.get_or_create_event(device.name, port.ifindex, PortStateEvent)
+            event: PortStateEvent = self.state.events.get_or_create_event(device.name, port.ifindex, PortStateEvent)
 
             event.portstate = new_state
             event.port = port.ifdescr
@@ -90,7 +90,7 @@ class LinkTrapObserver(TrapObserver):
 
             msg = f'{device.name}: intf "{port.ifdescr}" ix {port.ifindex} link{new_state.capitalize()}'
             if reason:
-                # TODO: Add reason attribute to event
+                event.reason = reason
                 msg = f'{msg}, "{reason}"'
             _logger.info(msg)
             event.add_log(msg)

--- a/src/zino/trapobservers/link_traps.py
+++ b/src/zino/trapobservers/link_traps.py
@@ -29,8 +29,14 @@ class LinkTrapObserver(TrapObserver):
         if "ifIndex" in trap.variables:
             ifindex = trap.variables.get("ifIndex").value
         else:
-            ifindex = -1
+            _logger.warning("%s: %s trap contained no ifIndex value, ignoring", trap.agent.device.name, trap.name)
+            return False
         port = trap.agent.device.ports.get(ifindex) if ifindex > 0 else None
+        if not port:
+            _logger.warning(
+                "%s: %s trap referenced unknown port (ix %s), ignoring", trap.agent.device.name, trap.name, ifindex
+            )
+            return False
 
         # TODO: The trap *might* contain an ifDescr value.  If present, Zino uses that for trap processing.
         #  Otherwise, it fetches ifDescr from its own state and uses that for trap processing.  Either way,

--- a/src/zino/trapobservers/link_traps.py
+++ b/src/zino/trapobservers/link_traps.py
@@ -165,7 +165,7 @@ class LinkTrapObserver(TrapObserver):
 
     def update_interface_flapping_score(self, index: Tuple[str, int]) -> bool:
         """Updates the running flapping score for a given port"""
-        pass  # stub implementation, see Zino 1 `proc intfFlap`
+        return False  # stub implementation, see Zino 1 `proc intfFlap`
 
     def is_interface_flapping(self, index: Tuple[str, int]) -> bool:
         """Determines if a given port is flapping"""

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -21,7 +21,7 @@ from zino.statemodels import Event
 from zino.trapd import TrapReceiver
 
 # ensure all our desired trap observers are loaded.  They will not be explicitly referenced here, hence the noqa tag
-from zino.trapobservers import ignored_traps, logged_traps  # noqa
+from zino.trapobservers import ignored_traps, link_traps, logged_traps  # noqa
 
 STATE_DUMP_JOB_ID = "zino.dump_state"
 # Never try to dump state more often than this:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,15 @@
 import asyncio
+import ipaddress
 import os
 from shutil import which
 
 import pytest
 import pytest_asyncio
 from retry import retry
+
+from zino.state import ZinoState
+from zino.statemodels import DeviceState
+from zino.trapd import TrapReceiver
 
 
 @pytest.fixture
@@ -117,6 +122,25 @@ def snmp_fixture_directory():
 @pytest.fixture(scope="session")
 def snmp_test_port():
     yield 1024
+
+
+@pytest.fixture
+def state_with_localhost():
+    localhost = ipaddress.ip_address("127.0.0.1")
+    state = ZinoState()
+    state.devices.devices["localhost"] = DeviceState(name="localhost", addresses={localhost})
+    state.addresses[localhost] = "localhost"
+    yield state
+
+
+@pytest_asyncio.fixture
+async def localhost_receiver(state_with_localhost, event_loop) -> TrapReceiver:
+    """Yields a TrapReceiver instance with a standardized setup for running external tests on localhost"""
+    receiver = TrapReceiver(address="127.0.0.1", port=1162, loop=event_loop, state=state_with_localhost)
+    receiver.add_community("public")
+    await receiver.open()
+    yield receiver
+    receiver.close()
 
 
 def _verify_localhost_snmp_response(port: int):

--- a/tests/trapd_test.py
+++ b/tests/trapd_test.py
@@ -163,6 +163,11 @@ class TestTrapReceiverExternally:
 
 
 async def send_trap_externally(*args: str):
+    """Uses the snmptrap command line program to send a trap to the local trap receiver test instance on port 1162.
+
+    :param args: The arguments to pass to the snmptrap command line program, see `man snmptrap` for details on the
+                 rather esoteric syntax.
+    """
     args = " ".join(args)
     proc = await asyncio.create_subprocess_shell(f"snmptrap -v 2c -c public localhost:1162 '' {args}")
     await proc.communicate()

--- a/tests/trapd_test.py
+++ b/tests/trapd_test.py
@@ -6,11 +6,8 @@ from collections import Counter
 from unittest.mock import Mock, patch
 
 import pytest
-import pytest_asyncio
 
 from zino.oid import OID
-from zino.state import ZinoState
-from zino.statemodels import DeviceState
 from zino.trapd import (
     TrapMessage,
     TrapObserver,
@@ -163,25 +160,6 @@ class TestTrapReceiverExternally:
             with patch.object(localhost_receiver, "dispatch_trap") as mock_dispatch:
                 await send_trap_externally(OID_COLD_START, OID_SYSNAME_0, "s", "'MockDevice'")
                 assert not mock_dispatch.called
-
-
-@pytest.fixture
-def state_with_localhost():
-    localhost = ipaddress.ip_address("127.0.0.1")
-    state = ZinoState()
-    state.devices.devices["localhost"] = DeviceState(name="localhost", addresses={localhost})
-    state.addresses[localhost] = "localhost"
-    yield state
-
-
-@pytest_asyncio.fixture
-async def localhost_receiver(state_with_localhost, event_loop) -> TrapReceiver:
-    """Yields a TrapReceiver instance with a standardized setup for running external tests on localhost"""
-    receiver = TrapReceiver(address="127.0.0.1", port=1162, loop=event_loop, state=state_with_localhost)
-    receiver.add_community("public")
-    await receiver.open()
-    yield receiver
-    receiver.close()
 
 
 async def send_trap_externally(*args: str):

--- a/tests/trapobservers/link_traps_test.py
+++ b/tests/trapobservers/link_traps_test.py
@@ -92,6 +92,15 @@ class TestLinkTrapObserver:
         localhost.boot_time = now() - timedelta(minutes=2)
         assert observer.is_port_ignored_by_policy(localhost, localhost.ports[1], is_up=False)
 
+    def test_when_link_trap_is_redundant_policy_should_ignore_trap(self, state_with_localhost_with_port):
+        observer = LinkTrapObserver(state=state_with_localhost_with_port, polldevs=Mock())
+        localhost = state_with_localhost_with_port.devices.devices["localhost"]
+        port = localhost.ports[1]
+        port.state = InterfaceState.DOWN
+        assert observer.is_port_ignored_by_policy(
+            localhost, localhost.ports[1], is_up=False
+        ), "did not ignore redundant linkDown trap"
+
 
 @pytest.fixture
 def state_with_localhost_with_port(state_with_localhost):

--- a/tests/trapobservers/link_traps_test.py
+++ b/tests/trapobservers/link_traps_test.py
@@ -1,0 +1,61 @@
+from datetime import timedelta
+from unittest.mock import Mock
+
+import pytest
+
+from zino.statemodels import InterfaceState, Port, PortStateEvent
+from zino.time import now
+from zino.trapobservers.link_traps import LinkTrapObserver
+
+from .. import trapd_test
+
+OID_LINKDOWN = ".1.3.6.1.6.3.1.1.5.3"
+OID_IFINDEX = ".1.3.6.1.2.1.2.2.1.1"
+OID_IFOPERSTATUS = ".1.3.6.1.2.1.2.2.1.8"
+
+
+class TestLinkTrapObserver:
+    @pytest.mark.asyncio
+    async def test_when_link_down_is_received_it_should_create_portstate_event(
+        self, state_with_localhost_with_port, localhost_receiver
+    ):
+        assert not state_with_localhost_with_port.events.get(
+            "localhost", 1, PortStateEvent
+        ), "initial state should be empty"
+
+        observer = LinkTrapObserver(
+            state=localhost_receiver.state, polldevs=localhost_receiver.polldevs, loop=localhost_receiver.loop
+        )
+        localhost_receiver.observe(observer, *LinkTrapObserver.WANTED_TRAPS)
+        await trapd_test.send_trap_externally(OID_LINKDOWN, OID_IFINDEX, "i", "1", OID_IFOPERSTATUS, "i", "2")
+
+        assert state_with_localhost_with_port.events.get(
+            "localhost", 1, PortStateEvent
+        ), "no portstate event was created"
+
+    def test_when_event_exists_policy_should_not_ignore_trap(self, state_with_localhost_with_port):
+        observer = LinkTrapObserver(state=state_with_localhost_with_port, polldevs=Mock())
+        localhost = state_with_localhost_with_port.devices.devices["localhost"]
+        state_with_localhost_with_port.events.create_event(localhost.name, 1, PortStateEvent)
+        assert not observer.is_port_ignored_by_policy(localhost, localhost.ports[1], is_up=False)
+
+    def test_when_boot_time_is_unknown_policy_should_not_ignore_trap(self, state_with_localhost_with_port):
+        observer = LinkTrapObserver(state=state_with_localhost_with_port, polldevs=Mock())
+        localhost = state_with_localhost_with_port.devices.devices["localhost"]
+        localhost.boot_time = None
+        assert not observer.is_port_ignored_by_policy(localhost, localhost.ports[1], is_up=False)
+
+    def test_when_boot_age_is_less_than_5_minutes_policy_should_ignore_trap(self, state_with_localhost_with_port):
+        observer = LinkTrapObserver(state=state_with_localhost_with_port, polldevs=Mock())
+        localhost = state_with_localhost_with_port.devices.devices["localhost"]
+        localhost.boot_time = now() - timedelta(minutes=2)
+        assert observer.is_port_ignored_by_policy(localhost, localhost.ports[1], is_up=False)
+
+
+@pytest.fixture
+def state_with_localhost_with_port(state_with_localhost):
+    port = Port(ifindex=1, ifdescr="eth0", state=InterfaceState.UP)
+    device = state_with_localhost.devices.devices["localhost"]
+    device.boot_time = now() - timedelta(minutes=10)
+    device.ports[port.ifindex] = port
+    yield state_with_localhost


### PR DESCRIPTION
Partially closes #232.  Makes provisions for handling flapping, but I'm trying to postpone it to a separate PR.

This reworks `TrapObserver` and the `PortStateEvent` model as needed.  So far, it lacks provisions to actually schedule poll jobs, as that is currently built as private methods of the linkstatetask.  I'm thinking this PR is already large enough for a review and for some simple functionality, so I suggest a followup PR to deal also with rescheduling, which will require more restructuring.