### PR TITLE
Only log new ifalias value if there is one

### DIFF
--- a/changelog.d/314.fixed.md
+++ b/changelog.d/314.fixed.md
@@ -1,0 +1,1 @@
+Stop logging empty interface descriptions on first discovery

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -179,8 +179,8 @@ class LinkStateTask(Task):
                 _logger.info(
                     "%s: changing desc for %s from %r to %r", self.device.name, data.index, port.ifalias, data.alias
                 )
-            else:
-                _logger.info("%s: setting desc for %s to %s", self.device.name, data.index, data.alias)
+            elif data.alias:
+                _logger.info("%s: setting desc for %r to %r", self.device.name, data.index, data.alias)
             port.ifalias = data.alias
 
 


### PR DESCRIPTION
## Scope and purpose

Running Zino for the first time against many devices will cause huge amounts of log messages about interface descriptions being set for the first time.  There is no reason to log that an interface description was set to an empty value the first time it was collected, so let's not.

Also, log the descr repr values, just as the code does for changing values (for consistency)

<!-- remove things that do not apply -->
### This pull request
* Removes redundant log messages about newly discovered interfaces



## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
  * No need to test non-functional behavior
* [ ] Added/changed documentation
  * Nothing to change
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
