### PR TITLE
Use default interval from pollfile to stagger new jobs

### DIFF
--- a/changelog.d/337.fixed.md
+++ b/changelog.d/337.fixed.md
@@ -1,0 +1,1 @@
+Use default interval from pollfile to stagger new jobs

--- a/src/zino/config/polldevs.py
+++ b/src/zino/config/polldevs.py
@@ -7,10 +7,10 @@ from pydantic import ValidationError
 from zino.config.models import PollDevice
 
 
-def read_polldevs(filename: str) -> dict[str, PollDevice]:
+def read_polldevs(filename: str) -> Tuple[dict[str, PollDevice], dict[str, str]]:
     """
     Reads and parses the legacy `polldevs.cf` format, returning a dictionary of device names and the associated
-    PollDevice object.
+    PollDevice object and a dictionary of default settings
 
     This parser is slightly more lax than the original Tcl-based parser, in that it allows multiple empty lines or
     multiple spaces in value assignments.
@@ -41,7 +41,7 @@ def read_polldevs(filename: str) -> dict[str, PollDevice]:
         error.filename = filename
         raise
 
-    return devices
+    return devices, defaults
 
 
 def _read_conf_sections(filehandle: TextIO) -> Iterator[Tuple[int, dict]]:

--- a/src/zino/getuptime.py
+++ b/src/zino/getuptime.py
@@ -20,7 +20,7 @@ def main():
 
 
 async def run(args: argparse.Namespace):
-    devices = {d.name: d for d in read_polldevs(config.polling.file)}
+    devices = read_polldevs(config.polling.file)
     device = devices[args.router]
 
     snmp = SNMP(device)
@@ -29,9 +29,9 @@ async def run(args: argparse.Namespace):
 
 
 def parse_args():
-    devicenames = [d.name for d in read_polldevs(config.polling.file)]
+    devices = read_polldevs(config.polling.file)
     parser = argparse.ArgumentParser(description="Fetch sysUptime from a device in the pollfile")
-    parser.add_argument("router", type=str, help="Zino router name", choices=devicenames)
+    parser.add_argument("router", type=str, help="Zino router name", choices=devices.keys())
     return parser.parse_args()
 
 

--- a/src/zino/getuptime.py
+++ b/src/zino/getuptime.py
@@ -20,7 +20,7 @@ def main():
 
 
 async def run(args: argparse.Namespace):
-    devices = read_polldevs(config.polling.file)
+    devices, _ = read_polldevs(config.polling.file)
     device = devices[args.router]
 
     snmp = SNMP(device)
@@ -29,7 +29,7 @@ async def run(args: argparse.Namespace):
 
 
 def parse_args():
-    devices = read_polldevs(config.polling.file)
+    devices, _ = read_polldevs(config.polling.file)
     parser = argparse.ArgumentParser(description="Fetch sysUptime from a device in the pollfile")
     parser.add_argument("router", type=str, help="Zino router name", choices=devices.keys())
     return parser.parse_args()

--- a/src/zino/scheduler.py
+++ b/src/zino/scheduler.py
@@ -46,7 +46,7 @@ def load_polldevs(polldevs_conf: str) -> Tuple[Set, Set, Set]:
     :returns: A tuple of (new_devices, deleted_devices, changed_devices)
     """
     try:
-        devices = {d.name: d for d in read_polldevs(polldevs_conf)}
+        devices = read_polldevs(polldevs_conf)
     except InvalidConfiguration as error:
         _log.error(error)
         return set(), set(), set()

--- a/src/zino/scheduler.py
+++ b/src/zino/scheduler.py
@@ -40,16 +40,16 @@ def get_scheduler() -> AsyncIOScheduler:
 
 
 @log_time_spent()
-def load_polldevs(polldevs_conf: str) -> Tuple[Set, Set, Set]:
+def load_polldevs(polldevs_conf: str) -> Tuple[Set, Set, Set, dict[str, str]]:
     """Loads pollfile into process state.
 
     :returns: A tuple of (new_devices, deleted_devices, changed_devices)
     """
     try:
-        devices = read_polldevs(polldevs_conf)
+        devices, defaults = read_polldevs(polldevs_conf)
     except InvalidConfiguration as error:
         _log.error(error)
-        return set(), set(), set()
+        return set(), set(), set(), dict()
 
     new_devices = set(devices) - set(state.polldevs)
     deleted_devices = set(state.polldevs) - set(devices)
@@ -68,7 +68,7 @@ def load_polldevs(polldevs_conf: str) -> Tuple[Set, Set, Set]:
     for device in deleted_devices:
         del state.polldevs[device]
 
-    return new_devices, deleted_devices, changed_devices
+    return new_devices, deleted_devices, changed_devices, defaults
 
 
 def init_state_for_devices(devices: Sequence[PollDevice]):
@@ -79,7 +79,7 @@ def init_state_for_devices(devices: Sequence[PollDevice]):
 
 
 async def load_and_schedule_polldevs(polldevs_conf: str):
-    new_devices, deleted_devices, changed_devices = load_polldevs(polldevs_conf)
+    new_devices, deleted_devices, changed_devices, defaults = load_polldevs(polldevs_conf)
     deschedule_devices(deleted_devices | changed_devices)
     schedule_devices(new_devices | changed_devices)
 

--- a/tests/config/polldevs_test.py
+++ b/tests/config/polldevs_test.py
@@ -14,14 +14,21 @@ from zino.config.polldevs import (
 
 class TestReadPolldevs:
     def test_should_generate_two_polldevices_from_test_config(self, polldevs_conf):
-        result = read_polldevs(polldevs_conf)
+        result, _ = read_polldevs(polldevs_conf)
         assert len(result) == 2
         assert all(isinstance(device, PollDevice) for device in result.values())
 
+    def test_should_return_default_values_from_test_config(self, polldevs_conf):
+        _, defaults = read_polldevs(polldevs_conf)
+        assert "community" in defaults
+        assert defaults["community"] == "foobar"
+        assert "domain" in defaults
+        assert defaults["domain"] == "uninett.no"
+
     def test_should_use_default_values_in_polldevices_generated_from_test_config(self, polldevs_conf):
-        result = read_polldevs(polldevs_conf).values()
-        assert all(device.community == "foobar" for device in result)
-        assert all(device.domain == "uninett.no" for device in result)
+        result, _ = read_polldevs(polldevs_conf)
+        assert all(device.community == "foobar" for device in result.values())
+        assert all(device.domain == "uninett.no" for device in result.values())
 
 
 class TestReadInvalidPolldevs:

--- a/tests/config/polldevs_test.py
+++ b/tests/config/polldevs_test.py
@@ -14,12 +14,12 @@ from zino.config.polldevs import (
 
 class TestReadPolldevs:
     def test_should_generate_two_polldevices_from_test_config(self, polldevs_conf):
-        result = list(read_polldevs(polldevs_conf))
+        result = read_polldevs(polldevs_conf)
         assert len(result) == 2
-        assert all(isinstance(device, PollDevice) for device in result)
+        assert all(isinstance(device, PollDevice) for device in result.values())
 
     def test_should_use_default_values_in_polldevices_generated_from_test_config(self, polldevs_conf):
-        result = list(read_polldevs(polldevs_conf))
+        result = read_polldevs(polldevs_conf).values()
         assert all(device.community == "foobar" for device in result)
         assert all(device.domain == "uninett.no" for device in result)
 
@@ -27,26 +27,26 @@ class TestReadPolldevs:
 class TestReadInvalidPolldevs:
     def test_should_raise_exception(self, invalid_polldevs_conf):
         with pytest.raises(InvalidConfiguration):
-            list(read_polldevs(invalid_polldevs_conf))
+            read_polldevs(invalid_polldevs_conf)
 
     def test_should_have_filename_in_exception(self, invalid_polldevs_conf):
         with pytest.raises(InvalidConfiguration) as e:
-            list(read_polldevs(invalid_polldevs_conf))
+            read_polldevs(invalid_polldevs_conf)
         assert "polldevs.cf" in str(e.value)
 
     def test_should_have_line_number_in_exception(self, invalid_polldevs_conf):
         with pytest.raises(InvalidConfiguration) as e:
-            list(read_polldevs(invalid_polldevs_conf))
+            read_polldevs(invalid_polldevs_conf)
         assert "2" in str(e.value)
 
     def test_exception_should_include_device_name_on_missing_address(self, missing_device_address_polldevs_conf):
         with pytest.raises(InvalidConfiguration) as e:
-            list(read_polldevs(missing_device_address_polldevs_conf))
+            read_polldevs(missing_device_address_polldevs_conf)
         assert "example-gw" in str(e.value)
 
     def test_exception_should_include_missing_attribute_on_missing_address(self, missing_device_address_polldevs_conf):
         with pytest.raises(InvalidConfiguration) as e:
-            list(read_polldevs(missing_device_address_polldevs_conf))
+            read_polldevs(missing_device_address_polldevs_conf)
         assert "Field required ('address')" in str(e.value)
 
 

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -12,16 +12,23 @@ class TestLoadPolldevs:
     @patch("zino.state.polldevs", dict())
     @patch("zino.state.state", ZinoState())
     def test_should_return_all_new_devices_on_first_run(self, polldevs_conf):
-        new_devices, deleted_devices, changed_devices = scheduler.load_polldevs(polldevs_conf)
+        new_devices, deleted_devices, changed_devices, _ = scheduler.load_polldevs(polldevs_conf)
         assert len(new_devices) > 0
         assert not deleted_devices
         assert not changed_devices
 
     @patch("zino.state.polldevs", dict())
     @patch("zino.state.state", ZinoState())
+    def test_should_return_defaults_on_first_run(self, polldevs_conf):
+        _, _, _, defaults = scheduler.load_polldevs(polldevs_conf)
+        assert len(defaults) > 0
+        assert "interval" in defaults
+
+    @patch("zino.state.polldevs", dict())
+    @patch("zino.state.state", ZinoState())
     def test_should_return_deleted_devices_on_second_run(self, polldevs_conf, polldevs_conf_with_single_router):
         scheduler.load_polldevs(polldevs_conf)
-        new_devices, deleted_devices, changed_devices = scheduler.load_polldevs(polldevs_conf_with_single_router)
+        new_devices, deleted_devices, changed_devices, _ = scheduler.load_polldevs(polldevs_conf_with_single_router)
         assert not new_devices
         assert len(deleted_devices) > 0
         assert not changed_devices
@@ -29,7 +36,7 @@ class TestLoadPolldevs:
     @patch("zino.state.polldevs", dict())
     @patch("zino.state.state", ZinoState())
     def test_should_return_no_new_or_deleted_devices_on_invalid_configuration(self, invalid_polldevs_conf):
-        new_devices, deleted_devices, changed_devices = scheduler.load_polldevs(invalid_polldevs_conf)
+        new_devices, deleted_devices, changed_devices, _ = scheduler.load_polldevs(invalid_polldevs_conf)
         assert not new_devices
         assert not deleted_devices
         assert not changed_devices
@@ -40,6 +47,30 @@ class TestLoadPolldevs:
         with caplog.at_level(logging.ERROR):
             scheduler.load_polldevs(invalid_polldevs_conf)
         assert "'lalala' is not a valid configuration line" in caplog.text
+
+    @patch("zino.state.polldevs", dict())
+    @patch("zino.state.state", ZinoState())
+    def test_should_return_changed_defaults(self, polldevs_conf, tmp_path):
+        polldevs_with_changed_defaults = tmp_path.joinpath("changed-defaults-polldevs.cf")
+        with open(polldevs_with_changed_defaults, "w") as conf:
+            conf.write(
+                """# polldevs test config
+                default interval: 10
+                default community: barfoo
+                default domain: uninett.no
+                default statistics: yes
+                default hcounters: yes
+
+                name: example-gw
+                address: 10.0.42.1
+
+                name: example-gw2
+                address: 10.0.43.1"""  # Lack of a new-line here is intentional to test the parser
+            )
+
+        _, _, _, defaults = scheduler.load_polldevs(polldevs_conf)
+        _, _, _, changed_defaults = scheduler.load_polldevs(polldevs_with_changed_defaults)
+        assert defaults != changed_defaults
 
     @patch("zino.state.polldevs", dict())
     @patch("zino.state.state", ZinoState())
@@ -62,7 +93,7 @@ class TestLoadPolldevs:
             )
 
         scheduler.load_polldevs(polldevs_conf)
-        new_devices, deleted_devices, changed_devices = scheduler.load_polldevs(polldevs_with_changed_defaults)
+        new_devices, deleted_devices, changed_devices, _ = scheduler.load_polldevs(polldevs_with_changed_defaults)
         assert not new_devices
         assert not deleted_devices
         assert changed_devices
@@ -89,7 +120,7 @@ class TestLoadPolldevs:
             )
 
         scheduler.load_polldevs(polldevs_conf)
-        new_devices, deleted_devices, changed_devices = scheduler.load_polldevs(polldevs_with_changed_defaults)
+        new_devices, deleted_devices, changed_devices, _ = scheduler.load_polldevs(polldevs_with_changed_defaults)
         assert not new_devices
         assert not deleted_devices
         assert changed_devices
@@ -99,7 +130,7 @@ class TestScheduleNewDevices:
     @patch("zino.state.polldevs", dict())
     @patch("zino.state.state", ZinoState())
     def test_should_schedule_jobs_for_new_devices(self, polldevs_conf, mocked_scheduler):
-        new_devices, _, _ = scheduler.load_polldevs(polldevs_conf)
+        new_devices, _, _, _ = scheduler.load_polldevs(polldevs_conf)
         assert len(new_devices) > 0
 
         scheduler.schedule_devices(new_devices)


### PR DESCRIPTION
## Scope and purpose

Fixes #337.

Changed the way that `read_polldevs` work to make it easier to return the `PollDevices` and the default values. I was considering splitting the function in two: One to read the defaults and one to read the rest - the poll devices, but decided for this method, since it is simpler changes.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
