### PR TITLE
Add more codecov configuration to fix associating commits within PRs

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -36,12 +36,21 @@ jobs:
           files: artifacts/**/*-results.xml
 
       - name: Read PR number file
-        if: ${{ hashFiles('artifacts/pr_number/pr_number') != '' }}
+        if: ${{ hashFiles('artifacts/extra/pr_number') != '' }}
         run: |
-          pr_number=$(cat artifacts/pr_number/pr_number)
+          pr_number=$(cat artifacts/extra/pr_number)
           re='^[0-9]+$'
           if [[ $pr_number =~ $re ]] ; then
             echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
+          fi
+
+      - name: Read base SHA file
+        if: ${{ hashFiles('artifacts/extra/base_sha') != '' }}
+        run: |
+          base_sha=$(cat artifacts/extra/base_sha)
+          re='[0-9a-f]{40}'
+          if [[ $base_sha =~ $re ]] ; then
+            echo "BASE_SHA=$base_sha" >> $GITHUB_ENV
           fi
 
       - name: Upload to Codecov
@@ -52,4 +61,5 @@ jobs:
           verbose: true
           override_branch: ${{ github.event.workflow_run.head_branch}}
           override_commit: ${{ github.event.workflow_run.head_sha}}
+          commit_parent: ${{ env.BASE_SHA }}
           override_pr: ${{ env.PR_NUMBER }}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -13,6 +13,14 @@ jobs:
     if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
 
     steps:
+      # Checking out the repo is necessary codecov/codecov-action@v4 to work properly
+      # Codecov requires source code to process the coverage file and generate coverage
+      # reports
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
       - name: Download and Extract Artifacts
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,19 +59,23 @@ jobs:
           path: |
             reports/**/*
 
-  upload-pr-number:
-    name: Save PR number in artifact
+  upload-pr-number-base-sha:
+    name: Save PR number and base SHA in artifact
     runs-on: ubuntu-latest
     if: ${{ github.event.number && always() }}
     env:
       PR_NUMBER: ${{ github.event.number }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
     steps:
       - name: Make PR number file
         run: |
-          mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number
-      - name: Upload PR number file
+          mkdir -p ./extra
+          echo $PR_NUMBER > ./extra/pr_number
+      - name: Make base SHA file
+        run: |
+          echo $BASE_SHA > ./extra/base_sha
+      - name: Upload PR number file and base SHA file
         uses: actions/upload-artifact@v4
         with:
-          name: pr_number
-          path: pr/
+          name: extra
+          path: extra/


### PR DESCRIPTION
This PR does two things to hopefully get the right coverage reports for PRs from forked repos:
1. Add a checkout action to the workflow where uploading coverage happens, this is instructed in [environment specific requirements of codecov](https://docs.codecov.com/docs/environment-specific-requirements#github-actions)
2. Override the parent commit value when uploading the coverage reports by creating an artifact in the test workflow and the accessing it in the uploading workflow