### PR TITLE
Add tests to show that get_or_create_event does not return closed events

### DIFF
--- a/changelog.d/+test-for-not-getting-closed-event.added.md
+++ b/changelog.d/+test-for-not-getting-closed-event.added.md
@@ -1,0 +1,1 @@
+Added tests to show that one will not get closed events using get_or_create_event

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -56,6 +56,15 @@ class TestEvents:
 
         assert event2 == event1
 
+    def test_get_or_create_event_should_not_return_closed_event(self):
+        events = Events()
+        event1 = events.get_or_create_event("foobar", None, ReachabilityEvent)
+        event1.set_state(EventState.CLOSED)
+        events.commit(event1)
+        event2 = events.get_or_create_event("foobar", None, ReachabilityEvent)
+
+        assert event2 != event1
+
     def test_checkout_should_return_copy(self):
         events = Events()
         original_event = events.get_or_create_event("foobar", None, ReachabilityEvent)


### PR DESCRIPTION
When working on #258 I suddenly got worried that `get_or_create_event` might return an event after it has been closed (which is not the case since when closing an event we remove it from the index, which is what we use to get and event). But since I had that worry I decided to add a test just to document it a bit more. 