### PR TITLE
Stop using dev/test version of API protocol

### DIFF
--- a/changelog.d/286.removed.md
+++ b/changelog.d/286.removed.md
@@ -1,0 +1,1 @@
+API test only commands have been removed

--- a/src/zino/api/server.py
+++ b/src/zino/api/server.py
@@ -2,7 +2,7 @@ import logging
 from asyncio import AbstractEventLoop
 from typing import Optional
 
-from zino.api.legacy import Zino1ServerProtocol, ZinoTestProtocol
+from zino.api.legacy import Zino1ServerProtocol
 from zino.api.notify import Zino1NotificationProtocol
 from zino.state import ZinoState
 from zino.statemodels import Event
@@ -30,7 +30,7 @@ class ZinoServer:
     def serve(self, address: str = "127.0.0.1"):
         """Sets up the two asyncio servers to serve in tandem 'forever'"""
         api_coroutine = self._loop.create_server(
-            lambda: ZinoTestProtocol(server=self, state=self.state), address, self.API_PORT
+            lambda: Zino1ServerProtocol(server=self, state=self.state), address, self.API_PORT
         )
         self.api_server = self._loop.run_until_complete(api_coroutine)
         _logger.info("Serving API on %r", self.api_server.sockets[0].getsockname())


### PR DESCRIPTION
## Scope and purpose

Fixes #279.

Up until now, Zino has by default launched a test version of the API protocol, which included test commands that weren't relevant for production operation of Zino.  This switches to using the Zino 1 legacy protocol implementation.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
