### PR TITLE
Add utility decorator to log time spent in function calls

### DIFF
--- a/src/zino/scheduler.py
+++ b/src/zino/scheduler.py
@@ -12,6 +12,7 @@ from zino import state
 from zino.config.models import DEFAULT_INTERVAL_MINUTES, PollDevice
 from zino.config.polldevs import InvalidConfiguration, read_polldevs
 from zino.tasks import run_all_tasks
+from zino.utils import log_time_spent
 
 _log = logging.getLogger(__name__)
 _scheduler = None
@@ -38,6 +39,7 @@ def get_scheduler() -> AsyncIOScheduler:
     return _scheduler
 
 
+@log_time_spent()
 def load_polldevs(polldevs_conf: str) -> Tuple[Set, Set]:
     """Loads pollfile into process state.
 

--- a/src/zino/state.py
+++ b/src/zino/state.py
@@ -13,6 +13,7 @@ from zino.events import Events
 from zino.flaps import FlappingStates
 from zino.planned_maintenance import PlannedMaintenances
 from zino.statemodels import DeviceStates
+from zino.utils import log_time_spent
 
 _log = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ class ZinoState(BaseModel):
     planned_maintenances: PlannedMaintenances = Field(default_factory=PlannedMaintenances)
     flapping: FlappingStates = Field(default_factory=FlappingStates)
 
+    @log_time_spent()
     def dump_state_to_file(self, filename: str):
         """Dumps the full state to a file in JSON format"""
         _log.debug("dumping state to %s", filename)
@@ -41,6 +43,7 @@ class ZinoState(BaseModel):
             statefile.write(self.model_dump_json(exclude_none=True, indent=2))
 
     @classmethod
+    @log_time_spent()
     def load_state_from_file(cls, filename: str) -> Optional["ZinoState"]:
         """Loads and returns a previously persisted ZinoState from a JSON file dump.
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,10 +1,11 @@
+import logging
 from ipaddress import IPv4Address, IPv6Address
 from unittest.mock import AsyncMock, MagicMock
 
 import aiodns
 import pytest
 
-from zino.utils import parse_ip, reverse_dns
+from zino.utils import log_time_spent, parse_ip, reverse_dns
 
 
 class TestParseIP:
@@ -76,6 +77,24 @@ class TestReverseDNS:
 
         result = await reverse_dns(invalid_ip)
         assert result is None
+
+
+class TestLogTimeSpent:
+    def test_when_logger_is_specified_it_should_log_time_spent_using_that_logger(self, caplog):
+        @log_time_spent(logger="test_logger", level=logging.DEBUG)
+        def test_function():
+            pass
+
+        with caplog.at_level(logging.DEBUG):
+            test_function()
+
+        assert any(
+            record.name == "test_logger"
+            and "took" in record.msg
+            and "seconds" in record.msg
+            and "test_function" in record.args
+            for record in caplog.records
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Scope and purpose

This adds a utility decorator `log_time_spent()`, which will log the number of seconds spent in the decorated function.  It also applies this to functions that load polldevs config or loads/dumps the Zino state, in order to get a picture of the performance of these functions.



## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * Purely an internal change.
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
  * Well, tests are documentation, right?
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
