### PR TITLE
Await async handle_trap function in bgp trap tests

### DIFF
--- a/tests/trapobservers/bgp_traps_test.py
+++ b/tests/trapobservers/bgp_traps_test.py
@@ -23,37 +23,39 @@ class TestBgpTrapObserver:
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ACTIVE
 
-    def test_when_trap_is_missing_required_varbinds_it_should_do_nothing(self, backward_transition_trap):
-        """jnxBgpM2PeerLocalAddrType is required to be present, according to legacy Zino"""
+    @pytest.mark.asyncio
+    async def test_when_trap_is_missing_required_varbinds_it_should_do_nothing(self, backward_transition_trap):
         device = backward_transition_trap.agent.device
         peer = next(iter(device.bgp_peers.keys()))
         addr_type = backward_transition_trap.get_all("jnxBgpM2PeerLocalAddrType")[0]
         backward_transition_trap.variables.remove(addr_type)
 
         observer = BgpTrapObserver(state=Mock())
-        observer.handle_trap(trap=backward_transition_trap)
+        await observer.handle_trap(trap=backward_transition_trap)
 
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ESTABLISHED
 
-    def test_when_trap_has_invalid_remote_addr_it_should_do_nothing(self, backward_transition_trap):
+    @pytest.mark.asyncio
+    async def test_when_trap_has_invalid_remote_addr_it_should_do_nothing(self, backward_transition_trap):
         device = backward_transition_trap.agent.device
         peer = next(iter(device.bgp_peers.keys()))
         backward_transition_trap.get_all("jnxBgpM2PeerRemoteAddr")[0].raw_value = b"INVALID"
 
         observer = BgpTrapObserver(state=Mock())
-        observer.handle_trap(trap=backward_transition_trap)
+        await observer.handle_trap(trap=backward_transition_trap)
 
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ESTABLISHED
 
-    def test_when_trap_has_invalid_oper_state_it_should_do_nothing(self, backward_transition_trap):
+    @pytest.mark.asyncio
+    async def test_when_trap_has_invalid_oper_state_it_should_do_nothing(self, backward_transition_trap):
         device = backward_transition_trap.agent.device
         peer = next(iter(device.bgp_peers.keys()))
         backward_transition_trap.get_all("jnxBgpM2PeerState")[0].value = "INVALIDFOOBAR"
 
         observer = BgpTrapObserver(state=Mock())
-        observer.handle_trap(trap=backward_transition_trap)
+        await observer.handle_trap(trap=backward_transition_trap)
 
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ESTABLISHED


### PR DESCRIPTION
## Scope and purpose

I noticed that when running the testsuite I got the following pytest warnings: 

```
tests/trapobservers/bgp_traps_test.py::TestBgpTrapObserver::test_when_trap_is_missing_required_varbinds_it_should_do_nothing
  /home/johanna/zino/tests/trapobservers/bgp_traps_test.py:34: RuntimeWarning: coroutine 'BgpTrapObserver.handle_trap' was never awaited
    observer.handle_trap(trap=backward_transition_trap)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/trapobservers/bgp_traps_test.py::TestBgpTrapObserver::test_when_trap_has_invalid_remote_addr_it_should_do_nothing
  /home/johanna/zino/tests/trapobservers/bgp_traps_test.py:45: RuntimeWarning: coroutine 'BgpTrapObserver.handle_trap' was never awaited
    observer.handle_trap(trap=backward_transition_trap)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/trapobservers/bgp_traps_test.py::TestBgpTrapObserver::test_when_trap_has_invalid_oper_state_it_should_do_nothing
  /home/johanna/zino/tests/trapobservers/bgp_traps_test.py:56: RuntimeWarning: coroutine 'BgpTrapObserver.handle_trap' was never awaited
    observer.handle_trap(trap=backward_transition_trap)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

This removes these warning by actually awaiting the async `handle_trap` function and marking the tests as async themselves.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  - this does not change any behavior, only corrects the way tests are run 
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
  - well, the tests are what is changed
* [ ] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
