### PR TITLE
Use pydantic alias for planned maintenance fields

### DIFF
--- a/changelog.d/287.fixed.md
+++ b/changelog.d/287.fixed.md
@@ -1,0 +1,1 @@
+Use Zino1 field names for serialization of planned maintenance

--- a/src/zino/state.py
+++ b/src/zino/state.py
@@ -40,7 +40,7 @@ class ZinoState(BaseModel):
         """Dumps the full state to a file in JSON format"""
         _log.debug("dumping state to %s", filename)
         with open(filename, "w") as statefile:
-            statefile.write(self.model_dump_json(exclude_none=True, indent=2))
+            statefile.write(self.model_dump_json(exclude_none=True, indent=2, by_alias=True))
 
     @classmethod
     @log_time_spent()

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -21,7 +21,7 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from zino.compat import StrEnum
 from zino.time import now
@@ -413,13 +413,16 @@ class PmType(StrEnum):
 
 
 class PlannedMaintenance(BaseModel):
+    # Allow populating fields by name or alias
+    model_config = ConfigDict(populate_by_name=True)
+
     id: Optional[int] = None
-    start_time: datetime.datetime
-    end_time: datetime.datetime
+    start_time: datetime.datetime = Field(alias="starttime")
+    end_time: datetime.datetime = Field(alias="endtime")
     type: PmType
     match_type: MatchType
-    match_device: Optional[str] = None
-    match_expression: str
+    match_device: Optional[str] = Field(default=None, alias="match_dev")
+    match_expression: str = Field(alias="match_expr")
     log: List[LogEntry] = []
     event_ids: List[int] = []
 

--- a/tests/planned_maintenance_test.py
+++ b/tests/planned_maintenance_test.py
@@ -159,6 +159,14 @@ def test_pms_should_be_parsed_as_correct_subclass_when_read_from_file(tmp_path, 
     assert isinstance(read_portstate_pm, PortStateMaintenance)
 
 
+def test_model_dump_of_pm_should_use_aliases(state, active_portstate_pm, active_pm):
+    state_dump = state.model_dump_json(exclude_none=True, indent=2, by_alias=True)
+    assert "starttime" in state_dump
+    assert "endtime" in state_dump
+    assert "match_dev" in state_dump
+    assert "match_expr" in state_dump
+
+
 @pytest.fixture
 def pms():
     return PlannedMaintenances()


### PR DESCRIPTION
## Scope and purpose

Fixes #287.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
