### PR TITLE
Improve config tests

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -16,7 +16,7 @@ class TestReadConfiguration:
         assert config.polling.file == str(polldevs_conf_with_single_router)
 
     def test_raises_error_on_file_not_found(self, tmp_path):
-        with pytest.raises(OSError):
+        with pytest.raises(FileNotFoundError):
             read_configuration(tmp_path / "non-existent-config.toml")
 
     def test_raises_error_on_invalid_toml_file(self, invalid_zino_conf):
@@ -24,13 +24,20 @@ class TestReadConfiguration:
             read_configuration(invalid_zino_conf)
 
     def test_raises_error_on_invalid_config_values(self, invalid_values_zino_conf):
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as excinfo:
             read_configuration(invalid_values_zino_conf)
 
+        assert "archiving.old_events_dir" in str(excinfo)
+
     def tests_raises_error_on_misspelled_key(self, extra_keys_zino_conf):
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as excinfo:
             read_configuration(extra_keys_zino_conf)
 
+        assert "Extra inputs are not permitted" in str(excinfo)
+
     def test_raises_error_on_pollfile_not_found(self, zino_conf_with_non_existent_pollfile):
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as excinfo:
             read_configuration(zino_conf_with_non_existent_pollfile)
+
+        assert "polling.file" in str(excinfo.value)
+        assert "non-existent-pollfile.cf doesn't exist or isn't readable" in str(excinfo.value)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -15,9 +15,9 @@ class TestReadConfiguration:
         assert config
         assert config.polling.file == str(polldevs_conf_with_single_router)
 
-    def test_raises_error_on_file_not_found(self):
+    def test_raises_error_on_file_not_found(self, tmp_path):
         with pytest.raises(OSError):
-            read_configuration("non-existent-config.toml")
+            read_configuration(tmp_path / "non-existent-config.toml")
 
     def test_raises_error_on_invalid_toml_file(self, invalid_zino_conf):
         with pytest.raises(InvalidConfigurationError):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -31,15 +31,6 @@ class TestReadConfiguration:
         with pytest.raises(ValidationError):
             read_configuration(extra_keys_zino_conf)
 
-    def test_raises_error_on_pollfile_not_found(self, tmp_path):
-        pollfile = "non-existent-pollfile.toml"
-        name = tmp_path / pollfile
-        with open(name, "w") as conf:
-            conf.write(
-                f"""
-                [polling]
-                file = "{pollfile}"
-                """
-            )
+    def test_raises_error_on_pollfile_not_found(self, zino_conf_with_non_existent_pollfile):
         with pytest.raises(ValidationError):
-            read_configuration(name)
+            read_configuration(zino_conf_with_non_existent_pollfile)


### PR DESCRIPTION
## Scope and purpose
This PR improves the config tests added in #249 by using already existing fixtures and little things from pytest that I learned about during EuroPython.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
    - only changes to the tests, no externally visible changes
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
