### PR TITLE
Add support for subcommands in the API

### DIFF
--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -123,7 +123,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
 
     def _dispatch_command(self, command, *args):
         commands = [command]
-        if command in self.HAS_SUBCOMMANDS and args:
+        if command.lower() in self.HAS_SUBCOMMANDS and args:
             commands.append(args[0])
             # Remove subcommand from args
             args = args[1:]

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -236,6 +236,23 @@ class TestZino1BaseServerProtocol:
 
         assert protocol not in server.active_clients
 
+    @pytest.mark.asyncio
+    async def test_subcommand_should_be_dispatched_if_command_with_support_of_subcommand_is_used(self):
+        args = []
+
+        class TestProtocol(Zino1BaseServerProtocol):
+            HAS_SUBCOMMANDS = ("testcommand",)
+
+            async def do_testcommand_subcommand(self, one, two):
+                args.extend((one, two))
+
+        protocol = TestProtocol()
+        fake_transport = Mock()
+        protocol.connection_made(fake_transport)
+        await protocol.message_received("testcommand subcommand foo bar")
+
+        assert args == ["foo", "bar"], "do_testcommand_subcommand() was apparently not called"
+
 
 class TestZino1ServerProtocolTranslateCaseIdToEvent:
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #255 

Suggestion for supporting subcommands. Adds a constant tuple where commands that support subcommands can be added (for us this will contain `pm`). If a command is registered in that tuple, the dispatcher will attempt to add the first argument to the command and look for functions matching this. If main command is `pm` and subcommand is `details` then it will look for `do_pm_details`

I imagine the `Zino1ServerProtocol` subclass would register `pm` as a subcommand by overriding the tuple

This is preliminary work for implementing the planned maintenance API commands, so i dont think this needs to be part of the changelog. The commands themselves will be, however