### PR TITLE
Fix two stupid bugs in `LinkStateTask.poll_single_interface`

### DIFF
--- a/changelog.d/+poll-single-interface-ifindex.fixed.md
+++ b/changelog.d/+poll-single-interface-ifindex.fixed.md
@@ -1,0 +1,1 @@
+Ensure polling single interfaces works for ifindex=0

--- a/changelog.d/+poll-single-interface-timeouts.fixed.md
+++ b/changelog.d/+poll-single-interface-timeouts.fixed.md
@@ -1,0 +1,1 @@
+Ensure polling single interfaces does not crash in the event of timeout errors

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -59,7 +59,10 @@ class LinkStateTask(Task):
 
     async def poll_single_interface(self, ifindex: int):
         """Polls and updates a single interface"""
-        poll_list = [("IF-MIB", column, str(ifindex - 1)) for column in BASE_POLL_LIST]
+        prev_ifindex = ifindex - 1
+        poll_list = [
+            ("IF-MIB", column, str(prev_ifindex)) if prev_ifindex else ("IF-MIB", column) for column in BASE_POLL_LIST
+        ]
         result = await self.snmp.getnext2(*poll_list)
         self.sysuptime = await self._get_uptime()
         self.device_state.set_boot_time_from_uptime(self.sysuptime)

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -63,8 +63,12 @@ class LinkStateTask(Task):
         poll_list = [
             ("IF-MIB", column, str(prev_ifindex)) if prev_ifindex else ("IF-MIB", column) for column in BASE_POLL_LIST
         ]
-        result = await self.snmp.getnext2(*poll_list)
-        self.sysuptime = await self._get_uptime()
+        try:
+            result = await self.snmp.getnext2(*poll_list)
+            self.sysuptime = await self._get_uptime()
+        except TimeoutError:
+            _logger.error("%s: timed out polling single interface %s", self.device.name, ifindex)
+            return
         self.device_state.set_boot_time_from_uptime(self.sysuptime)
         _logger.debug("poll_single_interface %s result: %r", self.device.name, result)
 

--- a/tests/tasks/test_linkstatetask.py
+++ b/tests/tasks/test_linkstatetask.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from zino.config.models import PollDevice
@@ -109,6 +111,12 @@ class TestBaseInterfaceRow:
         """
         target_index = 1
         assert await linkstatetask_with_one_link_down.poll_single_interface(target_index) is None
+
+    @pytest.mark.asyncio
+    async def test_when_timeout_occurs_poll_single_interface_should_not_crash(self, linkstatetask_with_one_link_down):
+        with patch.object(linkstatetask_with_one_link_down.snmp, "getnext2") as mock_getnext2:
+            mock_getnext2.side_effect = TimeoutError
+            assert await linkstatetask_with_one_link_down.poll_single_interface(42) is None
 
 
 @pytest.fixture

--- a/tests/tasks/test_linkstatetask.py
+++ b/tests/tasks/test_linkstatetask.py
@@ -102,6 +102,14 @@ class TestBaseInterfaceRow:
         assert port.ifdescr == "2"
         assert port.ifalias == "from a famous"
 
+    @pytest.mark.asyncio
+    async def test_when_ifindex_is_1_poll_single_interface_should_not_crash(self, linkstatetask_with_one_link_down):
+        """Regression test.  poll_single_interface constructs a GET-NEXT request by asking for the set of next values
+        after ifindex-1 - but 0 indexes are illegal when encoding OIDs into tables.
+        """
+        target_index = 1
+        assert await linkstatetask_with_one_link_down.poll_single_interface(target_index) is None
+
 
 @pytest.fixture
 def linkstatetask_with_links_up(snmpsim, snmp_test_port):


### PR DESCRIPTION
This fixes problems with timeouts and getting interface data for interfaces with `ifindex=1`.  See commit comments for details.