### PR TITLE
Make trap handlers asynchronous

### DIFF
--- a/src/zino/trapobservers/bgp_traps.py
+++ b/src/zino/trapobservers/bgp_traps.py
@@ -34,7 +34,7 @@ class BgpTrapObserver(TrapObserver):
         ("BGP4-V2-MIB-JUNIPER", "jnxBgpM2Established"),
     }
 
-    def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
+    async def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
         try:
             peer, state = self._pre_parse_trap(trap)
         except MissingRequiredTrapVariables:

--- a/src/zino/trapobservers/ignored_traps.py
+++ b/src/zino/trapobservers/ignored_traps.py
@@ -19,5 +19,5 @@ class IgnoreTraps(TrapObserver):
         ("CISCOTRAP-MIB", "tcpConnectionClose"),
     }
 
-    def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
+    async def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
         return False  # Stop processing here!

--- a/src/zino/trapobservers/link_traps.py
+++ b/src/zino/trapobservers/link_traps.py
@@ -27,7 +27,7 @@ class LinkTrapObserver(TrapObserver):
         super().__init__(*args, **kwargs)
         self._last_same_trap: dict[Tuple[str, int], datetime] = {}
 
-    def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
+    async def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
         _logger.debug("%s: %s (vars: %s)", trap.agent.device.name, trap.name, ", ".join(v.var for v in trap.variables))
 
         if "ifIndex" in trap:

--- a/src/zino/trapobservers/logged_traps.py
+++ b/src/zino/trapobservers/logged_traps.py
@@ -14,6 +14,6 @@ class RestartTrapLogger(TrapObserver):
         ("SNMPv2-MIB", "warmStart"),
     }
 
-    def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
+    async def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
         _logger.info("%s: %s", trap.agent.device.name, trap.name)
         return False  # stop trap processing here

--- a/tests/trapd_test.py
+++ b/tests/trapd_test.py
@@ -125,9 +125,13 @@ class TestTrapReceiverExternally:
             assert "mocked exception" in caplog.text
 
     @pytest.mark.asyncio
-    async def test_when_early_observer_returns_false_it_should_not_call_later_observers(self, localhost_receiver):
+    async def test_when_early_observer_returns_false_it_should_not_call_later_observers(
+        self, localhost_receiver, event_loop
+    ):
         early_observer = Mock()
-        early_observer.handle_trap.return_value = False
+        false_result = event_loop.create_future()
+        false_result.set_result(False)
+        early_observer.handle_trap.return_value = false_result
         late_observer = Mock()
         localhost_receiver.observe(early_observer, ("BGP4-MIB", "bgpBackwardTransition"))
         localhost_receiver.observe(late_observer, ("BGP4-MIB", "bgpBackwardTransition"))

--- a/tests/trapobservers/bgp_traps_test.py
+++ b/tests/trapobservers/bgp_traps_test.py
@@ -10,12 +10,15 @@ from zino.trapobservers.bgp_traps import BgpTrapObserver
 
 
 class TestBgpTrapObserver:
-    def test_when_backward_transition_trap_is_received_it_should_change_bgp_peer_state(self, backward_transition_trap):
+    @pytest.mark.asyncio
+    async def test_when_backward_transition_trap_is_received_it_should_change_bgp_peer_state(
+        self, backward_transition_trap
+    ):
         device = backward_transition_trap.agent.device
         peer = next(iter(device.bgp_peers.keys()))
 
         observer = BgpTrapObserver(state=Mock())
-        observer.handle_trap(trap=backward_transition_trap)
+        await observer.handle_trap(trap=backward_transition_trap)
 
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ACTIVE
@@ -56,11 +59,12 @@ class TestBgpTrapObserver:
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ESTABLISHED
 
-    def test_when_established_trap_is_received_it_should_just_log_it(self, established_trap, caplog):
+    @pytest.mark.asyncio
+    async def test_when_established_trap_is_received_it_should_just_log_it(self, established_trap, caplog):
         """This requirement is disputed until Håvard E confirms it"""
         observer = BgpTrapObserver(state=Mock())
         with caplog.at_level(logging.INFO):
-            observer.handle_trap(trap=established_trap)
+            await observer.handle_trap(trap=established_trap)
             assert "BGP peer up" in caplog.text
 
     def test_when_trap_is_unknown_it_should_pass_it_on(self, established_trap):

--- a/tests/trapobservers/ignored_traps_test.py
+++ b/tests/trapobservers/ignored_traps_test.py
@@ -1,9 +1,12 @@
 from unittest.mock import Mock
 
+import pytest
+
 from zino.trapobservers.ignored_traps import IgnoreTraps
 
 
 class TestIgnoreTraps:
-    def test_when_handle_trap_is_called_it_should_return_false(self):
+    @pytest.mark.asyncio
+    async def test_when_handle_trap_is_called_it_should_return_false(self):
         observer = IgnoreTraps(state=Mock())
-        assert not observer.handle_trap(trap=Mock())
+        assert not await observer.handle_trap(trap=Mock())

--- a/tests/trapobservers/link_traps_test.py
+++ b/tests/trapobservers/link_traps_test.py
@@ -102,19 +102,25 @@ class TestLinkTrapObserver:
             localhost, localhost.ports[1], is_up=False
         ), "did not ignore redundant linkDown trap"
 
-    def test_when_link_trap_is_missing_ifindex_value_it_should_ignore_trap_early(self, state_with_localhost_with_port):
+    @pytest.mark.asyncio
+    async def test_when_link_trap_is_missing_ifindex_value_it_should_ignore_trap_early(
+        self, state_with_localhost_with_port
+    ):
         observer = LinkTrapObserver(state=state_with_localhost_with_port, polldevs=Mock())
         trap = TrapMessage(agent=Mock())
         with patch.object(observer, "handle_link_transition") as handle_link_transition:
-            assert not observer.handle_trap(trap)
+            assert not await observer.handle_trap(trap)
             assert not handle_link_transition.called, "handle_link_transition was called"
 
-    def test_when_link_trap_refers_to_unknown_port_it_should_ignore_trap_early(self, state_with_localhost_with_port):
+    @pytest.mark.asyncio
+    async def test_when_link_trap_refers_to_unknown_port_it_should_ignore_trap_early(
+        self, state_with_localhost_with_port
+    ):
         observer = LinkTrapObserver(state=state_with_localhost_with_port, polldevs=Mock())
         localhost = state_with_localhost_with_port.devices.devices["localhost"]
         trap = TrapMessage(agent=Mock(device=localhost), variables=[Mock(var="ifIndex", value=99)])
         with patch.object(observer, "handle_link_transition") as handle_link_transition:
-            assert not observer.handle_trap(trap)
+            assert not await observer.handle_trap(trap)
             assert not handle_link_transition.called, "handle_link_transition was called"
 
 

--- a/tests/trapobservers/logged_traps_test.py
+++ b/tests/trapobservers/logged_traps_test.py
@@ -9,9 +9,12 @@ from zino.trapobservers.logged_traps import RestartTrapLogger
 
 class TestRestartTrapLogger:
     @pytest.mark.parametrize("trap_name", ["coldStart", "warmStart"])
-    def test_when_handle_trap_is_called_it_should_log_trap_name(self, caplog, localhost_trap_originator, trap_name):
+    @pytest.mark.asyncio
+    async def test_when_handle_trap_is_called_it_should_log_trap_name(
+        self, caplog, localhost_trap_originator, trap_name
+    ):
         observer = RestartTrapLogger(state=Mock())
         trap = TrapMessage(agent=localhost_trap_originator, mib="SNMPv2-MIB", name=trap_name)
         with caplog.at_level(logging.INFO):
-            observer.handle_trap(trap=trap)
+            await observer.handle_trap(trap=trap)
             assert f"localhost: {trap_name}" in caplog.text


### PR DESCRIPTION
## Scope and purpose

Trap handlers are all executed from a synchronous trap callback handler.  This makes it hard for trap handlers to work with async code, like calling out to make further SNMP queries and wait for the results.

This changes `TrapObserver.handle_trap` to be async, and updates the `TrapReceiver` class to ensure trap handlers are called asynchronously.  Trap tests are updated to ensure they operate asynchronously.


<!-- remove things that do not apply -->
### This pull request
* Changes the `TrapObserver.handle_trap()` signature to async


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * Don't think this is necessary.  This changes nothing user-facing and does not change any code or interfaces that have been part of a release.
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
