### PR TITLE
Fix test to only assert top level commands in HELP

### DIFF
--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -180,6 +180,9 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
             for name, responder in eligible.items()
         }
 
+    def _get_top_level_responders(self) -> dict[str, Responder]:
+        return {name: responder for name, responder in self._responders.items() if " " not in responder.name}
+
     def _read_multiline(self) -> asyncio.Future:
         """Sets the protocol in multline input mode and returns a Future that will trigger once multi-line input is
         complete.
@@ -236,10 +239,10 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
 
     async def do_help(self):
         """Lists all available top-level API commands"""
-        top_level_responders = (responder for responder in self._responders.values() if " " not in responder.name)
+        top_level_responders = self._get_top_level_responders()
         authorized_responders = (
             responder
-            for responder in top_level_responders
+            for responder in top_level_responders.values()
             if self.is_authenticated or not getattr(responder.function, "requires_authentication", False)
         )
 

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -341,7 +341,7 @@ class TestZino1ServerProtocolQuitCommand:
 
 class TestZino1ServerProtocolHelpCommand:
     @pytest.mark.asyncio
-    async def test_when_unauthenticated_help_is_issued_then_unauthenticated_commands_should_be_listed(
+    async def test_when_unauthenticated_help_is_issued_then_unauthenticated_top_level_commands_should_be_listed(
         self, buffered_fake_transport
     ):
         protocol = Zino1ServerProtocol()
@@ -351,7 +351,7 @@ class TestZino1ServerProtocolHelpCommand:
 
         all_unauthenticated_command_names = set(
             name
-            for name, responder in protocol._responders.items()
+            for name, responder in protocol._get_top_level_responders().items()
             if not getattr(responder.function, "requires_authentication", False)
         )
         for command_name in all_unauthenticated_command_names:
@@ -360,10 +360,12 @@ class TestZino1ServerProtocolHelpCommand:
             ), f"{command_name} is not listed in HELP"
 
     @pytest.mark.asyncio
-    async def test_when_authenticated_help_is_issued_then_all_commands_should_be_listed(self, authenticated_protocol):
+    async def test_when_authenticated_help_is_issued_then_all_top_level_commands_should_be_listed(
+        self, authenticated_protocol
+    ):
         await authenticated_protocol.message_received("HELP")
 
-        all_command_names = set(authenticated_protocol._get_all_responders())
+        all_command_names = set(authenticated_protocol._get_top_level_responders())
         for command_name in all_command_names:
             assert (
                 command_name.encode() in authenticated_protocol.transport.data_buffer.getvalue()


### PR DESCRIPTION
## Scope and purpose

Only top-level commands should be shown in HELP. This test would fail if a command `BLIPP BLAPP` was added, since the `do_help` function will not include subcommands (which is the correct behaviour).

`BLIPP`should be added to help, but this can be done "manually" by making a `do_blipp` as well as `do_blipp_blapp`, which would say something like "Invalid blipp command"



Add a description of what this PR does and why it is needed. If a linked ticket(s) fully
cover it, you can omit this.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
