### PR TITLE
Change naive `TrapMessage.variables` definition

### DIFF
--- a/src/zino/trapd.py
+++ b/src/zino/trapd.py
@@ -50,12 +50,22 @@ class TrapMessage:
     agent: TrapOriginator
     mib: Optional[str] = None
     name: Optional[str] = None
-    variables: dict[str, TrapVarBind] = field(default_factory=dict)
+    variables: List[TrapVarBind] = field(default_factory=list)
 
     def __str__(self):
-        variables = [f"{v.mib}::{v.var}{v.instance or ''}={v.value or v.raw_value}" for v in self.variables.values()]
+        variables = [f"{v.mib}::{v.var}{v.instance or ''}={v.value or v.raw_value}" for v in self.variables]
         variables = ", ".join(variables)
         return f"<Trap from {self.agent.device.name}: {variables}>"
+
+    def __contains__(self, label) -> bool:
+        for var in self.variables:
+            if var.var == label:
+                return True
+        return False
+
+    def get_all(self, label: str) -> List[TrapVarBind]:
+        """Returns all contained variables with the given label"""
+        return [var for var in self.variables if var.var == label]
 
 
 class TrapObserver:

--- a/src/zino/trapobservers/link_traps.py
+++ b/src/zino/trapobservers/link_traps.py
@@ -28,10 +28,10 @@ class LinkTrapObserver(TrapObserver):
         self._last_same_trap: dict[Tuple[str, int], datetime] = {}
 
     def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
-        _logger.debug("%s: %s (vars: %s)", trap.agent.device.name, trap.name, ", ".join(trap.variables))
+        _logger.debug("%s: %s (vars: %s)", trap.agent.device.name, trap.name, ", ".join(v.var for v in trap.variables))
 
-        if "ifIndex" in trap.variables:
-            ifindex = trap.variables.get("ifIndex").value
+        if "ifIndex" in trap:
+            ifindex = trap.get_all("ifIndex")[0].value
         else:
             _logger.warning("%s: %s trap contained no ifIndex value, ignoring", trap.agent.device.name, trap.name)
             return False

--- a/tests/trapd_test.py
+++ b/tests/trapd_test.py
@@ -30,26 +30,30 @@ class TestTrapReceiver:
     @pytest.mark.asyncio
     async def test_when_trap_lacks_trap_oid_it_should_be_ignored(self, localhost_receiver):
         trap = TrapMessage(agent=TrapOriginator(address=ipaddress.ip_address("127.0.0.1"), port=666))
-        trap.variables["sysUpTime"] = TrapVarBind(
-            oid=OID(".1.3.6.1.2.1.1.3.0"),
-            mib="SNMPv2-MIB",
-            var="sysUpTime",
-            instance=OID(".0"),
-            raw_value=None,
-            value=123,
+        trap.variables.append(
+            TrapVarBind(
+                oid=OID(".1.3.6.1.2.1.1.3.0"),
+                mib="SNMPv2-MIB",
+                var="sysUpTime",
+                instance=OID(".0"),
+                raw_value=None,
+                value=123,
+            )
         )
         assert not TrapReceiver._verify_trap(trap)
 
     @pytest.mark.asyncio
     async def test_when_trap_lacks_sysuptime_it_should_be_ignored(self, localhost_receiver):
         trap = TrapMessage(agent=TrapOriginator(address=ipaddress.ip_address("127.0.0.1"), port=666))
-        trap.variables["snmpTrapOID"] = TrapVarBind(
-            oid=OID(".1.3.6.1.6.3.1.1.4.1"),
-            mib="SNMPv2-MIB",
-            var="snmpTrapOID",
-            instance=None,
-            raw_value=OID(".1.1.1"),
-            value=("FAKE-MIB", "fakeTrap"),
+        trap.variables.append(
+            TrapVarBind(
+                oid=OID(".1.3.6.1.6.3.1.1.4.1"),
+                mib="SNMPv2-MIB",
+                var="snmpTrapOID",
+                instance=None,
+                raw_value=OID(".1.1.1"),
+                value=("FAKE-MIB", "fakeTrap"),
+            )
         )
         assert not TrapReceiver._verify_trap(trap)
 
@@ -152,7 +156,7 @@ class TestTrapReceiverExternally:
                 await send_trap_externally(OID_COLD_START, OID_SYSNAME_0, "s", "'MockDevice'")
                 assert mock_dispatch.called
                 trap = mock_dispatch.call_args.args[0]
-                assert all(var.value is None for var in trap.variables.values())
+                assert all(var.value is None for var in trap.variables)
 
     @pytest.mark.asyncio
     async def test_when_trap_verification_fails_it_should_not_dispatch_trap(self, localhost_receiver):

--- a/tests/trapobservers/link_traps_test.py
+++ b/tests/trapobservers/link_traps_test.py
@@ -6,6 +6,7 @@ import pytest
 from zino.config.models import PollDevice
 from zino.statemodels import InterfaceState, Port, PortStateEvent
 from zino.time import now
+from zino.trapd import TrapMessage
 from zino.trapobservers.link_traps import LinkTrapObserver
 
 from .. import trapd_test
@@ -103,7 +104,7 @@ class TestLinkTrapObserver:
 
     def test_when_link_trap_is_missing_ifindex_value_it_should_ignore_trap_early(self, state_with_localhost_with_port):
         observer = LinkTrapObserver(state=state_with_localhost_with_port, polldevs=Mock())
-        trap = Mock(variables={})
+        trap = TrapMessage(agent=Mock())
         with patch.object(observer, "handle_link_transition") as handle_link_transition:
             assert not observer.handle_trap(trap)
             assert not handle_link_transition.called, "handle_link_transition was called"
@@ -111,7 +112,7 @@ class TestLinkTrapObserver:
     def test_when_link_trap_refers_to_unknown_port_it_should_ignore_trap_early(self, state_with_localhost_with_port):
         observer = LinkTrapObserver(state=state_with_localhost_with_port, polldevs=Mock())
         localhost = state_with_localhost_with_port.devices.devices["localhost"]
-        trap = Mock(agent=Mock(device=localhost), variables={"ifIndex": Mock(value=99)})
+        trap = TrapMessage(agent=Mock(device=localhost), variables=[Mock(var="ifIndex", value=99)])
         with patch.object(observer, "handle_link_transition") as handle_link_transition:
             assert not observer.handle_trap(trap)
             assert not handle_link_transition.called, "handle_link_transition was called"


### PR DESCRIPTION
## Scope and purpose

`TrapMessage.variables` was naively built as a dictionary to look up individual trap variables by simple object labels, as we wanted to easily look up variables in a trap.

However, this implementation turned out to be too naive, because a trap can contain any number of variables that have the same object label but different instance numbers (e.g. it can contain all of `ifOperStatus.1`, `ifOperStatus.2`, `ifOperStatus.3` and so on).  The naive implementation would overwrite each successive variable in the variables dict using just the name `ifOperStatus`.

This introduces a breaking change to the implementation to be a list of variables, and instead provide convenience methods for common operations: Verify that an object is present at all in the trap, and get the full list of all similarly-named objects from the varbinds.

This issue was discovered during the work of implementing #292 

<!-- remove things that do not apply -->
### This pull request
* changes the `TrapMessage.variables` definition and therefore affects all `TrapObserver` implementations that have not yet been merged.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * This doesn't affect any outward functionality that has been released yet, it only affects ongoing work on `master`
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
