### PR TITLE
Index closed events

### DIFF
--- a/changelog.d/+closed-events-index.changed.md
+++ b/changelog.d/+closed-events-index.changed.md
@@ -1,0 +1,1 @@
+Index recently closed events to facilitate updating of prematurely closed flapping events


### PR DESCRIPTION
## Scope and purpose

The original Zino code will sometimes alter already closed events.  Apparently, the reasoning goes that operators sometimes prematurely close events for flapping ports (which Håvard E argues that we should maybe disallow in the future).  The original Zino therefore takes care to update both a closed flapping event and the currently open flapping event whenever the link trap code handles a flapping state.

A limitation I immediately see is that multiple closed events could exist for a flapping state (until they are expired/scavenged), but we can only index one of them.  As with the original code, there is a bias towards only indexing the latest event.

As a side note: Zino 1 used the terms "pre-closed" and "closed" for events.  The former refers to events that have been given a state of CLOSED by an operator.  The latter refers to events that have been evicted completely from the running state.

### This pull request

* Adds a `get_closed_event()` method to the `Events` class.
* Adds internal indexing of closed events to the `Events` class.

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * Not sure I need this for this feature, which is strictly internal.  No effect for end users (yet).
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
