### PR TITLE
Add PM subcommands to legacy API

### DIFF
--- a/changelog.d/298.added.md
+++ b/changelog.d/298.added.md
@@ -1,0 +1,1 @@
+Added the PM family of API commands to manipulate planned maintenance

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -525,6 +525,16 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         )
         self._respond(200, f"PM id {pm.id} successfully added")
 
+    @requires_authentication
+    @_translate_pm_id_to_pm
+    async def do_pm_matching(self, pm: PlannedMaintenance):
+        matches = pm.get_matching(self._state)
+        self._respond(300, "Matching ports/devices follows, terminated with '.'")
+        for match in matches:
+            output = " ".join(str(i) for i in match)
+            self._respond_raw(output)
+        self._respond_raw(".")
+
 
 class ZinoTestProtocol(Zino1ServerProtocol):
     """Extended Zino 1 server protocol with test commands added in"""

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -17,7 +17,7 @@ from zino import version
 from zino.api import auth
 from zino.api.notify import Zino1NotificationProtocol
 from zino.state import ZinoState, config
-from zino.statemodels import ClosedEventError, Event, EventState
+from zino.statemodels import ClosedEventError, Event, EventState, PlannedMaintenance
 
 if TYPE_CHECKING:
     from zino.api.server import ZinoServer
@@ -413,6 +413,12 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         for id in self._state.planned_maintenances.planned_maintenances:
             self._respond_raw(id)
         self._respond_raw(".")
+
+    @requires_authentication
+    @_translate_pm_id_to_pm
+    async def do_pm_cancel(self, pm: PlannedMaintenance):
+        self._state.planned_maintenances.close_planned_maintenance(pm.id, "PM cancelled", self.user)
+        self._respond_ok()
 
 
 class ZinoTestProtocol(Zino1ServerProtocol):

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -408,6 +408,21 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         return _verify
 
     @requires_authentication
+    async def do_pm(self):
+        """Implements the top-level PM command.
+
+        In the original Zino, this has its own dispatcher, and calling it without arguments only results an error.
+        """
+        return self._respond_error("PM command requires a subcommand")
+
+    @requires_authentication
+    async def do_pm_help(self):
+        """Lists all available PM sub-commands"""
+        responders = (responder for name, responder in self._responders.items() if responder.name.startswith("PM "))
+        commands = " ".join(sorted(responder.name.removeprefix("PM ") for responder in responders))
+        self._respond_multiline(200, ["PM subcommands are:"] + textwrap.wrap(commands, width=56))
+
+    @requires_authentication
     async def do_pm_list(self):
         self._respond(300, "PM event ids follows, terminated with '.'")
         for id in self._state.planned_maintenances.planned_maintenances:

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -420,6 +420,15 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         self._state.planned_maintenances.close_planned_maintenance(pm.id, "PM cancelled", self.user)
         self._respond_ok()
 
+    @requires_authentication
+    @_translate_pm_id_to_pm
+    async def do_pm_addlog(self, pm: PlannedMaintenance):
+        self._respond(302, "please provide new PM log entry, terminate with '.'")
+        data = await self._read_multiline()
+        message = f"{self.user}\n" + "\n".join(line.strip() for line in data)
+        pm.add_log(message)
+        self._respond_ok()
+
 
 class ZinoTestProtocol(Zino1ServerProtocol):
     """Extended Zino 1 server protocol with test commands added in"""

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -438,6 +438,11 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
                 self._respond_raw(line)
         self._respond_raw(".")
 
+    @requires_authentication
+    @_translate_pm_id_to_pm
+    async def do_pm_details(self, pm: PlannedMaintenance):
+        self._respond(200, pm.details())
+
 
 class ZinoTestProtocol(Zino1ServerProtocol):
     """Extended Zino 1 server protocol with test commands added in"""

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -429,6 +429,15 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         pm.add_log(message)
         self._respond_ok()
 
+    @requires_authentication
+    @_translate_pm_id_to_pm
+    async def do_pm_log(self, pm: PlannedMaintenance):
+        self._respond(300, "log follows, terminated with '.'")
+        for log in pm.log:
+            for line in log.model_dump_legacy():
+                self._respond_raw(line)
+        self._respond_raw(".")
+
 
 class ZinoTestProtocol(Zino1ServerProtocol):
     """Extended Zino 1 server protocol with test commands added in"""

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -388,6 +388,13 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
 
         return self._respond_ok()
 
+    @requires_authentication
+    async def do_pm_list(self):
+        self._respond(300, "PM event ids follows, terminated with '.'")
+        for id in self._state.planned_maintenances.planned_maintenances:
+            self._respond_raw(id)
+        self._respond_raw(".")
+
 
 class ZinoTestProtocol(Zino1ServerProtocol):
     """Extended Zino 1 server protocol with test commands added in"""

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -428,6 +428,25 @@ class PlannedMaintenance(BaseModel):
         self.log.append(entry)
         return entry
 
+    def details(self) -> str:
+        """Returns a string with the details of the object.
+        Format from zino1: $id $from_t $to_t $type $match_type [$match_dev] $match_expr
+        """
+        details = [
+            str(int(attr.timestamp())) if isinstance(attr, datetime.datetime) else str(attr)
+            for attr in [
+                self.id,
+                self.start_time,
+                self.end_time,
+                self.type,
+                self.match_type,
+                self.match_device,
+                self.match_expression,
+            ]
+            if attr
+        ]
+        return " ".join(details)
+
     def matches_event(self, event: Event, state: "ZinoState") -> bool:
         """Returns true if `event` will be affected by this planned maintenance"""
         raise NotImplementedError

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -705,6 +705,32 @@ class TestZino1TestProtocol:
         assert b"200 ok" in buffered_fake_transport.data_buffer.getvalue()
 
 
+class TestZino1ServerProtocolPmCommand:
+    @pytest.mark.asyncio
+    async def test_it_should_always_return_a_500_error(self, authenticated_protocol):
+        await authenticated_protocol.message_received("PM")
+
+        assert b"500 " in authenticated_protocol.transport.data_buffer.getvalue()
+
+
+class TestZino1ServerProtocolPmHelpCommand:
+    @pytest.mark.asyncio
+    async def test_when_authenticated_pm_help_is_issued_then_all_pm_subcommands_should_be_listed(
+        self, authenticated_protocol
+    ):
+        await authenticated_protocol.message_received("PM HELP")
+
+        all_command_names = set(
+            responder.name.removeprefix("PM ")
+            for responder in authenticated_protocol._responders.values()
+            if responder.name.startswith("PM ")
+        )
+        for command_name in all_command_names:
+            assert (
+                command_name.encode() in authenticated_protocol.transport.data_buffer.getvalue()
+            ), f"{command_name} is not listed in PM HELP"
+
+
 class TestZino1ServerProtocolPmListCommand:
     @pytest.mark.asyncio
     async def test_when_authenticated_should_list_all_pm_ids(self, authenticated_protocol):


### PR DESCRIPTION
## Scope and purpose

Fixes #101

Adds Planned maintenance subcommands to the legacy API

<!-- remove things that do not apply -->
### This pull request
* changes the API
* adds missing methods to Planned Maintenance data models
* adds support for variable number of arguments to API command responders


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
  * [ ] #307 
 
<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
