### PR TITLE
Add functionality for handling varbind errors in get command

### DIFF
--- a/changelog.d/261.fixed.md
+++ b/changelog.d/261.fixed.md
@@ -1,0 +1,1 @@
+Add handling of varbind errors for snmp get actions.

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -142,7 +142,9 @@ class SNMP:
         except PysnmpMibNotFoundError as error:
             raise MibNotFoundError(error)
         self._raise_errors(error_indication, error_status, error_index, query)
-        return self._object_type_to_mib_object(var_binds[0])
+        result = var_binds[0]
+        self._raise_varbind_errors(result)
+        return self._object_type_to_mib_object(result)
 
     def _raise_errors(
         self,

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -75,7 +75,7 @@ class SnmpError(Exception):
     """Base class for SNMP, MIB and OID specific errors"""
 
 
-class ErrorIndication(Exception):
+class ErrorIndication(SnmpError):
     """Class for SNMP errors that occur locally,
     as opposed to being reported from a different SNMP entity.
     """

--- a/src/zino/snmp.py
+++ b/src/zino/snmp.py
@@ -96,6 +96,22 @@ class NoSuchNameError(ErrorStatus):
     """Represents the "noSuchName" error. Raised if an object could not be found at an OID."""
 
 
+class VarBindError(SnmpError):
+    """Base class for errors carried in varbinds and not in the errorStatus or errorIndication fields"""
+
+
+class NoSuchObjectError(VarBindError):
+    """Raised if an object could not be found at an OID"""
+
+
+class NoSuchInstanceError(VarBindError):
+    """Raised if an instance could not be found at an OID"""
+
+
+class EndOfMibViewError(VarBindError):
+    """Raised if end of MIB view is encountered"""
+
+
 class SNMP:
     """Represents an SNMP management session for a single device"""
 


### PR DESCRIPTION
Work towards fixing #261 and #212 

Adds function that takes an `ObjectType` and raises a relevant exception if it contains an error instead of a real value. I refer to this type of error as varbind errors since they are not defined via `errorStatus` or `errorIndication`, but are defined as values inside the response varbind

This PR makes use of the new function in the `get` command, but should be used for all the different commands. That can be done in other PRs once this one is completed.

To fully fix #212, some changes have to be made to the `juniperalarmtask`, including reverting some changes made in #231.
Handling of the new errors should also be added. `NoSuchObjectError` is definitely relevant, but maybe `NoSuchInstanceError` is too? Im not too sure about the difference about these two.. I'll leave @johannaengland to complete this task

Also sneakily fixes `ErrorIndication` not inheriting correctly (an SNMP related exception should probably inherit from the exception specifically made to be a base exception for everything SNMP related...)

Also2, there's quite a few SNMP specific exception classes now, thoughts on putting them in their own file?
