### PR TITLE
Make `BGPPeerSession` fields optional

### DIFF
--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -108,9 +108,9 @@ class Port(BaseModel):
 class BGPPeerSession(BaseModel):
     """Keeps a BGP peer session"""
 
-    uptime: int
-    admin_status: BGPAdminStatus
-    oper_state: BGPOperState
+    uptime: Optional[int] = 0
+    admin_status: Optional[BGPAdminStatus] = None
+    oper_state: Optional[BGPOperState] = None
 
 
 class DeviceState(BaseModel):


### PR DESCRIPTION
## Scope and purpose

All the values associated with a BGP peering session aren't necessarily always available to us.

Case in point:  If a BGP transition trap is received, it will only contain a peer IP address and the new operational state value of the peering session.  We might not yet have learned the full details of the peering session through SNMP, but now we want to register the operational state of this session, having no idea what the uptime or administrative state is.  In order to be able to at least store an operational state value, the other attributes of a session need to be optional.

This therefore makes all the fields optional.

This requirement was discovered during the implementation of #288 and also #174 (since not all these variables are necessarily present in a Zino 1 state dump either)

### This pull request
* makes some internal state variables optional


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * Don't think we need one.  This shouldn't affect anyone, but adds value for developers.
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
