### PR TITLE
Exempt `raise NotImplementedError` from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ exclude_also = [
     "\\.\\.\\.",
     # Don't complain about lines excluded unless type checking
     "if TYPE_CHECKING:",
+    # We don't need tests to cover unimplementedness
+    "raise NotImplementedError",
 ]
 
 


### PR DESCRIPTION
We just don't need it.