### PR TITLE
Define and use a `TypeVar` for `Event` classes

### DIFF
--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -10,6 +10,7 @@ from zino.statemodels import (
     BGPEvent,
     Event,
     EventState,
+    EventType,
     PortStateEvent,
     ReachabilityEvent,
     SubIndex,
@@ -66,8 +67,8 @@ class Events(BaseModel):
         self,
         device_name: str,
         subindex: SubIndex,
-        event_class: Type[Event],
-    ) -> Event:
+        event_class: Type[EventType],
+    ) -> EventType:
         """Creates and returns a new event for the given event identifiers, or, if an event matching this identifier
         already exists in the index, returns that.
 
@@ -88,7 +89,7 @@ class Events(BaseModel):
             event = self.get(device_name, subindex, event_class)
             return self.checkout(event.id)
 
-    def create_event(self, device_name: str, subindex: SubIndex, event_class: Type[Event]) -> Event:
+    def create_event(self, device_name: str, subindex: SubIndex, event_class: Type[EventType]) -> EventType:
         """Creates a new event for the given event identifiers. If an event already exists for this combination of
         identifiers, an EventExistsError is raised.
 
@@ -108,7 +109,7 @@ class Events(BaseModel):
         _log.debug("created embryonic event %r", event)
         return event
 
-    def get(self, device_name: str, subindex: SubIndex, event_class: Type[Event]) -> Event:
+    def get(self, device_name: str, subindex: SubIndex, event_class: Type[EventType]) -> Optional[EventType]:
         """Returns an event based on its identifiers, None if no match was found"""
         index = EventIndex(device_name, subindex, event_class)
         return self._events_by_index.get(index)

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -8,7 +8,7 @@ import re
 from collections.abc import Generator
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, TypeVar, Union
 
 from pydantic import BaseModel, Field
 
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 IPAddress = Union[IPv4Address, IPv6Address]
 AlarmType = Literal["yellow", "red"]
 SubIndex = Union[None, int, IPAddress, AlarmType]
+EventType = TypeVar("EventType", bound="Event")
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Scope and purpose

Fix slightly incorrect type annotations for event registry functionality.

This is the canonical way to annotate that the return value of a function is an instance of the type that was used as one of the function arguments.

Seems to be the only way to make type checkers understand the *real* type of the return argument.

### This pull request
* Updates type annotations of the `Events` class, making IDE type inferences more useful.
* Was extracted from #244 

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * Changes no outward functionality, only helps devs
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
  * Not necessary, no functionality changed.
* [X] Added/changed documentation
  * This is, by definition, documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
