### PR TITLE
Add support for multi-varbind SNMP-GET operations

### DIFF
--- a/changelog.d/303.added.md
+++ b/changelog.d/303.added.md
@@ -1,0 +1,1 @@
+Fully support multi-varbind SNMP-GET operations

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -55,6 +55,13 @@ class TestSNMPRequestsResponseTypes:
         assert isinstance(response.value, int)
 
     @pytest.mark.asyncio
+    async def test_get2_should_return_symbolic_identifiers(self, snmp_client):
+        response = await snmp_client.get2(("IF-MIB", "ifName", 1), ("IF-MIB", "ifAlias", 1))
+        assert len(list(response)) == 2
+        assert any(identifier == Identifier("IF-MIB", "ifName", OID(".1")) for identifier, _ in response)
+        assert any(identifier == Identifier("IF-MIB", "ifAlias", OID(".1")) for identifier, _ in response)
+
+    @pytest.mark.asyncio
     async def test_getnext(self, snmp_client):
         response = await snmp_client.getnext("SNMPv2-MIB", "sysUpTime")
         assert isinstance(response.oid, OID)

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -62,6 +62,11 @@ class TestSNMPRequestsResponseTypes:
         assert any(identifier == Identifier("IF-MIB", "ifAlias", OID(".1")) for identifier, _ in response)
 
     @pytest.mark.asyncio
+    async def test_when_mib_is_unkown_get2_should_raise_mibnotfounderror(self, snmp_client):
+        with pytest.raises(MibNotFoundError):
+            await snmp_client.get2(("FOOBAR-MIB", "ifName", 1), ("FOOBAR-MIB", "ifAlias", 1))
+
+    @pytest.mark.asyncio
     async def test_getnext(self, snmp_client):
         response = await snmp_client.getnext("SNMPv2-MIB", "sysUpTime")
         assert isinstance(response.oid, OID)


### PR DESCRIPTION
## Scope and purpose

Following the pattern of `SNMP.getnext2()` and `SNMP.getbulk2()`, this adds `SNMP.get2()` which provides a more "advanced" usage than its `get()` counterpart, allowing single GET queries for multiple variables.

This becomes necessary for fully developing #292

<!-- remove things that do not apply -->
### This pull request
* Adds `get2()` method to the `SNMP` class.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
