### PR TITLE
Fix log message on initial Juniper alarm

### DIFF
--- a/changelog.d/213.added.md
+++ b/changelog.d/213.added.md
@@ -1,0 +1,1 @@
+Fix log message on initial Juniper alarm

--- a/tests/tasks/test_juniperalarmtask.py
+++ b/tests/tasks/test_juniperalarmtask.py
@@ -130,6 +130,24 @@ class TestJuniperalarmTask:
         assert red_event.alarm_count == 2
 
     @pytest.mark.asyncio
+    async def test_task_creates_event_with_correct_log_on_initial_run(self, juniper_alarm_task):
+        task = juniper_alarm_task
+        device_state = task.state.devices.get(device_name=task.device.name)
+        device_state.enterprise_id = 2636
+        device_state.alarms = {
+            "yellow": 1,
+            "red": 0,
+        }
+
+        await task.run()
+
+        red_event = task.state.events.get(device_name=task.device.name, subindex="red", event_class=AlarmEvent)
+
+        assert red_event.log
+        log_messages = [log_entry.message for log_entry in red_event.log]
+        assert f"{juniper_alarm_task.device.name} red alarms went from 0 to 2" in log_messages
+
+    @pytest.mark.asyncio
     async def test_task_updates_alarm_events(self, juniper_alarm_task):
         task = juniper_alarm_task
         device_state = task.state.devices.get(device_name=task.device.name)


### PR DESCRIPTION
Closes #213. 

We got the log message "yellow alarms went from None to 1", because on the first Juniper alarm we create an event, which does not have an alarm count yet.