### PR TITLE
Serialize underscores as dashes in event attribute names in the legacy API

### DIFF
--- a/changelog.d/+ac_down-timedelta.fixed.md
+++ b/changelog.d/+ac_down-timedelta.fixed.md
@@ -1,0 +1,1 @@
+Properly encode timedelta values as an integer number of seconds in the legacy API

--- a/changelog.d/281.fixed.md
+++ b/changelog.d/281.fixed.md
@@ -1,0 +1,1 @@
+Properly use dashes in event attribute names in the legacy API

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -309,7 +309,7 @@ class Event(BaseModel):
         Pydantic can support that.
         """
         attrs = self.model_dump(mode="python", exclude={"log", "history"}, exclude_none=True)
-        return {attr: self.zinoify_value(value) for attr, value in attrs.items()}
+        return {attr.replace("_", "-"): self.zinoify_value(value) for attr, value in attrs.items()}
 
     @staticmethod
     def zinoify_value(value: Any) -> str:

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -318,6 +318,8 @@ class Event(BaseModel):
             return str(value.value)
         if isinstance(value, datetime.datetime):
             return str(int(value.timestamp()))
+        if isinstance(value, datetime.timedelta):
+            return str(int(value.total_seconds()))
         return str(value)
 
     def get_changed_fields(self, other: "Event") -> List[str]:

--- a/tests/statemodels/statemodels_test.py
+++ b/tests/statemodels/statemodels_test.py
@@ -43,6 +43,13 @@ class TestEvent:
         assert "ac_down" not in attrs
         assert "ac-down" in attrs
 
+    def test_model_dump_simple_attrs_should_represent_timedeltas_as_number_of_seconds(self, fake_event):
+        """Legacy Zino protocol event attributes use dashes, not underscores in their names."""
+        fake_event.ac_down = datetime.timedelta(seconds=42)
+        attrs = fake_event.model_dump_simple_attrs()
+
+        assert attrs["ac-down"] == "42"
+
     def test_zinoify_value_when_value_is_enum_it_should_return_its_real_value(self):
         assert Event.zinoify_value(EventState.OPEN) == "open"
 

--- a/tests/statemodels/statemodels_test.py
+++ b/tests/statemodels/statemodels_test.py
@@ -35,6 +35,14 @@ class TestEvent:
         assert "log" not in attrs
         assert "history" not in attrs
 
+    def test_model_dump_simple_attrs_should_replace_underscores_with_dashes_in_attr_names(self, fake_event):
+        """Legacy Zino protocol event attributes use dashes, not underscores in their names."""
+        fake_event.ac_down = datetime.timedelta(seconds=42)
+        attrs = fake_event.model_dump_simple_attrs()
+
+        assert "ac_down" not in attrs
+        assert "ac-down" in attrs
+
     def test_zinoify_value_when_value_is_enum_it_should_return_its_real_value(self):
         assert Event.zinoify_value(EventState.OPEN) == "open"
 


### PR DESCRIPTION
## Scope and purpose

Fixes #281.

Additionally, while fixing this, I also discovered a problem with how attributes like `ac-down` were serialized to the legacy API: `ac-down` is represented as a `timedelta` in the Python code, and should be represented as an integer (a number of seconds) in the protocol, but the existing implementation returned something akin to `str(ac_down)`, which caused `timedelta(seconds=42)` to be serialized as `"0:00:42"` rather than just `"42"`.  I should maybe have put this as a separate PR, but IMHO it was sufficiently small to include here.


<!-- remove things that do not apply -->
### This pull request
* fixes event attribute serialization bugs for the legacy API
* 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
