### PR TITLE
Implement a `BFDTrapObserver`

### DIFF
--- a/changelog.d/305.added.md
+++ b/changelog.d/305.added.md
@@ -1,0 +1,1 @@
+Act to update BFD session information on incoming BFD session traps

--- a/src/zino/tasks/bfdtask.py
+++ b/src/zino/tasks/bfdtask.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict
+from typing import Dict, Sequence
 
 from zino.oid import OID
 from zino.scheduler import get_scheduler
@@ -35,12 +35,15 @@ class BFDTask(Task):
         super().__init__(*args, **kwargs)
         self._scheduler = get_scheduler()
 
-    async def run(self):
+    async def run(self, session_index: int = None):
+        """Polls data for all BFD sessions.  If session_index is provided, only that session is polled."""
+        msg = f" for session index {session_index}" if session_index is not None else ""
+        _log.debug("%s: polling BFD data%s", self.device.name, msg)
         if self.device_state.is_juniper:
-            polled_state = await self._poll_juniper()
+            polled_state = await self._poll_juniper(session_index)
             await self._update_state_for_all_ports_juniper(polled_state)
         elif self.device_state.is_cisco:
-            polled_state = await self._poll_cisco()
+            polled_state = await self._poll_cisco(session_index)
             await self._update_state_for_all_ports_cisco(polled_state)
 
     async def _update_state_for_all_ports_juniper(self, polled_state: DescrBFDStates):
@@ -84,8 +87,12 @@ class BFDTask(Task):
         event.add_log(f"Port {port.ifdescr}" + log)
         self.state.events.commit(event)
 
-    async def _poll_juniper(self) -> DescrBFDStates:
-        bfd_rows = await self.snmp.sparsewalk(*self.JUNIPER_BFD_COLUMNS)
+    async def _poll_juniper(self, session_index: int = None) -> DescrBFDStates:
+        if session_index is None:
+            bfd_rows = await self.snmp.sparsewalk(*self.JUNIPER_BFD_COLUMNS)
+        else:
+            bfd_rows = await self._get_single_row(session_index, *self.JUNIPER_BFD_COLUMNS)
+
         bfd_states = self._parse_juniper_rows(bfd_rows)
         return bfd_states
 
@@ -103,8 +110,12 @@ class BFDTask(Task):
             bfd_states[interface_name] = bfd_state
         return bfd_states
 
-    async def _poll_cisco(self) -> IndexBFDStates:
-        bfd_rows = await self.snmp.sparsewalk(*self.CISCO_BFD_COLUMNS)
+    async def _poll_cisco(self, session_index: int = None) -> IndexBFDStates:
+        if session_index is None:
+            bfd_rows = await self.snmp.sparsewalk(*self.CISCO_BFD_COLUMNS)
+        else:
+            bfd_rows = self._get_single_row(session_index, *self.CISCO_BFD_COLUMNS)
+
         bfd_states = self._parse_cisco_rows(bfd_rows)
         return bfd_states
 
@@ -121,6 +132,15 @@ class BFDTask(Task):
             )
             bfd_states[ifindex] = bfd_state
         return bfd_states
+
+    async def _get_single_row(self, session_index: int, *variables: Sequence[str]) -> SparseWalkResponse:
+        """Fetches a single row of BFD data for a specific session index using SNMP-GET, and returns a simulated
+        SparseWalkResponse for the single row.
+        """
+        columns = [var + (session_index,) for var in variables]
+        response = await self.snmp.get2(*columns)
+        row = {var.object: val for var, val in response}
+        return {OID((session_index,)): row}
 
     def _parse_row(self, index: OID, state: str, discr: int, addr: str) -> BFDState:
         try:

--- a/src/zino/trapobservers/bfd_traps.py
+++ b/src/zino/trapobservers/bfd_traps.py
@@ -1,0 +1,65 @@
+"""This module implements handling of BFD session traps.
+
+bfdSessUp and bfdSessDown traps only tell which BFD sessions have changed state and why, but does not actually include
+the new state value for the session.  This means most of this observer's work is to just kick off a BFDTask to poll the
+individual session(s) that have changed state and ensure state and events are updated accordingly.
+
+Example of test trap message:
+
+ snmptrap -v 2c -c public localhost:1162 "" \
+     BFD-STD-MIB::bfdSessDown \
+     BFD-STD-MIB::bfdSessDiag.1 u 5 \
+     BFD-STD-MIB::bfdSessDiag.5 u 5
+
+"""
+
+import logging
+from pprint import pformat
+from typing import Optional
+
+from zino.tasks.bfdtask import BFDTask
+from zino.trapd import TrapMessage, TrapObserver
+
+_logger = logging.getLogger(__name__)
+
+
+class BFDTrapObserver(TrapObserver):
+    WANTED_TRAPS = {
+        ("BFD-STD-MIB", "bfdSessUp"),
+        ("BFD-STD-MIB", "bfdSessDown"),
+    }
+
+    async def handle_trap(self, trap: TrapMessage) -> Optional[bool]:
+        try:
+            affected_indexes = self._parse_trap(trap)
+        except ValueError:
+            return
+
+        device = trap.agent.device
+        polldev = self.polldevs.get(device.name)
+        if not polldev:
+            _logger.error("%s: No polldevs config, ignoring BFD trap", device.name)
+            return False
+
+        updater = BFDTask(device=polldev, state=self.state)
+        for bfd_session_index in affected_indexes:
+            await updater.run(bfd_session_index)
+
+        return False
+
+    def _parse_trap(self, trap: TrapMessage) -> range:
+        _logger.debug("%s: %s variables:\n%s", trap.agent.device.name, trap.name, pformat(trap.variables))
+
+        bfd_sess_diags = trap.get_all("bfdSessDiag")
+        if len(bfd_sess_diags) < 2:
+            msg = f"{trap.agent.device.name} sent malformed BFD trap (less than two bfdSessDiag values)"
+            _logger.error(msg)
+            raise ValueError(msg)
+
+        lower_index = min(var.instance[0] for var in bfd_sess_diags)
+        upper_index = max(var.instance[0] for var in bfd_sess_diags)
+        _logger.debug(
+            "%s: BFD session %s affects indexes %s..%s", trap.agent.device.name, trap.name, lower_index, upper_index
+        )
+        affected_indexes = range(lower_index, upper_index + 1)
+        return affected_indexes

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -23,6 +23,7 @@ from zino.trapd import TrapReceiver
 
 # ensure all our desired trap observers are loaded.  They will not be explicitly referenced here, hence the noqa tag
 from zino.trapobservers import (  # noqa
+    bfd_traps,
     bgp_traps,
     ignored_traps,
     link_traps,

--- a/tests/tasks/test_bfdtask.py
+++ b/tests/tasks/test_bfdtask.py
@@ -28,6 +28,16 @@ class TestJuniper:
         state = result.get(device_port.ifdescr)
         assert state == bfd_state
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("task", ["juniper-bfd-up"], indirect=True)
+    async def test_when_single_index_is_given_then_poll_juniper_should_return_correct_ifdescr_to_state_mapping(
+        self, task, bfd_state, device_port
+    ):
+        result = await task._poll_juniper(session_index=bfd_state.session_index)
+        assert device_port.ifdescr in result
+        state = result.get(device_port.ifdescr)
+        assert state == bfd_state
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("task", ["juniper-bfd-up", "cisco-bfd-up"], indirect=True)

--- a/tests/trapobservers/bfd_traps_test.py
+++ b/tests/trapobservers/bfd_traps_test.py
@@ -1,0 +1,85 @@
+import ipaddress
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from zino.config.models import PollDevice
+from zino.oid import OID
+from zino.trapd import TrapMessage
+from zino.trapobservers.bfd_traps import BFDTrapObserver
+
+
+class TestBFDTrapObserver:
+    @pytest.mark.asyncio
+    async def test_when_bfd_trap_is_received_it_should_poll_all_affected_sessions(
+        self, bfd_session_down_trap, monkeypatch, event_loop
+    ):
+        device = bfd_session_down_trap.agent.device
+        polldevs_dict = {device.name: PollDevice(name=device.name, address=ipaddress.IPv4Address("127.0.0.1"))}
+        called_future = event_loop.create_future()
+        called_future.set_result(None)
+        bfdtask_run = Mock(return_value=called_future)
+        monkeypatch.setattr("zino.tasks.bfdtask.BFDTask.run", bfdtask_run)
+
+        observer = BFDTrapObserver(state=Mock(), polldevs=polldevs_dict)
+        await observer.handle_trap(trap=bfd_session_down_trap)
+
+        assert bfdtask_run.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_when_polldevs_config_is_missing_it_should_do_nothing(
+        self, bfd_session_down_trap, monkeypatch, event_loop
+    ):
+        called_future = event_loop.create_future()
+        called_future.set_result(None)
+        bfdtask_run = Mock(return_value=called_future)
+        monkeypatch.setattr("zino.tasks.bfdtask.BFDTask.run", bfdtask_run)
+
+        observer = BFDTrapObserver(state=Mock(), polldevs={})
+        await observer.handle_trap(trap=bfd_session_down_trap)
+
+        assert bfdtask_run.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_when_malformed_bfd_trap_is_received_it_should_log_and_return(
+        self,
+        malformed_bfd_session_down_trap,
+        monkeypatch,
+        event_loop,
+        caplog,
+    ):
+        device = malformed_bfd_session_down_trap.agent.device
+        polldevs_dict = {device.name: PollDevice(name=device.name, address=ipaddress.IPv4Address("127.0.0.1"))}
+        called_future = event_loop.create_future()
+        called_future.set_result(None)
+        bfdtask_run = Mock(return_value=called_future)
+        monkeypatch.setattr("zino.tasks.bfdtask.BFDTask.run", bfdtask_run)
+
+        observer = BFDTrapObserver(state=Mock(), polldevs=polldevs_dict)
+        with caplog.at_level(logging.INFO):
+            await observer.handle_trap(trap=malformed_bfd_session_down_trap)
+            assert "malformed" in caplog.text
+
+        assert bfdtask_run.call_count == 0
+
+
+@pytest.fixture
+def bfd_session_down_trap(localhost_trap_originator) -> TrapMessage:
+    """Returns a correct BFD session-down trap for 4 sessions, with internal state to match"""
+    trap = TrapMessage(agent=localhost_trap_originator, mib="BGP4-V2-MIB-JUNIPER", name="bfdSessDown")
+    trap.variables = [
+        Mock(var="bfdSessDiag", instance=OID(".42"), value="pathDown"),
+        Mock(var="bfdSessDiag", instance=OID(".45"), value="pathDown"),
+    ]
+    return trap
+
+
+@pytest.fixture
+def malformed_bfd_session_down_trap(localhost_trap_originator) -> TrapMessage:
+    """Returns a BFD session-down trap with only a single bfdSessDiag value"""
+    trap = TrapMessage(agent=localhost_trap_originator, mib="BGP4-V2-MIB-JUNIPER", name="bfdSessDown")
+    trap.variables = [
+        Mock(var="bfdSessDiag", instance=OID(".42"), value="pathDown"),
+    ]
+    return trap


### PR DESCRIPTION
## Scope and purpose

Fixes #292.  Dependent on #303 to be merged first.

`bfdSessUp` and `bfdSessDown` traps only tell which BFD sessions have changed state and why, but does not actually include the new state value for the session.  This means most of this new observer's work is to just offload everything to `BFDTask` to poll the individual session(s) that have changed state and ensure state and events are updated accordingly.

<!-- remove things that do not apply -->
### This pull request

* Adds a new BFD Trap observer to the default Zino trap listener setup.
* Adds the optional ability for the existing `BFDTask` to fetch and update single BFD sessions, used by the trap observer.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
