### PR TITLE
Default to serve API on 0.0.0.0

### DIFF
--- a/changelog.d/285.fixed.md
+++ b/changelog.d/285.fixed.md
@@ -1,0 +1,1 @@
+API now listens to all interfaces, not just loopback

--- a/src/zino/api/server.py
+++ b/src/zino/api/server.py
@@ -27,7 +27,7 @@ class ZinoServer:
         self.notification_channels: dict[str, Zino1NotificationProtocol] = {}
         self.notify_server = self.api_server = None
 
-    def serve(self, address: str = "127.0.0.1"):
+    def serve(self, address: str = "0.0.0.0"):
         """Sets up the two asyncio servers to serve in tandem 'forever'"""
         api_coroutine = self._loop.create_server(
             lambda: ZinoTestProtocol(server=self, state=self.state), address, self.API_PORT


### PR DESCRIPTION
## Scope and purpose

Fixes #225

Replaces `127.0.0.1` with `0.0.0.0` as the default listening address for the API server.

Ideally we would want to serve both IPv4 and IPv6 simultaneously, but that will actually require two sockets.  Once the configuration file is in place, we can at least make the default listening address configurable, so the user can choose between IPv4 and IPv6.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [X] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
