### PR TITLE
Add `polldevs` dictionary to `Zino1BaseServerProtocol` instances

### DIFF
--- a/src/zino/api/server.py
+++ b/src/zino/api/server.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from zino.api.legacy import Zino1ServerProtocol
 from zino.api.notify import Zino1NotificationProtocol
+from zino.config.models import PollDevice
 from zino.state import ZinoState
 from zino.statemodels import Event
 
@@ -20,9 +21,10 @@ class ZinoServer:
     API_PORT = 8001
     NOTIFY_PORT = 8002
 
-    def __init__(self, loop: AbstractEventLoop, state: ZinoState):
+    def __init__(self, loop: AbstractEventLoop, state: ZinoState, polldevs: dict[str, PollDevice]):
         self._loop = loop
         self.state: ZinoState = state
+        self.polldevs: dict[str, PollDevice] = polldevs
         self.active_clients: set[Zino1ServerProtocol] = set()
         self.notification_channels: dict[str, Zino1NotificationProtocol] = {}
         self.notify_server = self.api_server = None
@@ -30,7 +32,7 @@ class ZinoServer:
     def serve(self, address: str = "0.0.0.0"):
         """Sets up the two asyncio servers to serve in tandem 'forever'"""
         api_coroutine = self._loop.create_server(
-            lambda: Zino1ServerProtocol(server=self, state=self.state), address, self.API_PORT
+            lambda: Zino1ServerProtocol(server=self, state=self.state, polldevs=self.polldevs), address, self.API_PORT
         )
         self.api_server = self._loop.run_until_complete(api_coroutine)
         _logger.info("Serving API on %r", self.api_server.sockets[0].getsockname())

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -141,7 +141,7 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
         minutes=30,
     )
 
-    server = ZinoServer(loop=loop, state=state.state)
+    server = ZinoServer(loop=loop, state=state.state, polldevs=state.polldevs)
     server.serve()
 
     if args.stop_in:

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -635,10 +635,7 @@ class TestZino1ServerProtocolSetstateCommand:
 
 class TestZino1ServerProtocolCommunityCommand:
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_should_output_community_for_router(self, authenticated_protocol):
-        from zino.state import polldevs
-
         router_name = "buick.lab.example.org"
         community = "public"
         device = PollDevice(
@@ -647,7 +644,8 @@ class TestZino1ServerProtocolCommunityCommand:
             port=666,
             community=community,
         )
-        polldevs[device.name] = device
+        polldevs = {device.name: device}
+        authenticated_protocol._polldevs = polldevs
 
         await authenticated_protocol.message_received(f"COMMUNITY {router_name}")
 
@@ -655,7 +653,6 @@ class TestZino1ServerProtocolCommunityCommand:
         assert f"201 {device.community}\r\n".encode() in output
 
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_should_output_error_response_for_unknown_router(self, authenticated_protocol):
         await authenticated_protocol.message_received("COMMUNITY unknown.router.example.org")
 
@@ -703,10 +700,7 @@ class TestZino1ServerProtocolNtieCommand:
 
 class TestZino1ServerProtocolPollrtrCommand:
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_should_add_run_all_tasks_job(self, authenticated_protocol):
-        from zino.state import polldevs
-
         router_name = "buick.lab.example.org"
         community = "public"
         device = PollDevice(
@@ -715,7 +709,8 @@ class TestZino1ServerProtocolPollrtrCommand:
             port=666,
             community=community,
         )
-        polldevs[device.name] = device
+        polldevs = {device.name: device}
+        authenticated_protocol._polldevs = polldevs
 
         with patch("zino.api.legacy.get_scheduler") as get_scheduler:
             mock_scheduler = Mock()
@@ -728,7 +723,6 @@ class TestZino1ServerProtocolPollrtrCommand:
         assert mock_scheduler.add_job.called
 
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_should_output_error_response_for_unknown_router(self, authenticated_protocol):
         unknown_router = "unknown.router.example.org"
         await authenticated_protocol.message_received(f"POLLRTR {unknown_router}")
@@ -739,10 +733,7 @@ class TestZino1ServerProtocolPollrtrCommand:
 
 class TestZino1ServerProtocolPollintfCommand:
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_should_call_poll_single_interface(self, authenticated_protocol):
-        from zino.state import polldevs
-
         router_name = "buick.lab.example.org"
         community = "public"
         device = PollDevice(
@@ -751,7 +742,8 @@ class TestZino1ServerProtocolPollintfCommand:
             port=666,
             community=community,
         )
-        polldevs[device.name] = device
+        polldevs = {device.name: device}
+        authenticated_protocol._polldevs = polldevs
 
         with patch(
             "zino.tasks.linkstatetask.LinkStateTask.schedule_verification_of_single_port", Mock()
@@ -763,7 +755,6 @@ class TestZino1ServerProtocolPollintfCommand:
         assert mock_schedule_verification.called
 
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_should_output_error_response_for_unknown_router(self, authenticated_protocol):
         unknown_router = "unknown.router.example.org"
         await authenticated_protocol.message_received(f"POLLINTF {unknown_router} 1")
@@ -772,10 +763,7 @@ class TestZino1ServerProtocolPollintfCommand:
         assert f"500 Router {unknown_router} unknown\r\n".encode() in output
 
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_should_output_error_response_for_invalid_ifindex(self, authenticated_protocol):
-        from zino.state import polldevs
-
         router_name = "buick.lab.example.org"
         community = "public"
         device = PollDevice(
@@ -784,7 +772,8 @@ class TestZino1ServerProtocolPollintfCommand:
             port=666,
             community=community,
         )
-        polldevs[device.name] = device
+        polldevs = {device.name: device}
+        authenticated_protocol._polldevs = polldevs
         await authenticated_protocol.message_received(f"POLLINTF {router_name} foobar")
 
         output = authenticated_protocol.transport.data_buffer.getvalue()
@@ -793,11 +782,8 @@ class TestZino1ServerProtocolPollintfCommand:
 
 class TestZino1ServerProtocolClearflapCommand:
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_it_should_set_event_flapstate_to_stable_and_respond_with_ok(self, authenticated_protocol):
         # Arrange bigly
-        from zino.state import polldevs
-
         router_name = "buick.lab.example.org"
         community = "public"
         device = PollDevice(
@@ -806,7 +792,8 @@ class TestZino1ServerProtocolClearflapCommand:
             port=666,
             community=community,
         )
-        polldevs[device.name] = device
+        polldevs = {device.name: device}
+        authenticated_protocol._polldevs = polldevs
 
         device_state = DeviceState(name=router_name)
         port = Port(ifindex=1, ifdescr="eth0", ifalias="Test port", state=InterfaceState.FLAPPING)
@@ -831,7 +818,6 @@ class TestZino1ServerProtocolClearflapCommand:
         assert updated_event.flapstate == FlapState.STABLE
 
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_it_should_output_error_response_for_unknown_router(self, authenticated_protocol):
         unknown_router = "unknown.router.example.org"
         await authenticated_protocol.message_received(f"CLEARFLAP {unknown_router} 1")
@@ -840,10 +826,7 @@ class TestZino1ServerProtocolClearflapCommand:
         assert f"500 Router {unknown_router} unknown\r\n".encode() in output
 
     @pytest.mark.asyncio
-    @patch("zino.state.polldevs", dict())
     async def test_it_should_output_error_response_for_invalid_ifindex(self, authenticated_protocol):
-        from zino.state import polldevs
-
         router_name = "buick.lab.example.org"
         community = "public"
         device = PollDevice(
@@ -852,7 +835,9 @@ class TestZino1ServerProtocolClearflapCommand:
             port=666,
             community=community,
         )
-        polldevs[device.name] = device
+        polldevs = {device.name: device}
+        authenticated_protocol._polldevs = polldevs
+
         await authenticated_protocol.message_received(f"CLEARFLAP {router_name} foobar")
 
         output = authenticated_protocol.transport.data_buffer.getvalue()

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -250,7 +250,7 @@ class TestZino1BaseServerProtocol:
         assert "ZeroDivisionError" in caplog.text
 
     def test_when_connected_it_should_register_instance_in_server(self, event_loop):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         protocol = Zino1BaseServerProtocol(server=server)
         fake_transport = Mock()
         protocol.connection_made(fake_transport)
@@ -258,7 +258,7 @@ class TestZino1BaseServerProtocol:
         assert protocol in server.active_clients
 
     def test_when_disconnected_it_should_deregister_instance_from_server(self, event_loop):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         protocol = Zino1BaseServerProtocol(server=server)
         fake_transport = Mock()
         protocol.connection_made(fake_transport)
@@ -663,7 +663,7 @@ class TestZino1ServerProtocolCommunityCommand:
 class TestZino1ServerProtocolNtieCommand:
     @pytest.mark.asyncio
     async def test_when_nonce_is_bogus_it_should_respond_with_error(self, event_loop, authenticated_protocol):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         server.notification_channels = dict()  # Ensure there are none for this test
         authenticated_protocol.server = server
 
@@ -674,7 +674,7 @@ class TestZino1ServerProtocolNtieCommand:
 
     @pytest.mark.asyncio
     async def test_when_nonce_exists_it_should_respond_with_ok(self, event_loop, authenticated_protocol):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         nonce = get_challenge()
         mock_channel = Mock()
         server.notification_channels[nonce] = mock_channel
@@ -687,7 +687,7 @@ class TestZino1ServerProtocolNtieCommand:
 
     @pytest.mark.asyncio
     async def test_when_nonce_exists_it_should_tie_the_corresponding_channel(self, event_loop, authenticated_protocol):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         nonce = get_challenge()
         mock_channel = Mock()
         server.notification_channels[nonce] = mock_channel

--- a/tests/api/notify_test.py
+++ b/tests/api/notify_test.py
@@ -28,7 +28,7 @@ class TestZino1NotificationProtocol:
         assert protocol.peer_name == expected
 
     def test_when_connected_it_should_register_instance_in_server(self, event_loop):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         protocol = Zino1NotificationProtocol(server=server)
         fake_transport = Mock()
         protocol.connection_made(fake_transport)
@@ -37,7 +37,7 @@ class TestZino1NotificationProtocol:
         assert server.notification_channels[protocol.nonce] is protocol
 
     def test_when_disconnected_it_should_deregister_instance_from_server(self, event_loop):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         protocol = Zino1NotificationProtocol(server=server)
         fake_transport = Mock()
         protocol.connection_made(fake_transport)
@@ -55,14 +55,14 @@ class TestZino1NotificationProtocol:
         assert response.startswith(b"42 test data")
 
     def test_tied_to_should_be_settable_and_gettable(self, event_loop):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         protocol = Zino1NotificationProtocol()
 
         protocol.tied_to = server
         assert protocol.tied_to == server
 
     def test_goodbye_should_close_transport(self, event_loop):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         protocol = Zino1NotificationProtocol(server=server)
         fake_transport = Mock()
         protocol.connection_made(fake_transport)
@@ -121,7 +121,7 @@ class TestZino1NotificationProtocolBuildNotifications:
 
 class TestZino1NotificationProtocolBuildAndSendNotifications:
     def test_should_send_notifications_only_to_tied_channels(self, event_loop, fake_event, changed_fake_event):
-        server = ZinoServer(loop=event_loop, state=ZinoState())
+        server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
         channel1 = Mock()
         channel2 = Mock()
         mock_api = Mock()

--- a/tests/api/server_test.py
+++ b/tests/api/server_test.py
@@ -3,7 +3,7 @@ from zino.state import ZinoState
 
 
 def test_zinoserver_should_serve_without_error(event_loop):
-    server = ZinoServer(event_loop, ZinoState())
+    server = ZinoServer(loop=event_loop, state=ZinoState(), polldevs=dict())
     server.serve()
     server.notify_server.close()
     server.api_server.close()


### PR DESCRIPTION
## Scope and purpose

Fixes #309.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
    - internal change, so no changelog fragment needed
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
