### PR TITLE
Catch new SNMP errors in juniper alarm task

### DIFF
--- a/changelog.d/212.changed.md
+++ b/changelog.d/212.changed.md
@@ -1,0 +1,1 @@
+Handle new errors from SNMP in juniper alarm task

--- a/src/zino/tasks/juniperalarmtask.py
+++ b/src/zino/tasks/juniperalarmtask.py
@@ -1,6 +1,6 @@
 import logging
 
-from zino.snmp import NoSuchNameError
+from zino.snmp import NoSuchNameError, VarBindError
 from zino.statemodels import AlarmEvent, AlarmType
 from zino.tasks.task import Task
 
@@ -16,7 +16,7 @@ class JuniperAlarmTask(Task):
 
         try:
             yellow_alarm_count, red_alarm_count = await self._get_juniper_alarms()
-        except (TypeError, NoSuchNameError):
+        except (NoSuchNameError, TypeError, VarBindError):
             return
 
         if not self.device_state.alarms:
@@ -44,11 +44,6 @@ class JuniperAlarmTask(Task):
             yellow_alarm_count = yellow_alarm_count.value
         if red_alarm_count:
             red_alarm_count = red_alarm_count.value
-
-        if (not yellow_alarm_count and not isinstance(yellow_alarm_count, int)) and (
-            not red_alarm_count and not isinstance(red_alarm_count, int)
-        ):
-            raise NoSuchNameError
 
         if not isinstance(yellow_alarm_count, int) or not isinstance(red_alarm_count, int):
             _logger.error(


### PR DESCRIPTION
## Scope and purpose

Fixes #212.

This amends the changes made in #231 according to the new SNMP errors introduced/handled in #262.
This should finally lead to error being correctly handled and only things being logged if the device has an alarm count of an invalid type (but not none).

## Contributor Checklist

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
