### PR TITLE
Do not try to publish test results/code coverage in fork

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -10,7 +10,7 @@ jobs:
   publish-test-results:
     name: "Publish test and coverage results"
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion != 'skipped'
+    if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
 
     steps:
       - name: Download and Extract Artifacts


### PR DESCRIPTION
When doing #230 I remove the condition `github.repository_owner == 'Uninett'` because I thought that was given, but I forgot, that the workflow `Run test suite` will also be triggered by pushes to the master branch of a fork, which will in turn trigger the `Publish test and coverage results` workflow. This workflow will then run on the master branch of the fork. 
And both uploading test results and code coverage will fail since the fork does not have the correct permissions/the code coverage token. Failing workflows can be seen here for [publish test results](https://github.com/johannaengland/zino/actions/runs/9345474386/job/25718806440) and [publish code coverage](https://github.com/england-johanna/testing/actions/runs/9345772140/job/25719278459).

So we do need to restrict this workflow to only run on the Uninett repository. 