### PR TITLE
Add generic Zino config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ old-events/
 # avoid accidental commits of config and state files
 polldevs.cf
 zino-state.json
+zino.toml

--- a/README.md
+++ b/README.md
@@ -190,6 +190,18 @@ Zino will check `polldevs.cf` for changes on a scheduled interval while it's
 running, so any changes made while Zino is running should be picked up without
 requiring a restart of the process.
 
+### Configuring other settings
+
+Other settings can be also configured in a separate [TOML](https://toml.io/en/) file,
+which defaults to `zino.toml` in the current working directory, but a different file
+can be specified using the `--config-file` command line option.
+
+See the [zino.toml.example](./zino.toml.example) file for the settings that can be
+configured and their default values.
+
+Zino does not currently check `zino.toml` for changes on a scheduled interval while
+it's running, so Zino needs to be restarted for changes to take effect.
+
 ### Configuring API users
 
 Zino 2 reimplements the text-based (vaguely SMTP-esque) API protocol from Zino

--- a/changelog.d/224.added.md
+++ b/changelog.d/224.added.md
@@ -1,0 +1,1 @@
+Add generic Zino config file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pysnmplib",
     "pyasn1<0.5.0",
     "aiodns",
+    "tomli; python_version < '3.11'",
 ]
 dynamic = ["version"]
 

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 from zino import version
 from zino.api import auth
 from zino.api.notify import Zino1NotificationProtocol
-from zino.state import ZinoState
+from zino.state import ZinoState, config
 from zino.statemodels import ClosedEventError, Event, EventState
 
 if TYPE_CHECKING:
@@ -38,7 +38,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
         self,
         server: Optional["ZinoServer"] = None,
         state: Optional[ZinoState] = None,
-        secrets_file: Optional[Union[Path, str]] = "secrets",
+        secrets_file: Optional[Union[Path, str]] = None,
     ):
         """Initializes a protocol instance.
 
@@ -58,7 +58,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
         self._authentication_challenge: Optional[str] = None
 
         self._state = state if state is not None else ZinoState()
-        self._secrets_file = secrets_file
+        self._secrets_file = secrets_file or config.authentication.file
 
     @property
     def peer_name(self) -> Optional[str]:

--- a/src/zino/config/__init__.py
+++ b/src/zino/config/__init__.py
@@ -12,21 +12,17 @@ class InvalidConfigurationError(Exception):
     """The configuration file is invalid toml"""
 
 
-def read_configuration(config_file_name: Optional[str] = None, poll_file_name: Optional[str] = None) -> Configuration:
+def read_configuration(config_file_name: Optional[str], poll_file_name: Optional[str] = None) -> Configuration:
     """
     Reads and validates config toml file
 
-    Returns configuration if file name is given and file exists, returns a
-    configuration with the default values if no file name is given
+    Returns configuration if file name is given and file exists
 
     Raises InvalidConfigurationError if toml file is invalid,
     OSError if the config toml file could not be found and
     pydantic.ValidationError if values in it are invalid or the specified files
     don't exist
     """
-    if not config_file_name:
-        return Configuration()
-
     with open(config_file_name, mode="rb") as cf:
         try:
             config_dict = load(cf)

--- a/src/zino/config/__init__.py
+++ b/src/zino/config/__init__.py
@@ -12,7 +12,7 @@ class InvalidConfigurationError(Exception):
     """The configuration file is invalid toml"""
 
 
-def read_configuration(config_file_name: Optional[str] = None) -> Configuration:
+def read_configuration(config_file_name: Optional[str] = None, poll_file_name: Optional[str] = None) -> Configuration:
     """
     Reads and validates config toml file
 
@@ -32,6 +32,13 @@ def read_configuration(config_file_name: Optional[str] = None) -> Configuration:
             config_dict = load(cf)
         except TOMLDecodeError:
             raise InvalidConfigurationError
+
+    # Polldevs by command line argument will override config file entry
+    if poll_file_name:
+        if "polling" not in config_dict.keys():
+            config_dict["polling"] = {"file": poll_file_name}
+        else:
+            config_dict["polling"]["file"] = poll_file_name
 
     config = Configuration.model_validate(obj=config_dict, strict=True)
 

--- a/src/zino/config/__init__.py
+++ b/src/zino/config/__init__.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+try:
+    from tomllib import TOMLDecodeError, load
+except ImportError:
+    from tomli import TOMLDecodeError, load
+
+from .models import Configuration
+
+
+class InvalidConfigurationError(Exception):
+    """The configuration file is invalid toml"""
+
+
+def read_configuration(config_file_name: Optional[str] = None) -> Configuration:
+    """
+    Reads and validates config toml file
+
+    Returns configuration if file name is given and file exists, returns a
+    configuration with the default values if no file name is given
+
+    Raises InvalidConfigurationError if toml file is invalid,
+    OSError if the config toml file could not be found and
+    pydantic.ValidationError if values in it are invalid or the specified files
+    don't exist
+    """
+    if not config_file_name:
+        return Configuration()
+
+    with open(config_file_name, mode="rb") as cf:
+        try:
+            config_dict = load(cf)
+        except TOMLDecodeError:
+            raise InvalidConfigurationError
+
+    config = Configuration.model_validate(obj=config_dict, strict=True)
+
+    return config

--- a/src/zino/config/__init__.py
+++ b/src/zino/config/__init__.py
@@ -12,7 +12,7 @@ class InvalidConfigurationError(Exception):
     """The configuration file is invalid toml"""
 
 
-def read_configuration(config_file_name: Optional[str], poll_file_name: Optional[str] = None) -> Configuration:
+def read_configuration(config_file_name: str, poll_file_name: Optional[str] = None) -> Configuration:
     """
     Reads and validates config toml file
 

--- a/src/zino/config/models.py
+++ b/src/zino/config/models.py
@@ -1,13 +1,28 @@
 """Zino configuration models"""
 
 from ipaddress import IPv4Address, IPv6Address
+from os import R_OK, access
+from os.path import isfile
 from typing import Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+from pydantic.functional_validators import AfterValidator
+from typing_extensions import Annotated
 
 DEFAULT_INTERVAL_MINUTES = 5
+STATE_FILENAME = "zino-state.json"
+EVENT_DUMP_DIR = "old-events"
+POLLFILE = "polldevs.cf"
 
 IPAddress = Union[IPv4Address, IPv6Address]
+
+
+def validate_file_can_be_opened(filename: str) -> str:
+    assert isfile(filename) and access(filename, R_OK), f"File {filename} doesn't exist or isn't readable"
+    return filename
+
+
+ExistingFileName = Annotated[str, AfterValidator(validate_file_can_be_opened)]
 
 
 # config fields and default values from
@@ -30,3 +45,41 @@ class PollDevice(BaseModel):
     hcounters: bool = False
     do_bgp: bool = True
     port: int = 161
+
+
+class Archiving(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    old_events_dir: str = EVENT_DUMP_DIR
+
+
+class Authentication(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    file: ExistingFileName = "secrets"
+
+
+class Persistence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    file: str = STATE_FILENAME
+    period: int = DEFAULT_INTERVAL_MINUTES
+
+
+class Polling(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    file: ExistingFileName = POLLFILE
+    period: int = 1
+
+
+class Configuration(BaseModel):
+    """Class for keeping track of the configuration set by zino.toml"""
+
+    # throw ValidationError on extra keys
+    model_config = ConfigDict(extra="forbid")
+
+    archiving: Archiving = Archiving()
+    authentication: Authentication = Authentication()
+    persistence: Persistence = Persistence()
+    polling: Polling = Polling()

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -20,7 +20,6 @@ from zino.time import now
 _log = logging.getLogger(__name__)
 
 EVENT_EXPIRY = timedelta(hours=8)
-EVENT_DUMP_DIR = "old-events"
 
 
 class EventIndex(NamedTuple):
@@ -166,10 +165,13 @@ class Events(BaseModel):
 
     def _delete(self, event: Event):
         """Removes a closed event from the events dict and notifies all observers"""
+        from zino.state import config
+
         if event.state != EventState.CLOSED:
             return
 
-        event.dump_event_to_file(dir_name=f"{EVENT_DUMP_DIR}/{now().year}-{now().month}/{now().day}")
+        base_dir = config.archiving.old_events_dir
+        event.dump_event_to_file(dir_name=f"{base_dir}/{now().year}-{now().month}/{now().day}")
         index = EventIndex(event.router, event.subindex, type(event))
         if self._closed_events_by_index.get(index) and event.id == self._closed_events_by_index[index].id:
             del self._closed_events_by_index[index]

--- a/src/zino/getuptime.py
+++ b/src/zino/getuptime.py
@@ -6,6 +6,7 @@ import logging
 
 from zino.config.polldevs import read_polldevs
 from zino.snmp import SNMP
+from zino.state import config
 
 _log = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ def main():
 
 
 async def run(args: argparse.Namespace):
-    devices = {d.name: d for d in read_polldevs("polldevs.cf")}
+    devices = {d.name: d for d in read_polldevs(config.polling.file)}
     device = devices[args.router]
 
     snmp = SNMP(device)
@@ -28,8 +29,8 @@ async def run(args: argparse.Namespace):
 
 
 def parse_args():
-    devicenames = [d.name for d in read_polldevs("polldevs.cf")]
-    parser = argparse.ArgumentParser(description="Fetch sysUptime from a device in polldevs.cf")
+    devicenames = [d.name for d in read_polldevs(config.polling.file)]
+    parser = argparse.ArgumentParser(description="Fetch sysUptime from a device in the pollfile")
     parser.add_argument("router", type=str, help="Zino router name", choices=devicenames)
     return parser.parse_args()
 

--- a/src/zino/scheduler.py
+++ b/src/zino/scheduler.py
@@ -39,7 +39,7 @@ def get_scheduler() -> AsyncIOScheduler:
 
 
 def load_polldevs(polldevs_conf: str) -> Tuple[Set, Set]:
-    """Loads polldevs.cf into process state.
+    """Loads pollfile into process state.
 
     :returns: A tuple of (new_devices, deleted_devices)
     """

--- a/src/zino/state.py
+++ b/src/zino/state.py
@@ -14,7 +14,6 @@ from zino.planned_maintenance import PlannedMaintenances
 from zino.statemodels import DeviceStates
 
 _log = logging.getLogger(__name__)
-STATE_FILENAME = "zino-state.json"
 
 # Dictionary of configured devices
 polldevs: Dict[str, PollDevice] = {}
@@ -33,14 +32,14 @@ class ZinoState(BaseModel):
     addresses: dict[IPAddress, str] = {}
     planned_maintenances: PlannedMaintenances = Field(default_factory=PlannedMaintenances)
 
-    def dump_state_to_file(self, filename: str = STATE_FILENAME):
+    def dump_state_to_file(self, filename: str):
         """Dumps the full state to a file in JSON format"""
         _log.debug("dumping state to %s", filename)
         with open(filename, "w") as statefile:
             statefile.write(self.model_dump_json(exclude_none=True, indent=2))
 
     @classmethod
-    def load_state_from_file(cls, filename: str = STATE_FILENAME) -> Optional["ZinoState"]:
+    def load_state_from_file(cls, filename: str) -> Optional["ZinoState"]:
         """Loads and returns a previously persisted ZinoState from a JSON file dump.
 
         :returns: A ZinoState object if the state file was found, None if it wasn't.  If the state file is invalid or

--- a/src/zino/state.py
+++ b/src/zino/state.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
 
-from zino.config.models import IPAddress, PollDevice
+from zino.config.models import Configuration, IPAddress, PollDevice
 from zino.events import Events
 from zino.planned_maintenance import PlannedMaintenances
 from zino.statemodels import DeviceStates
@@ -21,6 +21,8 @@ polldevs: Dict[str, PollDevice] = {}
 
 # Global (sic) state
 state: "ZinoState" = None
+
+config: Configuration = Configuration()
 
 
 class ZinoState(BaseModel):

--- a/src/zino/trapd.py
+++ b/src/zino/trapd.py
@@ -93,7 +93,7 @@ class TrapReceiver:
 
     A major difference to Zino 1 is that this receiver must explicitly be configured with SNMP community strings that
     will be accepted.  Zino 1 accepts traps with any community string, as long as their origin is any one of the
-    devices configured in `polldevs.cf`.  However, PySNMP places heavy emphasis on being standards compliant,
+    devices configured in the pollfile.  However, PySNMP places heavy emphasis on being standards compliant,
     and will not even pass on traps to our callbacks unless they match the authorization config for the SNMP engine.
     """
 

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -70,7 +70,7 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
     scheduler.add_job(
         func=load_and_schedule_polldevs,
         trigger="interval",
-        args=(args.polldevs.name or state.config.polling.file,),
+        args=(state.config.polling.file,),
         minutes=state.config.polling.period,
         next_run_time=datetime.now(),
     )
@@ -188,7 +188,11 @@ def reschedule_dump_state(log_msg: str) -> None:
 def parse_args(arguments=None):
     parser = argparse.ArgumentParser(description="Zino is not OpenView")
     parser.add_argument(
-        "--polldevs", type=argparse.FileType("r"), metavar="PATH", default=None, help="Path to the pollfile"
+        "--polldevs",
+        type=argparse.FileType("r"),
+        metavar="PATH",
+        required=False,
+        help="Path to the pollfile",
     )
     parser.add_argument(
         "--config-file",

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -182,6 +182,13 @@ def parse_args(arguments=None):
         "--polldevs", type=argparse.FileType("r"), metavar="PATH", default="polldevs.cf", help="Path to polldevs.cf"
     )
     parser.add_argument(
+        "--config-file",
+        type=argparse.FileType("r"),
+        metavar="PATH",
+        required=False,
+        help="Path to zino configuration file",
+    )
+    parser.add_argument(
         "--debug", action="store_true", default=False, help="Set global log level to DEBUG. Very chatty!"
     )
     parser.add_argument("--stop-in", type=int, default=None, help="Stop zino after N seconds.", metavar="N")
@@ -199,6 +206,8 @@ def parse_args(arguments=None):
     args = parser.parse_args(args=arguments)
     if args.polldevs:
         args.polldevs.close()  # don't leave this temporary file descriptor open
+    if args.config_file:
+        args.config_file.close()  # don't leave this temporary file descriptor open
     return args
 
 

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -36,7 +36,7 @@ def main():
         level=logging.INFO if not args.debug else logging.DEBUG,
         format="%(asctime)s - %(levelname)s - %(name)s (%(threadName)s) - %(message)s",
     )
-    state.config = read_configuration(args.config_file)
+    state.config = read_configuration(args.config_file, args.polldevs)
     # Polldevs by command line argument will override config file entry
     if args.polldevs:
         state.config.polling.file = args.polldevs

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -16,6 +16,7 @@ import tzlocal
 from zino import state
 from zino.api.server import ZinoServer
 from zino.config import read_configuration
+from zino.config.models import validate_file_can_be_opened
 from zino.scheduler import get_scheduler, load_and_schedule_polldevs
 from zino.statemodels import Event
 from zino.trapd import TrapReceiver
@@ -39,6 +40,8 @@ def main():
     # Polldevs by command line argument will override config file entry
     if args.polldevs:
         state.config.polling.file = args.polldevs.name
+    else:
+        validate_file_can_be_opened(state.config.polling.file)
     state.state = state.ZinoState.load_state_from_file(state.config.persistence.file) or state.ZinoState()
     init_event_loop(args)
 

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -70,7 +70,7 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
     scheduler.add_job(
         func=load_and_schedule_polldevs,
         trigger="interval",
-        args=(args.polldevs.name,),
+        args=(args.polldevs.name or state.config.polling.file,),
         minutes=1,
         next_run_time=datetime.now(),
     )
@@ -188,7 +188,7 @@ def reschedule_dump_state(log_msg: str) -> None:
 def parse_args(arguments=None):
     parser = argparse.ArgumentParser(description="Zino is not OpenView")
     parser.add_argument(
-        "--polldevs", type=argparse.FileType("r"), metavar="PATH", default="polldevs.cf", help="Path to polldevs.cf"
+        "--polldevs", type=argparse.FileType("r"), metavar="PATH", default=None, help="Path to the pollfile"
     )
     parser.add_argument(
         "--config-file",

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -46,10 +46,8 @@ def main():
     except InvalidConfigurationError:
         print(f"Configuration file with the name {args.config_name or DEFAULT_CONFIG_FILE} is invalid TOML.")
         sys.exit(1)
-    except ValidationError:
-        print(
-            f"Configuration file with the name {args.config_name or DEFAULT_CONFIG_FILE} has invalid values or misspelled keys. Check the zino.toml.example file."
-        )
+    except ValidationError as e:
+        print(e)
         sys.exit(1)
 
     state.state = state.ZinoState.load_state_from_file(state.config.persistence.file) or state.ZinoState()

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -15,6 +15,7 @@ import tzlocal
 
 from zino import state
 from zino.api.server import ZinoServer
+from zino.config import read_configuration
 from zino.config.models import DEFAULT_INTERVAL_MINUTES
 from zino.scheduler import get_scheduler, load_and_schedule_polldevs
 from zino.statemodels import Event
@@ -35,6 +36,10 @@ def main():
         level=logging.INFO if not args.debug else logging.DEBUG,
         format="%(asctime)s - %(levelname)s - %(name)s (%(threadName)s) - %(message)s",
     )
+    state.config = read_configuration(args.config_file.name if args.config_file else None)
+    # Polldevs by command line argument will override config file entry
+    if args.polldevs:
+        state.config.polling.file = args.polldevs.name
     state.state = state.ZinoState.load_state_from_file() or state.ZinoState()
     init_event_loop(args)
 

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -16,7 +16,6 @@ import tzlocal
 from zino import state
 from zino.api.server import ZinoServer
 from zino.config import read_configuration
-from zino.config.models import DEFAULT_INTERVAL_MINUTES
 from zino.scheduler import get_scheduler, load_and_schedule_polldevs
 from zino.statemodels import Event
 from zino.trapd import TrapReceiver
@@ -75,9 +74,13 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
         minutes=1,
         next_run_time=datetime.now(),
     )
-    # Schedule state dumping every DEFAULT_INTERVAL_MINUTES and reschedule whenever events are committed
+    # Schedule state dumping as often as configured in
+    # 'config.persistence.period' and reschedule whenever events are committed
     scheduler.add_job(
-        func=state.state.dump_state_to_file, trigger="interval", id=STATE_DUMP_JOB_ID, minutes=DEFAULT_INTERVAL_MINUTES
+        func=state.state.dump_state_to_file,
+        trigger="interval",
+        id=STATE_DUMP_JOB_ID,
+        minutes=state.config.persistence.period,
     )
     # Schedule planned maintenance
     scheduler.add_job(

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -41,13 +41,13 @@ def main():
         state.config = read_configuration(args.config_file or DEFAULT_CONFIG_FILE, args.polldevs)
     except OSError:
         if args.config_file:
-            print(f"No config file with the name {args.config_name} found.")
+            _log.fatal(f"No config file with the name {args.config_file} found.")
             sys.exit(1)
     except InvalidConfigurationError:
-        print(f"Configuration file with the name {args.config_name or DEFAULT_CONFIG_FILE} is invalid TOML.")
+        print(f"Configuration file with the name {args.config_file or DEFAULT_CONFIG_FILE} is invalid TOML.")
         sys.exit(1)
     except ValidationError as e:
-        print(e)
+        _log.fatal(e)
         sys.exit(1)
 
     state.state = state.ZinoState.load_state_from_file(state.config.persistence.file) or state.ZinoState()

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -39,7 +39,7 @@ def main():
     # Polldevs by command line argument will override config file entry
     if args.polldevs:
         state.config.polling.file = args.polldevs.name
-    state.state = state.ZinoState.load_state_from_file() or state.ZinoState()
+    state.state = state.ZinoState.load_state_from_file(state.config.persistence.file) or state.ZinoState()
     init_event_loop(args)
 
 
@@ -79,6 +79,7 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
     scheduler.add_job(
         func=state.state.dump_state_to_file,
         trigger="interval",
+        args=(state.config.persistence.file,),
         id=STATE_DUMP_JOB_ID,
         minutes=state.config.persistence.period,
     )

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -44,7 +44,7 @@ def main():
             _log.fatal(f"No config file with the name {args.config_file} found.")
             sys.exit(1)
     except InvalidConfigurationError:
-        print(f"Configuration file with the name {args.config_file or DEFAULT_CONFIG_FILE} is invalid TOML.")
+        _log.fatal(f"Configuration file with the name {args.config_file or DEFAULT_CONFIG_FILE} is invalid TOML.")
         sys.exit(1)
     except ValidationError as e:
         _log.fatal(e)

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -71,7 +71,7 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
         func=load_and_schedule_polldevs,
         trigger="interval",
         args=(args.polldevs.name or state.config.polling.file,),
-        minutes=1,
+        minutes=state.config.polling.period,
         next_run_time=datetime.now(),
     )
     # Schedule state dumping as often as configured in

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -36,12 +36,11 @@ def main():
         level=logging.INFO if not args.debug else logging.DEBUG,
         format="%(asctime)s - %(levelname)s - %(name)s (%(threadName)s) - %(message)s",
     )
-    state.config = read_configuration(args.config_file.name if args.config_file else None)
+    state.config = read_configuration(args.config_file)
     # Polldevs by command line argument will override config file entry
     if args.polldevs:
-        state.config.polling.file = args.polldevs.name
-    else:
-        validate_file_can_be_opened(state.config.polling.file)
+        state.config.polling.file = args.polldevs
+    validate_file_can_be_opened(state.config.polling.file)
     state.state = state.ZinoState.load_state_from_file(state.config.persistence.file) or state.ZinoState()
     init_event_loop(args)
 
@@ -192,15 +191,13 @@ def parse_args(arguments=None):
     parser = argparse.ArgumentParser(description="Zino is not OpenView")
     parser.add_argument(
         "--polldevs",
-        type=argparse.FileType("r"),
-        metavar="PATH",
+        type=str,
         required=False,
         help="Path to the pollfile",
     )
     parser.add_argument(
         "--config-file",
-        type=argparse.FileType("r"),
-        metavar="PATH",
+        type=str,
         required=False,
         help="Path to zino configuration file",
     )
@@ -220,10 +217,6 @@ def parse_args(arguments=None):
         "--user", metavar="USER", help="Switch to this user immediately after binding to privileged ports"
     )
     args = parser.parse_args(args=arguments)
-    if args.polldevs:
-        args.polldevs.close()  # don't leave this temporary file descriptor open
-    if args.config_file:
-        args.config_file.close()  # don't leave this temporary file descriptor open
     return args
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -5,10 +5,15 @@ from zino.config import InvalidConfigurationError, read_configuration
 
 
 class TestReadConfiguration:
-    def test_returns_config_defined_in_file(self, zino_conf, tmp_path):
+    def test_returns_config_defined_in_file(self, zino_conf, polldevs_conf_with_no_routers):
         config = read_configuration(zino_conf)
         assert config
-        assert config.polling.file == f"{tmp_path}/polldevs-empty.cf"
+        assert config.polling.file == str(polldevs_conf_with_no_routers)
+
+    def test_pollfile_argument_overrides_pollfile_defined_in_file(self, zino_conf, polldevs_conf_with_single_router):
+        config = read_configuration(config_file_name=zino_conf, poll_file_name=str(polldevs_conf_with_single_router))
+        assert config
+        assert config.polling.file == str(polldevs_conf_with_single_router)
 
     def test_raises_error_on_file_not_found(self):
         with pytest.raises(OSError):
@@ -27,12 +32,13 @@ class TestReadConfiguration:
             read_configuration(extra_keys_zino_conf)
 
     def test_raises_error_on_pollfile_not_found(self, tmp_path):
-        name = tmp_path / "non-existent-pollfile.toml"
+        pollfile = "non-existent-pollfile.toml"
+        name = tmp_path / pollfile
         with open(name, "w") as conf:
             conf.write(
-                """
+                f"""
                 [polling]
-                file = "non-existent-pollfile.cf"
+                file = "{pollfile}"
                 """
             )
         with pytest.raises(ValidationError):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2,17 +2,11 @@ import pytest
 from pydantic import ValidationError
 
 from zino.config import InvalidConfigurationError, read_configuration
-from zino.config.models import EVENT_DUMP_DIR
 
 
 class TestReadConfiguration:
-    def test_returns_default_config_object_on_no_file(self):
-        config = read_configuration()
-        assert config
-        assert config.archiving.old_events_dir == EVENT_DUMP_DIR
-
-    def test_returns_config_defined_in_file(self, zino_non_default_conf, tmp_path):
-        config = read_configuration(zino_non_default_conf)
+    def test_returns_config_defined_in_file(self, zino_conf, tmp_path):
+        config = read_configuration(zino_conf)
         assert config
         assert config.polling.file == f"{tmp_path}/polldevs-empty.cf"
 
@@ -20,41 +14,17 @@ class TestReadConfiguration:
         with pytest.raises(OSError):
             read_configuration("non-existent-config.toml")
 
-    def test_raises_error_on_invalid_toml_file(self, tmp_path):
-        name = tmp_path / "invalid-config.toml"
-        with open(name, "w") as conf:
-            conf.write(
-                """
-                [archiving]
-                old_events_dir = abc
-                """
-            )
+    def test_raises_error_on_invalid_toml_file(self, invalid_zino_conf):
         with pytest.raises(InvalidConfigurationError):
-            read_configuration(name)
+            read_configuration(invalid_zino_conf)
 
-    def test_raises_error_on_invalid_config_values(self, tmp_path):
-        name = tmp_path / "invalid-config-values.toml"
-        with open(name, "w") as conf:
-            conf.write(
-                """
-                [archiving]
-                old_events_dir = false
-                """
-            )
+    def test_raises_error_on_invalid_config_values(self, invalid_values_zino_conf):
         with pytest.raises(ValidationError):
-            read_configuration(name)
+            read_configuration(invalid_values_zino_conf)
 
-    def tests_raises_error_on_misspelled_key(self, tmp_path):
-        name = tmp_path / "extra-keys.toml"
-        with open(name, "w") as conf:
-            conf.write(
-                """
-                [archiving]
-                typo = "old-zino-events"
-                """
-            )
+    def tests_raises_error_on_misspelled_key(self, extra_keys_zino_conf):
         with pytest.raises(ValidationError):
-            read_configuration(name)
+            read_configuration(extra_keys_zino_conf)
 
     def test_raises_error_on_pollfile_not_found(self, tmp_path):
         name = tmp_path / "non-existent-pollfile.toml"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import ValidationError
+
+from zino.config import InvalidConfigurationError, read_configuration
+from zino.config.models import EVENT_DUMP_DIR
+
+
+class TestReadConfiguration:
+    def test_returns_default_config_object_on_no_file(self):
+        config = read_configuration()
+        assert config
+        assert config.archiving.old_events_dir == EVENT_DUMP_DIR
+
+    def test_returns_config_defined_in_file(self, zino_non_default_conf, tmp_path):
+        config = read_configuration(zino_non_default_conf)
+        assert config
+        assert config.polling.file == f"{tmp_path}/polldevs-empty.cf"
+
+    def test_raises_error_on_file_not_found(self):
+        with pytest.raises(OSError):
+            read_configuration("non-existent-config.toml")
+
+    def test_raises_error_on_invalid_toml_file(self, tmp_path):
+        name = tmp_path / "invalid-config.toml"
+        with open(name, "w") as conf:
+            conf.write(
+                """
+                [archiving]
+                old_events_dir = abc
+                """
+            )
+        with pytest.raises(InvalidConfigurationError):
+            read_configuration(name)
+
+    def test_raises_error_on_invalid_config_values(self, tmp_path):
+        name = tmp_path / "invalid-config-values.toml"
+        with open(name, "w") as conf:
+            conf.write(
+                """
+                [archiving]
+                old_events_dir = false
+                """
+            )
+        with pytest.raises(ValidationError):
+            read_configuration(name)
+
+    def tests_raises_error_on_misspelled_key(self, tmp_path):
+        name = tmp_path / "extra-keys.toml"
+        with open(name, "w") as conf:
+            conf.write(
+                """
+                [archiving]
+                typo = "old-zino-events"
+                """
+            )
+        with pytest.raises(ValidationError):
+            read_configuration(name)
+
+    def test_raises_error_on_pollfile_not_found(self, tmp_path):
+        name = tmp_path / "non-existent-pollfile.toml"
+        with open(name, "w") as conf:
+            conf.write(
+                """
+                [polling]
+                file = "non-existent-pollfile.cf"
+                """
+            )
+        with pytest.raises(ValidationError):
+            read_configuration(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,13 +81,77 @@ def invalid_polldevs_conf(tmp_path):
 
 
 @pytest.fixture
-def zino_non_default_conf(tmp_path, polldevs_conf_with_no_routers):
+def secrets_file(tmp_path):
+    name = tmp_path / "secrets"
+    with open(name, "w") as conf:
+        conf.write("""user1 password123""")
+    yield name
+
+
+@pytest.fixture
+def zino_conf(tmp_path, polldevs_conf_with_no_routers, secrets_file):
     name = tmp_path / "zino.toml"
     with open(name, "w") as conf:
         conf.write(
             f"""
+            [authentication]
+            file = "{tmp_path}/secrets"
             [polling]
             file = "{tmp_path}/polldevs-empty.cf"
+            """
+        )
+    yield name
+
+
+@pytest.fixture
+def zino_conf_with_non_existent_pollfile(tmp_path, secrets_file):
+    name = tmp_path / "zino-no-pollfile.toml"
+    with open(name, "w") as conf:
+        conf.write(
+            f"""
+            [authentication]
+            file = "{tmp_path}/secrets"
+            [polling]
+            file = "{tmp_path}/non-existent-pollfile.cf"
+            """
+        )
+    yield name
+
+
+@pytest.fixture
+def invalid_zino_conf(tmp_path):
+    name = tmp_path / "invalid-zino.toml"
+    with open(name, "w") as conf:
+        conf.write(
+            """
+                [archiving]
+                old_events_dir = abc
+            """
+        )
+    yield name
+
+
+@pytest.fixture
+def invalid_values_zino_conf(tmp_path):
+    name = tmp_path / "invalid-config-values.toml"
+    with open(name, "w") as conf:
+        conf.write(
+            """
+                [archiving]
+                typo = "old-zino-events"
+            """
+        )
+    yield name
+
+
+@pytest.fixture
+def extra_keys_zino_conf(tmp_path):
+    name = tmp_path / "extra-keys.toml"
+    with open(name, "w") as conf:
+        conf.write(
+            """
+                [archiving]
+                old_events_dir = false
             """
         )
     yield name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,19 @@ def invalid_polldevs_conf(tmp_path):
     yield name
 
 
+@pytest.fixture
+def zino_non_default_conf(tmp_path, polldevs_conf_with_no_routers):
+    name = tmp_path / "zino.toml"
+    with open(name, "w") as conf:
+        conf.write(
+            f"""
+            [polling]
+            file = "{tmp_path}/polldevs-empty.cf"
+            """
+        )
+    yield name
+
+
 @pytest.fixture(scope="session")
 def event_loop():
     """Redefine pytest-asyncio's event_loop fixture to have a session scope"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,9 +95,9 @@ def zino_conf(tmp_path, polldevs_conf_with_no_routers, secrets_file):
         conf.write(
             f"""
             [authentication]
-            file = "{tmp_path}/secrets"
+            file = "{secrets_file}"
             [polling]
-            file = "{tmp_path}/polldevs-empty.cf"
+            file = "{polldevs_conf_with_no_routers}"
             """
         )
     yield name
@@ -110,7 +110,7 @@ def zino_conf_with_non_existent_pollfile(tmp_path, secrets_file):
         conf.write(
             f"""
             [authentication]
-            file = "{tmp_path}/secrets"
+            file = "{secrets_file}"
             [polling]
             file = "{tmp_path}/non-existent-pollfile.cf"
             """
@@ -138,7 +138,7 @@ def invalid_values_zino_conf(tmp_path):
         conf.write(
             """
                 [archiving]
-                typo = "old-zino-events"
+                old_events_dir = false
             """
         )
     yield name
@@ -151,7 +151,7 @@ def extra_keys_zino_conf(tmp_path):
         conf.write(
             """
                 [archiving]
-                old_events_dir = false
+                typo = "old-zino-events"
             """
         )
     yield name

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -159,7 +159,7 @@ class TestEvents:
         event.set_state(EventState.CLOSED)
         events.commit(event)
         event.updated = now() - timedelta(days=1)
-        with patch("zino.events.EVENT_DUMP_DIR", tmp_path):
+        with patch("zino.config.models.EVENT_DUMP_DIR", tmp_path):
             events.delete_expired_events()
         assert event.id not in events.events.keys()
 
@@ -172,7 +172,7 @@ class TestEvents:
         events.commit(event)
         assert events.get_closed_event(*index), "event wasn't added to closed index in the first place"
         event.updated = now() - timedelta(days=1)
-        with patch("zino.events.EVENT_DUMP_DIR", tmp_path):
+        with patch("zino.config.models.EVENT_DUMP_DIR", tmp_path):
             events.delete_expired_events()
         assert not events.get_closed_event(*index)
 
@@ -181,7 +181,7 @@ class TestEvents:
         event = events.get_or_create_event("foobar", None, ReachabilityEvent)
         event.set_state(EventState.CLOSED)
         events.commit(event)
-        with patch("zino.events.EVENT_DUMP_DIR", tmp_path):
+        with patch("zino.config.models.EVENT_DUMP_DIR", tmp_path):
             events.delete_expired_events()
         assert event.id in events.events.keys()
 
@@ -189,7 +189,7 @@ class TestEvents:
         events = Events()
         event = events.get_or_create_event("foobar", None, ReachabilityEvent)
         events.commit(event)
-        with patch("zino.events.EVENT_DUMP_DIR", tmp_path):
+        with patch("zino.config.models.EVENT_DUMP_DIR", tmp_path):
             events.delete_expired_events()
         assert event.id in events.events.keys()
 
@@ -229,7 +229,7 @@ class TestEvents:
             observer.called = True
 
         events.add_event_observer(observer)
-        with patch("zino.events.EVENT_DUMP_DIR", tmp_path):
+        with patch("zino.config.models.EVENT_DUMP_DIR", tmp_path):
             events._delete(event)
         assert observer.called
 

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -26,7 +26,7 @@ def test_zino_help_screen_should_not_crash():
     assert subprocess.check_call(["zino", "--help"]) == 0
 
 
-def test_zino_should_not_crash_right_away(polldevs_conf_with_no_routers):
+def test_zino_should_not_crash_right_away(polldevs_conf_with_no_routers, zino_conf):
     """This tests that the main function runs Zino for at least 2 seconds"""
     seconds_to_run_for = 2
     subprocess.check_call(
@@ -36,13 +36,15 @@ def test_zino_should_not_crash_right_away(polldevs_conf_with_no_routers):
             str(seconds_to_run_for),
             "--polldevs",
             str(polldevs_conf_with_no_routers),
+            "--config-file",
+            str(zino_conf),
             "--trap-port",
             "1162",
         ]
     )
 
 
-def test_zino_should_run_with_pollfile_name_in_config_file(polldevs_conf_with_no_routers, zino_non_default_conf):
+def test_zino_should_run_with_pollfile_name_in_config_file(polldevs_conf_with_no_routers, zino_conf):
     """This tests that the main function runs Zino for at least 2 seconds when
     the name of the pollfile is defined in the config file
     """
@@ -53,29 +55,49 @@ def test_zino_should_run_with_pollfile_name_in_config_file(polldevs_conf_with_no
             "--stop-in",
             str(seconds_to_run_for),
             "--config-file",
-            str(zino_non_default_conf),
+            str(zino_conf),
             "--trap-port",
             "1162",
         ]
     )
 
 
-def test_zino_should_not_run_without_pollfile(tmp_path):
-    """This tests that the main function runs Zino for at least 2 seconds when
-    the name of the pollfile is defined in the config file
+def test_zino_should_not_run_without_pollfile(zino_conf_with_non_existent_pollfile):
+    """This tests that the main function does not Zino for at least 2 seconds when
+    the name of the pollfile is defined in the config file, but does not exist
     """
-    with patch("zino.config.models.POLLFILE", f"{tmp_path}/non-existent-pollfile.cf"):
+    with pytest.raises(subprocess.CalledProcessError):
         seconds_to_run_for = 2
-        with pytest.raises(subprocess.CalledProcessError):
-            subprocess.check_call(
-                [
-                    "zino",
-                    "--stop-in",
-                    str(seconds_to_run_for),
-                    "--trap-port",
-                    "1162",
-                ]
-            )
+        subprocess.check_call(
+            [
+                "zino",
+                "--stop-in",
+                str(seconds_to_run_for),
+                "--config-file",
+                str(zino_conf_with_non_existent_pollfile),
+                "--trap-port",
+                "1162",
+            ]
+        )
+
+
+def test_zino_should_not_run_with_invalid_conf_file(invalid_zino_conf):
+    """This tests that the main function does not Zino for at least 2 seconds when
+    the name of the pollfile is defined in the config file, but does not exist
+    """
+    with pytest.raises(subprocess.CalledProcessError):
+        seconds_to_run_for = 2
+        subprocess.check_call(
+            [
+                "zino",
+                "--stop-in",
+                str(seconds_to_run_for),
+                "--config-file",
+                str(invalid_zino_conf),
+                "--trap-port",
+                "1162",
+            ]
+        )
 
 
 def test_zino_argparser_works(polldevs_conf):

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -42,6 +42,24 @@ def test_zino_should_not_crash_right_away(polldevs_conf_with_no_routers):
     )
 
 
+def test_zino_should_run_with_pollfile_name_in_config_file(polldevs_conf_with_no_routers, zino_non_default_conf):
+    """This tests that the main function runs Zino for at least 2 seconds when
+    the name of the pollfile is defined in the config file
+    """
+    seconds_to_run_for = 2
+    subprocess.check_call(
+        [
+            "zino",
+            "--stop-in",
+            str(seconds_to_run_for),
+            "--config-file",
+            str(zino_non_default_conf),
+            "--trap-port",
+            "1162",
+        ]
+    )
+
+
 def test_zino_argparser_works(polldevs_conf):
     parser = zino.parse_args(["--polldevs", str(polldevs_conf)])
     assert isinstance(parser, Namespace)

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -60,6 +60,24 @@ def test_zino_should_run_with_pollfile_name_in_config_file(polldevs_conf_with_no
     )
 
 
+def test_zino_should_not_run_without_pollfile(tmp_path):
+    """This tests that the main function runs Zino for at least 2 seconds when
+    the name of the pollfile is defined in the config file
+    """
+    with patch("zino.config.models.POLLFILE", f"{tmp_path}/non-existent-pollfile.cf"):
+        seconds_to_run_for = 2
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.check_call(
+                [
+                    "zino",
+                    "--stop-in",
+                    str(seconds_to_run_for),
+                    "--trap-port",
+                    "1162",
+                ]
+            )
+
+
 def test_zino_argparser_works(polldevs_conf):
     parser = zino.parse_args(["--polldevs", str(polldevs_conf)])
     assert isinstance(parser, Namespace)

--- a/zino.toml.example
+++ b/zino.toml.example
@@ -1,0 +1,27 @@
+[archiving]
+# Path to directory where dumps of expired events are saved
+# default "old-events"
+old_events_dir = "old-events"
+
+[authentication]
+# Path to the file containing user accounts and secrets for the Zino API
+# default "secrets"
+file = "secrets"
+
+[persistence]
+# Path to where the persistent Zino state should be saved
+# default "zino-state.json"
+file = "zino-state.json"
+
+# How often the persistent Zino state should be saved, in minutes
+# default 5 min
+period = 5
+
+[polling]
+# Path to a pollfile, the list of routers to monitor and related configuration
+# default "polldevs.cf"
+file = "polldevs.cf"
+
+# How often the pollfile is read, in minutes
+# default 1 min
+period = 1


### PR DESCRIPTION
Closes #224.

A few notes for discussion/information:
- as @runborg already commented in #224: `eventid_file` is not necessary, since it only keeps track of the last event id, which is something we already cover with `last_event_id`, which is dumped to `zino-state.json`

New questions that popped up during the fixing/writing tests:
- is it enough validation or does any other field need to be further validated?