### PR TITLE
Rewrite API command dispatcher to match commands by patterns

### DIFF
--- a/changelog.d/274.added.md
+++ b/changelog.d/274.added.md
@@ -1,0 +1,1 @@
+Added framework support for API "sub-commands", to support the `PM` set of commands.

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -64,6 +64,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
         self._multiline_future: asyncio.Future = None
         self._multiline_buffer: List[str] = []
         self._authentication_challenge: Optional[str] = None
+        self._responders = self._get_all_responders()
 
         self._state = state if state is not None else ZinoState()
         self._secrets_file = secrets_file

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -236,14 +236,14 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
 
     async def do_help(self):
         """Lists all available top-level API commands"""
-        eligible = (
-            responder.name
-            for responder in self._responders.values()
-            if " " not in responder.name
-            and (self.is_authenticated or not getattr(responder.function, "requires_authentication", False))
+        top_level_responders = (responder for responder in self._responders.values() if " " not in responder.name)
+        authorized_responders = (
+            responder
+            for responder in top_level_responders
+            if self.is_authenticated or not getattr(responder.function, "requires_authentication", False)
         )
 
-        commands = " ".join(sorted(eligible))
+        commands = " ".join(sorted(responder.name for responder in authorized_responders))
         self._respond_multiline(200, ["commands are:"] + textwrap.wrap(commands, width=56))
 
     async def do_version(self):

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -235,13 +235,15 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         self.transport.close()
 
     async def do_help(self):
-        responders = self._get_all_responders()
-        if not self.is_authenticated:
-            responders = {
-                name: func for name, func in responders.items() if not getattr(func, "requires_authentication", False)
-            }
+        """Lists all available top-level API commands"""
+        eligible = (
+            responder.name
+            for responder in self._responders.values()
+            if " " not in responder.name
+            and (self.is_authenticated or not getattr(responder.function, "requires_authentication", False))
+        )
 
-        commands = " ".join(sorted(responders))
+        commands = " ".join(sorted(eligible))
         self._respond_multiline(200, ["commands are:"] + textwrap.wrap(commands, width=56))
 
     async def do_version(self):

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -164,7 +164,7 @@ class TestZino1BaseServerProtocol:
         result = protocol._get_all_responders()
         assert len(result) == 1
         assert "FOO" in result
-        assert callable(result["FOO"])
+        assert callable(result["FOO"].function)
 
     def test_when_command_has_too_few_args_then_an_error_response_should_be_sent(self):
         class TestProtocol(Zino1BaseServerProtocol):
@@ -197,7 +197,8 @@ class TestZino1BaseServerProtocol:
 
     def test_when_command_is_not_alphanumeric_then_get_responder_should_ignore_it(self):
         protocol = Zino1BaseServerProtocol()
-        assert protocol._get_responder("-340-405??#$") is None
+        responder, args = protocol._get_responder("-340-405??#$")
+        assert responder is None
 
     @pytest.mark.asyncio
     async def test_when_command_raises_unhandled_exception_then_error_response_should_be_sent(
@@ -338,8 +339,8 @@ class TestZino1ServerProtocolHelpCommand:
 
         all_unauthenticated_command_names = set(
             name
-            for name, func in protocol._get_all_responders().items()
-            if not getattr(func, "requires_authentication", False)
+            for name, responder in protocol._responders.items()
+            if not getattr(responder.function, "requires_authentication", False)
         )
         for command_name in all_unauthenticated_command_names:
             assert (

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -200,6 +200,18 @@ class TestZino1BaseServerProtocol:
         responder, args = protocol._get_responder("-340-405??#$")
         assert responder is None
 
+    def test_when_multiple_responders_match_then_get_responder_should_return_the_longest_name_match(self):
+        class TestProtocol(Zino1BaseServerProtocol):
+            async def do_foo(self):
+                pass
+
+            async def do_foo_bar(self):
+                pass
+
+        protocol = TestProtocol()
+        responder, args = protocol._get_responder("FOO BAR")
+        assert responder.name == "FOO BAR"
+
     @pytest.mark.asyncio
     async def test_when_command_raises_unhandled_exception_then_error_response_should_be_sent(
         self, buffered_fake_transport


### PR DESCRIPTION
An alternative to #254.

This changes the API command dispatcher framework more fundamentally to pre-build maps of API command patterns to match incoming messages against, in order to support arbitrarily long "sub-command" names.

With these changes, a `PM` command with e.g. a `PM FOO` sub-command can be implemented by adding two methods, following the existing pattern, and with no need to "pre-register" as a sub-command implementation:

```python
def do_pm(self):
   ...

def do_pm_foo(self, arg1, arg2, ...):
  ...
```

@stveit: You weren't available for pair programming, so I threw this together at my own initiative.

Fixes #255