### PR TITLE
Coerce `BaseBGPRow` attribute values to expected types

### DIFF
--- a/changelog.d/312.fixed.md
+++ b/changelog.d/312.fixed.md
@@ -1,0 +1,1 @@
+Fix BGP-related Pydantic serialization warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "apscheduler",
-    "pydantic>=2",
+    "pydantic>=2.7.0",
     "pysnmplib",
     "pyasn1<0.5.0",
     "aiodns",

--- a/src/zino/tasks/bgpstatemonitortask.py
+++ b/src/zino/tasks/bgpstatemonitortask.py
@@ -265,13 +265,13 @@ class BGPStateMonitorTask(Task):
             _logger.debug(f"Noted external reset for {self.device_state.name}: {data.peer_remote_address}")
         else:
             event = self.state.events.get(self.device.name, data.peer_remote_address, BGPEvent)
-            if event and event.bgpos != "established":
+            if event and event.bgpos != BGPOperState.ESTABLISHED:
                 self._bgp_external_reset(data)
                 _logger.debug(f"BGP session up for {self.device_state.name}: {data.peer_remote_address}")
 
     def _update_nonestablished_peer(self, data: BaseBGPRow, uptime: int):
         saved_bgp_peer_session = self.device_state.bgp_peers.get(data.peer_remote_address)
-        if data.peer_admin_status in ["stop", "halted"]:
+        if data.peer_admin_status in [BGPAdminStatus.STOP, BGPAdminStatus.HALTED]:
             if not saved_bgp_peer_session or saved_bgp_peer_session.admin_status != data.peer_admin_status:
                 self._bgp_admin_down(data)
                 _logger.debug(
@@ -286,7 +286,7 @@ class BGPStateMonitorTask(Task):
     ):
         if not saved_bgp_peer_session or saved_bgp_peer_session.admin_status != data.peer_admin_status:
             self._bgp_admin_up(data)
-        if not saved_bgp_peer_session or saved_bgp_peer_session.oper_state == "established":
+        if not saved_bgp_peer_session or saved_bgp_peer_session.oper_state == BGPOperState.ESTABLISHED:
             # First verify that we've been up longer than the required time before we flag it as an alert
             if uptime > TIME_BEFORE_OPER_DOWN_ALERT:
                 self._bgp_oper_down(data)
@@ -350,10 +350,10 @@ class BGPStateMonitorTask(Task):
     def _bgp_oper_down(self, data: BaseBGPRow):
         event = self.state.events.get_or_create_event(self.device.name, data.peer_remote_address, BGPEvent)
 
-        if event.bgpos == "down":
+        if event.bgpos == BGPOperState.DOWN:
             return
 
-        copied_data = replace(data, peer_state="down")
+        copied_data = replace(data, peer_state=BGPOperState.DOWN)
         event = self._update_bgp_event(event=event, data=copied_data, last_event="peer is down")
 
         log = (

--- a/src/zino/tasks/bgpstatemonitortask.py
+++ b/src/zino/tasks/bgpstatemonitortask.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass, replace
+from ipaddress import ip_address
 from typing import Iterable, Optional
 
 from zino.snmp import SparseWalkResponse
@@ -59,6 +60,14 @@ class BaseBGPRow:
     peer_remote_address: IPAddress
     peer_remote_as: int
     peer_fsm_established_time: int
+
+    def __post_init__(self):
+        """Coerces incoming values to expected types"""
+        self.peer_state = BGPOperState(self.peer_state)
+        self.peer_admin_status = BGPAdminStatus(self.peer_admin_status)
+        self.peer_remote_address = ip_address(self.peer_remote_address)
+        self.peer_remote_as = int(self.peer_remote_as)
+        self.peer_fsm_established_time = int(self.peer_fsm_established_time)
 
 
 class BGPStateMonitorTask(Task):

--- a/tests/tasks/test_bgpstatemonitortask.py
+++ b/tests/tasks/test_bgpstatemonitortask.py
@@ -12,7 +12,7 @@ from zino.statemodels import (
     BGPPeerSession,
     BGPStyle,
 )
-from zino.tasks.bgpstatemonitortask import BGPStateMonitorTask
+from zino.tasks.bgpstatemonitortask import BaseBGPRow, BGPStateMonitorTask
 
 PEER_ADDRESS = IPv4Address("10.0.0.1")
 DEFAULT_REMOTE_AS = 20
@@ -281,6 +281,19 @@ class TestGetLocalAs:
     @pytest.mark.parametrize("task", ["public"], indirect=True)
     async def test_get_local_as_returns_none_for_non_existent_local_as_with_juniper_bgp_style(self, task):
         assert (await task._get_local_as(bgp_style=BGPStyle.JUNIPER)) is None
+
+
+class TestBaseBGPRow:
+    def test_when_input_is_valid_it_should_not_fail(self):
+        assert BaseBGPRow("active", "running", "10.0.42.0", 5, 0)
+
+    def test_when_peer_state_is_invalid_it_should_raise_an_error(self):
+        with pytest.raises(ValueError):
+            BaseBGPRow("invalid foobar", "running", "10.0.42.0", 5, 0)
+
+    def test_when_peer_admin_status_is_invalid_it_should_raise_an_error(self):
+        with pytest.raises(ValueError):
+            BaseBGPRow("active", "invalid flimflam", "10.0.42.0", 5, 0)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Scope and purpose

Fixes #312. 

The issue could also have been fixed by ensuring the assigned types were correct to begin with, or by changing the type annotations of the dataclass to `str` and ensure the Pydantic model coerces the values instead, but this is my initial suggestion.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
