### PR TITLE
Output more user-friendly error reports for `polldevs.py` parsing errors

### DIFF
--- a/changelog.d/248.added.md
+++ b/changelog.d/248.added.md
@@ -1,0 +1,1 @@
+Improved error reporting, including line/block location, for `polldevs.cf` parsing errors

--- a/src/zino/config/polldevs.py
+++ b/src/zino/config/polldevs.py
@@ -1,6 +1,8 @@
 """Functionality to parse and validate the legacy polldevs.cf config file"""
 
-from typing import Iterator, TextIO
+from typing import Iterator, TextIO, Tuple
+
+from pydantic import ValidationError
 
 from zino.config.models import PollDevice
 
@@ -12,34 +14,53 @@ def read_polldevs(filename: str) -> Iterator[PollDevice]:
     multiple spaces in value assignments.
     """
     defaults = {}
-    with open(filename, "r") as devs:
-        for section in _read_conf_sections(devs):
-            if _contains_defaults(section):
-                defaults.update(_parse_defaults(section))
-                continue
+    try:
+        with open(filename, "r") as devs:
+            for lineno, section in _read_conf_sections(devs):
+                if _contains_defaults(section):
+                    defaults.update(_parse_defaults(section))
+                    continue
 
-            yield PollDevice(**(defaults | section))
+                try:
+                    yield PollDevice(**(defaults | section))
+                except ValidationError as error:
+                    first_error = error.errors()[0]
+                    device_name = section.get("name", "N/A")
+                    attribute = first_error["loc"][0]
+                    raise InvalidConfiguration(
+                        f"Validation error in device block {device_name!r}: {first_error['msg']} ({attribute!r})",
+                        filename=filename,
+                        lineno=lineno,
+                    )
+
+    except InvalidConfiguration as error:
+        error.filename = filename
+        raise
 
 
-def _read_conf_sections(filehandle: TextIO) -> Iterator[dict]:
+def _read_conf_sections(filehandle: TextIO) -> Iterator[Tuple[int, dict]]:
     """Reads individual configuration sections from `polldevs.cf`, yielding each one as a separate dict"""
     section = {}
-    for line in filehandle:
+    first_line = None
+    for lineno, line in enumerate(filehandle):
+        if not first_line:
+            first_line = lineno + 1
         line = line.strip()
         if line.startswith("#"):
             continue
         if not line:
             if section:
-                yield section
+                yield first_line, section
                 section = {}
+                first_line = None
             continue
         try:
             key, value = line.split(":", maxsplit=1)
         except ValueError:
-            raise InvalidConfiguration(f"{line!r} is not a valid configuration line")
+            raise InvalidConfiguration(f"{line!r} is not a valid configuration line", lineno=lineno + 1)
         section[key.strip()] = value.strip()
     if section:
-        yield section
+        yield first_line, section
 
 
 def _contains_defaults(section: dict) -> bool:
@@ -51,4 +72,14 @@ def _parse_defaults(section: dict) -> dict:
 
 
 class InvalidConfiguration(Exception):
-    pass
+    def __init__(self, message=None, filename=None, lineno=None):
+        self.filename = filename
+        self.lineno = lineno
+        super().__init__(message)
+
+    def __str__(self):
+        location = [item for item in (self.filename, self.lineno) if item]
+        if location:
+            location = ":".join(str(item) for item in location)
+            return f"{location}: {super().__str__()}"
+        return super().__str__()

--- a/src/zino/config/polldevs.py
+++ b/src/zino/config/polldevs.py
@@ -39,7 +39,10 @@ def read_polldevs(filename: str) -> Iterator[PollDevice]:
 
 
 def _read_conf_sections(filehandle: TextIO) -> Iterator[Tuple[int, dict]]:
-    """Reads individual configuration sections from `polldevs.cf`, yielding each one as a separate dict"""
+    """Reads and yields individual configuration sections from `polldevs.cf`.
+
+    Each yielded value is a two-tuple of the first line number of the section and the parsed section as a dict.
+    """
     section = {}
     first_line = None
     for lineno, line in enumerate(filehandle):

--- a/src/zino/scheduler.py
+++ b/src/zino/scheduler.py
@@ -10,7 +10,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from zino import state
 from zino.config.models import DEFAULT_INTERVAL_MINUTES, PollDevice
-from zino.config.polldevs import read_polldevs
+from zino.config.polldevs import InvalidConfiguration, read_polldevs
 from zino.tasks import run_all_tasks
 
 _log = logging.getLogger(__name__)
@@ -43,7 +43,12 @@ def load_polldevs(polldevs_conf: str) -> Tuple[Set, Set]:
 
     :returns: A tuple of (new_devices, deleted_devices)
     """
-    devices = {d.name: d for d in read_polldevs(polldevs_conf)}
+    try:
+        devices = {d.name: d for d in read_polldevs(polldevs_conf)}
+    except InvalidConfiguration as error:
+        _log.error(error)
+        return set(), set()
+
     new_devices = set(devices) - set(state.polldevs)
     deleted_devices = set(state.polldevs) - set(devices)
     if new_devices:

--- a/tests/config/polldevs_test.py
+++ b/tests/config/polldevs_test.py
@@ -25,7 +25,6 @@ class TestReadPolldevs:
 
 
 class TestReadInvalidPolldevs:
-
     def test_should_raise_exception(self, invalid_polldevs_conf):
         with pytest.raises(InvalidConfiguration):
             list(read_polldevs(invalid_polldevs_conf))
@@ -39,6 +38,16 @@ class TestReadInvalidPolldevs:
         with pytest.raises(InvalidConfiguration) as e:
             list(read_polldevs(invalid_polldevs_conf))
         assert "2" in str(e.value)
+
+    def test_exception_should_include_device_name_on_missing_address(self, missing_device_address_polldevs_conf):
+        with pytest.raises(InvalidConfiguration) as e:
+            list(read_polldevs(missing_device_address_polldevs_conf))
+        assert "example-gw" in str(e.value)
+
+    def test_exception_should_include_missing_attribute_on_missing_address(self, missing_device_address_polldevs_conf):
+        with pytest.raises(InvalidConfiguration) as e:
+            list(read_polldevs(missing_device_address_polldevs_conf))
+        assert "Field required ('address')" in str(e.value)
 
 
 class TestReadConfSections:
@@ -98,3 +107,21 @@ class TestParseDefaults:
         section = {"default value1": "foobar", "default value2": "cromulent", "value3": "zaphod"}
         expected = {"value1": "foobar", "value2": "cromulent"}
         assert _parse_defaults(section) == expected
+
+
+@pytest.fixture
+def missing_device_address_polldevs_conf(tmp_path):
+    name = tmp_path.joinpath("polldevs.cf")
+    with open(name, "w") as conf:
+        conf.write(
+            """# polldevs test config
+            default interval: 5
+            default community: foobar
+            default domain: uninett.no
+            default statistics: yes
+            default hcounters: yes
+
+            name: example-gw
+            """
+        )
+    yield name

--- a/tests/config/polldevs_test.py
+++ b/tests/config/polldevs_test.py
@@ -40,7 +40,7 @@ class TestReadConfSections:
         )
         result = list(_read_conf_sections(data))
         assert len(result) == 2
-        assert all(isinstance(i, dict) for i in result)
+        assert all(isinstance(block, dict) for lineno, block in result)
 
     def test_when_file_contains_comments_they_should_be_ignored(self):
         data = io.StringIO(
@@ -52,7 +52,7 @@ class TestReadConfSections:
             """
         )
         expected = {"name": "zaphod", "address": "127.0.0.1"}
-        result = list(_read_conf_sections(data))
+        result = list(block for lineno, block in _read_conf_sections(data))
         assert result == [expected]
 
     def test_when_file_contains_non_assignments_it_should_fail(self):

--- a/tests/config/polldevs_test.py
+++ b/tests/config/polldevs_test.py
@@ -24,6 +24,23 @@ class TestReadPolldevs:
         assert all(device.domain == "uninett.no" for device in result)
 
 
+class TestReadInvalidPolldevs:
+
+    def test_should_raise_exception(self, invalid_polldevs_conf):
+        with pytest.raises(InvalidConfiguration):
+            list(read_polldevs(invalid_polldevs_conf))
+
+    def test_should_have_filename_in_exception(self, invalid_polldevs_conf):
+        with pytest.raises(InvalidConfiguration) as e:
+            list(read_polldevs(invalid_polldevs_conf))
+        assert "polldevs.cf" in str(e.value)
+
+    def test_should_have_line_number_in_exception(self, invalid_polldevs_conf):
+        with pytest.raises(InvalidConfiguration) as e:
+            list(read_polldevs(invalid_polldevs_conf))
+        assert "2" in str(e.value)
+
+
 class TestReadConfSections:
     def test_when_file_is_empty_it_should_return_nothing(self):
         data = io.StringIO("")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,18 @@ def polldevs_conf_with_no_routers(tmp_path):
     yield name
 
 
+@pytest.fixture
+def invalid_polldevs_conf(tmp_path):
+    name = tmp_path.joinpath("polldevs.cf")
+    with open(name, "w") as conf:
+        conf.write(
+            """# polldevs test config
+            lalala
+            """
+        )
+    yield name
+
+
 @pytest.fixture(scope="session")
 def event_loop():
     """Redefine pytest-asyncio's event_loop fixture to have a session scope"""

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -24,6 +24,20 @@ class TestLoadPolldevs:
         assert not new_devices
         assert len(deleted_devices) > 0
 
+    @patch("zino.state.polldevs", dict())
+    @patch("zino.state.state", ZinoState())
+    def test_should_return_no_new_or_deleted_devices_on_invalid_configuration(self, invalid_polldevs_conf):
+        new_devices, deleted_devices = scheduler.load_polldevs(invalid_polldevs_conf)
+        assert not new_devices
+        assert not deleted_devices
+
+    @patch("zino.state.polldevs", dict())
+    @patch("zino.state.state", ZinoState())
+    def test_should_log_error_on_invalid_configuration(self, caplog, invalid_polldevs_conf):
+        with caplog.at_level(logging.ERROR):
+            scheduler.load_polldevs(invalid_polldevs_conf)
+        assert "'lalala' is not a valid configuration line" in caplog.text
+
 
 class TestScheduleNewDevices:
     @patch("zino.state.polldevs", dict())


### PR DESCRIPTION
Closes #247 

Examples of output:

```
ERROR - zino.scheduler (MainThread) - polldevs.cf:4: 'foobar' is not a valid configuration line
```
```
ERROR - zino.scheduler (MainThread) - polldevs.cf:11: Validation error in device block 'N/A': Field required ('name')
```

```
ERROR - zino.scheduler (MainThread) - polldevs.cf:11: Validation error in device block 'example-gw': Input is not a valid IPv4 address ('address')
```


Still missing added test coverage.