### PR TITLE
Fix incorrect timezone-naive datetimes

### DIFF
--- a/src/zino/planned_maintenance.py
+++ b/src/zino/planned_maintenance.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Dict, Optional, Protocol, Union
 
 from pydantic.main import BaseModel
@@ -12,6 +12,7 @@ from zino.statemodels import (
     PlannedMaintenance,
     PortStateMaintenance,
 )
+from zino.time import now as utcnow
 
 if TYPE_CHECKING:
     from zino.state import ZinoState
@@ -31,7 +32,7 @@ class PlannedMaintenanceObserver(Protocol):
 class PlannedMaintenances(BaseModel):
     planned_maintenances: Dict[int, Union[DeviceMaintenance, PortStateMaintenance]] = {}
     last_pm_id: int = 0
-    last_run: Optional[datetime] = datetime.fromtimestamp(0)
+    last_run: Optional[datetime] = datetime.fromtimestamp(0, tz=timezone.utc)
     _observers: list[PlannedMaintenanceObserver] = []
 
     def __getitem__(self, item):
@@ -119,7 +120,7 @@ class PlannedMaintenances(BaseModel):
         """This function starts and stops planned maintenances according to their
         schedule and updates affected events
         """
-        now = datetime.now()
+        now = utcnow()
 
         # Initiate PM once it becomes active
         for started_pm in self.get_started_planned_maintenances(now=now):

--- a/tests/planned_maintenance_test.py
+++ b/tests/planned_maintenance_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -14,6 +14,7 @@ from zino.statemodels import (
     PortStateMaintenance,
     ReachabilityEvent,
 )
+from zino.time import now
 
 
 def test_should_start_with_no_planned_maintenances(pms):
@@ -26,63 +27,63 @@ def test_pm_should_be_gettable_by_id(pms, active_pm):
 
 class TestGetStartedPlannedMaintenances:
     def test_should_return_pms_that_started_since_last_run(self, pms, recent_pm):
-        pms.last_run = datetime.now() - timedelta(hours=1)
-        started_pms = pms.get_started_planned_maintenances(now=datetime.now())
+        pms.last_run = now() - timedelta(hours=1)
+        started_pms = pms.get_started_planned_maintenances(now=now())
         assert recent_pm in started_pms
 
     def test_should_not_return_pms_that_started_before_last_run(self, pms, active_pm):
-        pms.last_run = datetime.now() - timedelta(hours=1)
-        started_pms = pms.get_started_planned_maintenances(now=datetime.now())
+        pms.last_run = now() - timedelta(hours=1)
+        started_pms = pms.get_started_planned_maintenances(now=now())
         assert active_pm not in started_pms
 
     def test_should_not_return_pms_that_have_not_started_yet(self, pms, not_started_pm):
-        pms.last_run = datetime.now() - timedelta(hours=1)
-        started_pms = pms.get_started_planned_maintenances(now=datetime.now())
+        pms.last_run = now() - timedelta(hours=1)
+        started_pms = pms.get_started_planned_maintenances(now=now())
         assert not_started_pm not in started_pms
 
 
 class TestGetEndedPlannedMaintenances:
     def test_should_return_pms_that_ended_after_last_run(self, pms, active_pm, ended_pm, old_pm):
-        pms.last_run = datetime.now() - timedelta(hours=1)
-        ended_pms = pms.get_ended_planned_maintenances(now=datetime.now())
+        pms.last_run = now() - timedelta(hours=1)
+        ended_pms = pms.get_ended_planned_maintenances(now=now())
         assert ended_pm in ended_pms
 
     def test_should_not_return_pms_that_ended_before_last_run(self, pms, old_pm):
-        pms.last_run = datetime.now() - timedelta(hours=1)
-        ended_pms = pms.get_ended_planned_maintenances(now=datetime.now())
+        pms.last_run = now() - timedelta(hours=1)
+        ended_pms = pms.get_ended_planned_maintenances(now=now())
         assert old_pm not in ended_pms
 
     def test_should_not_return_pms_that_have_not_ended(self, pms, active_pm):
-        pms.last_run = datetime.now() - timedelta(hours=1)
-        ended_pms = pms.get_ended_planned_maintenances(now=datetime.now())
+        pms.last_run = now() - timedelta(hours=1)
+        ended_pms = pms.get_ended_planned_maintenances(now=now())
         assert active_pm not in ended_pms
 
 
 class TestGetActivePlannedMaintenances:
     def test_should_return_active_pms(self, pms, active_pm):
-        active_pms = pms.get_active_planned_maintenances(datetime.now())
+        active_pms = pms.get_active_planned_maintenances(now())
         assert active_pm in active_pms
 
     def test_should_not_return_ended_pms(self, pms, ended_pm):
-        active_pms = pms.get_active_planned_maintenances(datetime.now())
+        active_pms = pms.get_active_planned_maintenances(now())
         assert ended_pm not in active_pms
 
     def test_should_not_return_pms_that_have_not_started_yet(self, pms, not_started_pm):
-        active_pms = pms.get_active_planned_maintenances(datetime.now())
+        active_pms = pms.get_active_planned_maintenances(now())
         assert not_started_pm not in active_pms
 
 
 class TestGetOldPlannedMaintenances:
     def test_should_return_old_pms(self, pms, old_pm):
-        old_pms = pms.get_old_planned_maintenances(now=datetime.now())
+        old_pms = pms.get_old_planned_maintenances(now=now())
         assert old_pm in old_pms
 
     def test_should_not_return_pms_that_have_not_ended_yet(self, pms, active_pm):
-        old_pms = pms.get_old_planned_maintenances(now=datetime.now())
+        old_pms = pms.get_old_planned_maintenances(now=now())
         assert active_pm not in old_pms
 
     def test_should_not_return_pms_that_ended_since_last_run(self, pms, ended_pm):
-        old_pms = pms.get_old_planned_maintenances(now=datetime.now())
+        old_pms = pms.get_old_planned_maintenances(now=now())
         assert ended_pm not in old_pms
 
 
@@ -173,8 +174,8 @@ def state(pms):
 @pytest.fixture
 def not_started_pm(pms):
     return pms.create_planned_maintenance(
-        start_time=datetime.now() + timedelta(days=1),
-        end_time=datetime.now() + timedelta(days=2),
+        start_time=now() + timedelta(days=1),
+        end_time=now() + timedelta(days=2),
         pm_class=DeviceMaintenance,
         match_type="exact",
         match_expression="device",
@@ -185,8 +186,8 @@ def not_started_pm(pms):
 @pytest.fixture
 def recent_pm(pms):
     return pms.create_planned_maintenance(
-        start_time=datetime.now() - timedelta(minutes=1),
-        end_time=datetime.now() + timedelta(days=1),
+        start_time=now() - timedelta(minutes=1),
+        end_time=now() + timedelta(days=1),
         pm_class=DeviceMaintenance,
         match_type="str",
         match_expression="hello",
@@ -197,8 +198,8 @@ def recent_pm(pms):
 @pytest.fixture
 def active_pm(pms):
     return pms.create_planned_maintenance(
-        start_time=datetime.now() - timedelta(days=1),
-        end_time=datetime.now() + timedelta(days=1),
+        start_time=now() - timedelta(days=1),
+        end_time=now() + timedelta(days=1),
         pm_class=DeviceMaintenance,
         match_type="exact",
         match_expression="device",
@@ -209,8 +210,8 @@ def active_pm(pms):
 @pytest.fixture
 def active_portstate_pm(pms):
     return pms.create_planned_maintenance(
-        start_time=datetime.now() - timedelta(days=1),
-        end_time=datetime.now() + timedelta(days=1),
+        start_time=now() - timedelta(days=1),
+        end_time=now() + timedelta(days=1),
         pm_class=PortStateMaintenance,
         match_type="regexp",
         match_expression="port",
@@ -221,8 +222,8 @@ def active_portstate_pm(pms):
 @pytest.fixture
 def ended_pm(pms):
     return pms.create_planned_maintenance(
-        start_time=datetime.now() - timedelta(days=1),
-        end_time=datetime.now() - timedelta(minutes=10),
+        start_time=now() - timedelta(days=1),
+        end_time=now() - timedelta(minutes=10),
         pm_class=DeviceMaintenance,
         match_type="exact",
         match_expression="device",
@@ -233,8 +234,8 @@ def ended_pm(pms):
 @pytest.fixture
 def old_pm(pms):
     return pms.create_planned_maintenance(
-        start_time=datetime.now() - timedelta(days=100),
-        end_time=datetime.now() - timedelta(days=99),
+        start_time=now() - timedelta(days=100),
+        end_time=now() - timedelta(days=99),
         pm_class=DeviceMaintenance,
         match_type="exact",
         match_expression="device",


### PR DESCRIPTION
## Scope and purpose

Timezone-naive datetime objects were used in the PlannedMaintenance data structures and methods implemented in #194.  Not sure how I didn't notice this during review.  This leads to very bad behavior once we start comparing with timezone-aware datetime objects.

ALL datetime objects in Zino should be timezone aware.  The internal default should always be the UTC timezone, although the local system timezone can be acceptable in some circumstances.

<!-- remove things that do not apply -->
### This pull request
* Updates all inappropriate usages of `datetime.now()` to either use the existing timezone-aware `zino.time.now()`, or to explicitly add a UTC timezone to the generated datetime object.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * This fixes a bug in code that hasn't been released yet, I don't see the point.
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
