### PR TITLE
Add logging configuration options to `zino.toml`

### DIFF
--- a/changelog.d/+config-logging.added.md
+++ b/changelog.d/+config-logging.added.md
@@ -1,0 +1,1 @@
+Custom logging configuration can now be applied in `zino.toml`

--- a/src/zino/config/models.py
+++ b/src/zino/config/models.py
@@ -3,7 +3,7 @@
 from ipaddress import IPv4Address, IPv6Address
 from os import R_OK, access
 from os.path import isfile
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict
 from pydantic.functional_validators import AfterValidator
@@ -83,3 +83,18 @@ class Configuration(BaseModel):
     authentication: Authentication = Authentication()
     persistence: Persistence = Persistence()
     polling: Polling = Polling()
+    logging: dict[str, Any] = {
+        "version": 1,
+        "loggers": {
+            "root": {"level": "INFO", "handlers": ["console"]},
+            "apscheduler": {"level": "WARNING"},
+        },
+        "formatters": {"standard": {"format": "%(asctime)s - %(levelname)s - %(name)s (%(threadName)s) - %(message)s"}},
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "standard",
+                "stream": "ext://sys.stderr",
+            }
+        },
+    }

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -239,7 +239,11 @@ def parse_args(arguments=None):
         help="Path to zino configuration file",
     )
     parser.add_argument(
-        "--debug", action="store_true", default=False, help="Set global log level to DEBUG. Very chatty!"
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Set global log level to DEBUG. Very verbose! For more fine-grained control of logging configuration, it "
+        "is recommended to use the 'logging' section in the configuration file.",
     )
     parser.add_argument("--stop-in", type=int, default=None, help="Stop zino after N seconds.", metavar="N")
     parser.add_argument(

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -43,8 +43,15 @@ def main():
         level=logging.INFO if not args.debug else logging.DEBUG,
         format="%(asctime)s - %(levelname)s - %(name)s (%(threadName)s) - %(message)s",
     )
+    state.config = load_config(args)
+    state.state = state.ZinoState.load_state_from_file(state.config.persistence.file) or state.ZinoState()
+    init_event_loop(args)
+
+
+def load_config(args: argparse.Namespace) -> state.Configuration:
+    """Loads the configuration file, exiting the process if there are config errors"""
     try:
-        state.config = read_configuration(args.config_file or DEFAULT_CONFIG_FILE, args.polldevs)
+        return read_configuration(args.config_file or DEFAULT_CONFIG_FILE, args.polldevs)
     except OSError:
         if args.config_file:
             _log.fatal(f"No config file with the name {args.config_file} found.")
@@ -55,9 +62,6 @@ def main():
     except ValidationError as e:
         _log.fatal(e)
         sys.exit(1)
-
-    state.state = state.ZinoState.load_state_from_file(state.config.persistence.file) or state.ZinoState()
-    init_event_loop(args)
 
 
 def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] = None):

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -81,6 +81,12 @@ def test_zino_should_not_run_without_pollfile(zino_conf_with_non_existent_pollfi
         )
 
 
+def test_when_args_specified_config_file_does_not_exist_then_load_config_should_exit():
+    args = Mock(config_file="non_existent_file.toml")
+    with pytest.raises(SystemExit):
+        zino.load_config(args)
+
+
 def test_zino_should_not_run_with_invalid_conf_file(invalid_zino_conf):
     """This tests that the main function does not Zino for at least 2 seconds when
     the name of the pollfile is defined in the config file, but does not exist

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -87,6 +87,11 @@ def test_when_args_specified_config_file_does_not_exist_then_load_config_should_
         zino.load_config(args)
 
 
+def test_when_logging_config_is_invalid_then_apply_logging_config_should_exit():
+    with pytest.raises(SystemExit):
+        zino.apply_logging_config({"loggers": {"zino": {"level": "invalid"}}})
+
+
 def test_zino_should_not_run_with_invalid_conf_file(invalid_zino_conf):
     """This tests that the main function does not Zino for at least 2 seconds when
     the name of the pollfile is defined in the config file, but does not exist

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -81,8 +81,8 @@ def test_zino_should_not_run_without_pollfile(zino_conf_with_non_existent_pollfi
         )
 
 
-def test_when_args_specified_config_file_does_not_exist_then_load_config_should_exit():
-    args = Mock(config_file="non_existent_file.toml")
+def test_when_args_specified_config_file_does_not_exist_then_load_config_should_exit(tmp_path):
+    args = Mock(config_file=tmp_path / "non_existent_file.toml")
     with pytest.raises(SystemExit):
         zino.load_config(args)
 

--- a/zino.toml.example
+++ b/zino.toml.example
@@ -25,3 +25,26 @@ file = "polldevs.cf"
 # How often the pollfile is read, in minutes
 # default 1 min
 period = 1
+
+# Logging configuration is optional, but if specified, it will override the
+# default logging config of Zino.  This is a TOML representation of the default
+# logging configuration dictionary, whose full documentation is available at
+# https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+#
+#[logging]
+#version = 1
+#
+#[logging.loggers.root]
+#level = "INFO"
+#handlers = ["console"]
+#
+#[logging.loggers.apscheduler]
+#level = "WARNING"
+#
+#[logging.formatters.standard]
+#format = "%(asctime)s - %(levelname)s - %(name)s (%(threadName)s) - %(message)s"
+#
+#[logging.handlers.console]
+#class = "logging.StreamHandler"
+#formatter = "standard"
+#stream = "ext://sys.stderr"


### PR DESCRIPTION
## Scope and purpose

This adds the option of fully controlling Zino's logging setup through applying a `logging` dictionary from `zino.toml` to the `logging.config.dictConfig()` function.

The Python logging module does not provide an option to validate a logging config dict before applying it to runtime, so the Pydantic configuration model will accept any dict for the `logging` option, and the validation of said config is only handled as Zino attempts to apply it.

The existing Zino defaults are codified in the default configuration model.  Changing the logging configuration is mostly for advanced users or developers who want to control which parts of Zino are debug logging, or where the logs are sent, so it should be entirely optional to provide it in the config file.

<!-- remove things that do not apply -->
### This pull request
* adds `logging` option to `zino.toml`
* factors out various config loading and error handling from the `main()` method, which already did too much.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
