### PR TITLE
Add dummy `CLEARFLAP` API command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ to be ported:
 - Not all SNMP traps are logged in the same detail as in Zino 1.
 - No support for reading trap messages from a trap multiplexer like
   `straps`/`nmtrapd`.
+- The `CLEARFLAP` API command is not yet fully implemented.
 
 Development of Zino 2.0 is fully sponsored by [NORDUnet](https://nordu.net/),
 on behalf of the nordic NRENs.

--- a/changelog.d/+dummy-clearflap.added.md
+++ b/changelog.d/+dummy-clearflap.added.md
@@ -1,0 +1,1 @@
+Added a dummy `CLEARFLAP` API command in order not to crash older clients

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -448,6 +448,22 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
         )
         return self._respond_ok()
 
+    @requires_authentication
+    async def do_clearflap(self, router_name: str, ifindex: Union[str, int]):
+        """Implements a dummy CLEARFLAP command (for now)"""
+        from zino.state import polldevs
+
+        try:
+            _device = polldevs[router_name]
+        except KeyError:
+            return self._respond_error(f"Router {router_name} unknown")
+        try:
+            ifindex = abs(int(ifindex))
+        except ValueError:
+            return self._respond_error(f"{ifindex} is an invalid ifindex value")
+
+        return self._respond_ok("not implemented")
+
     def _translate_pm_id_to_pm(responder: callable):  # noqa
         """Decorates any command that works with planned maintenance adding verification of the
         incoming pm_id argument and translation to an actual PlannedMaintenance object.


### PR DESCRIPTION
## Scope and purpose

There's no time to build a fully functional `CLEARFLAP` command before the next beta release.  This adds a dummy implementation just to ensure older clients do not crash when issuing a non-existant command.

#113 should be fully implemented after the beta release.

<!-- remove things that do not apply -->
### This pull request
* Adds a `CLEARFLAP` command to the API


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
