### PR TITLE
Reschedule changed devices

### DIFF
--- a/changelog.d/330.fixed.md
+++ b/changelog.d/330.fixed.md
@@ -1,0 +1,1 @@
+Reschedule devices whose configuration attributes where changed in the pollfile

--- a/src/zino/scheduler.py
+++ b/src/zino/scheduler.py
@@ -80,8 +80,8 @@ def init_state_for_devices(devices: Sequence[PollDevice]):
 
 async def load_and_schedule_polldevs(polldevs_conf: str):
     new_devices, deleted_devices, changed_devices = load_polldevs(polldevs_conf)
-    schedule_new_devices(new_devices)
-    deschedule_deleted_devices(deleted_devices)
+    deschedule_deleted_devices(deleted_devices | changed_devices)
+    schedule_new_devices(new_devices | changed_devices)
 
 
 def schedule_new_devices(new_devices: Sequence[str]):
@@ -89,7 +89,7 @@ def schedule_new_devices(new_devices: Sequence[str]):
     if not devices:
         return
 
-    _log.debug("Scheduling %s new devices", len(devices))
+    _log.debug("Scheduling %s new/changed devices", len(devices))
 
     scheduler = get_scheduler()
 

--- a/src/zino/scheduler.py
+++ b/src/zino/scheduler.py
@@ -80,16 +80,16 @@ def init_state_for_devices(devices: Sequence[PollDevice]):
 
 async def load_and_schedule_polldevs(polldevs_conf: str):
     new_devices, deleted_devices, changed_devices = load_polldevs(polldevs_conf)
-    deschedule_deleted_devices(deleted_devices | changed_devices)
-    schedule_new_devices(new_devices | changed_devices)
+    deschedule_devices(deleted_devices | changed_devices)
+    schedule_devices(new_devices | changed_devices)
 
 
-def schedule_new_devices(new_devices: Sequence[str]):
-    devices = sorted((state.polldevs[name] for name in new_devices), key=operator.attrgetter("priority"), reverse=True)
+def schedule_devices(devices: Sequence[str]):
+    devices = sorted((state.polldevs[name] for name in devices), key=operator.attrgetter("priority"), reverse=True)
     if not devices:
         return
 
-    _log.debug("Scheduling %s new/changed devices", len(devices))
+    _log.debug("Scheduling %s devices", len(devices))
 
     scheduler = get_scheduler()
 
@@ -109,10 +109,10 @@ def schedule_new_devices(new_devices: Sequence[str]):
         )
 
 
-def deschedule_deleted_devices(deleted_devices: Sequence[str]):
-    """De-schedules recurring jobs for the deleted devices"""
+def deschedule_devices(devices: Sequence[str]):
+    """De-schedules recurring jobs for the given devices"""
     scheduler = get_scheduler()
-    for name in deleted_devices:
+    for name in devices:
         try:
             scheduler.remove_job(job_id=name)
         except JobLookupError:

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -102,23 +102,23 @@ class TestScheduleNewDevices:
         new_devices, _, _ = scheduler.load_polldevs(polldevs_conf)
         assert len(new_devices) > 0
 
-        scheduler.schedule_new_devices(new_devices)
+        scheduler.schedule_devices(new_devices)
         assert mocked_scheduler.add_job.called
 
     @patch("zino.state.polldevs", dict())
     def test_should_do_nothing_when_device_list_is_empty(self, mocked_scheduler):
-        scheduler.schedule_new_devices([])
+        scheduler.schedule_devices([])
         assert not mocked_scheduler.add_job.called
 
 
 def test_deschedule_deleted_devices_should_deschedule_jobs(mocked_scheduler):
-    scheduler.deschedule_deleted_devices(["test-gw"])
+    scheduler.deschedule_devices(["test-gw"])
     assert mocked_scheduler.remove_job.called
 
 
 def test_deschedule_deleted_devices_should_not_fail_on_not_found_job(mocked_scheduler_raising_error, caplog):
     with caplog.at_level(logging.DEBUG):
-        scheduler.deschedule_deleted_devices(["test-gw"])
+        scheduler.deschedule_devices(["test-gw"])
     assert mocked_scheduler_raising_error.remove_job.called
     assert "Job for device test-gw could not be found" in caplog.text
 


### PR DESCRIPTION
## Scope and purpose

Fixes #330.

Makes `load_polldevs` detect changed devices and then deletes scheduled jobs for these and adds new jobs with the new configuration values.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
