### PR TITLE
Use ifalias for Planned Maintenance "str" and "regexp" matching

### DIFF
--- a/changelog.d/297.fixed.md
+++ b/changelog.d/297.fixed.md
@@ -1,1 +1,1 @@
-Fix PM matching wrongly using ifdescr instead of the correct ifalias
+Match against port alias instead of port description when match_type is "regexp" or "str" for portstate maintenance events. Still matches port description for "intf-regexp".

--- a/changelog.d/297.fixed.md
+++ b/changelog.d/297.fixed.md
@@ -1,0 +1,1 @@
+Fix PM matching wrongly using ifdescr instead of the correct ifalias

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -555,12 +555,12 @@ class PortStateMaintenance(PlannedMaintenance):
         would be affected by this planned maintenance
         """
         if self.match_type == MatchType.REGEXP:
-            return regex_match(self.match_expression, port.ifdescr)
+            return regex_match(self.match_expression, port.ifalias)
         if self.match_type == MatchType.STR:
-            return string_match(self.match_expression, port.ifdescr)
+            return string_match(self.match_expression, port.ifalias)
         if self.match_type == MatchType.INTF_REGEXP:
             if regex_match(self.match_device, device.name):
-                return regex_match(self.match_expression, port.ifdescr)
+                return regex_match(self.match_expression, port.ifalias)
         return False
 
     def get_matching(self, state: "ZinoState") -> Iterator[Sequence[Union[str, int]]]:

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -560,7 +560,7 @@ class PortStateMaintenance(PlannedMaintenance):
             return string_match(self.match_expression, port.ifalias)
         if self.match_type == MatchType.INTF_REGEXP:
             if regex_match(self.match_device, device.name):
-                return regex_match(self.match_expression, port.ifalias)
+                return regex_match(self.match_expression, port.ifdescr)
         return False
 
     def get_matching(self, state: "ZinoState") -> Iterator[Sequence[Union[str, int]]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,7 +267,7 @@ def _verify_localhost_snmp_response(port: int):
 
 @pytest.fixture
 def state_with_localhost_with_port(state_with_localhost):
-    port = Port(ifindex=1, ifdescr="eth0", state=InterfaceState.UP)
+    port = Port(ifindex=1, ifalias="eth0", state=InterfaceState.UP)
     device = state_with_localhost.devices.devices["localhost"]
     device.boot_time = now() - timedelta(minutes=10)
     device.ports[port.ifindex] = port

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,7 +267,7 @@ def _verify_localhost_snmp_response(port: int):
 
 @pytest.fixture
 def state_with_localhost_with_port(state_with_localhost):
-    port = Port(ifindex=1, ifalias="eth0", state=InterfaceState.UP)
+    port = Port(ifindex=1, ifdescr="eth0", ifalias="eth0alias", state=InterfaceState.UP)
     device = state_with_localhost.devices.devices["localhost"]
     device.boot_time = now() - timedelta(minutes=10)
     device.ports[port.ifindex] = port

--- a/tests/planned_maintenance_test.py
+++ b/tests/planned_maintenance_test.py
@@ -115,7 +115,7 @@ class TestUpdatePmStates:
 
     def test_events_matching_active_portstate_pm_should_be_set_to_ignored(self, state, active_portstate_pm):
         device = state.devices.get("device")
-        port = Port(ifindex=1, ifdescr="port")
+        port = Port(ifindex=1, ifdescr="port", ifalias="portalias")
         device.ports[port.ifindex] = port
         state.planned_maintenances.update_pm_states(state)
         event = state.events.get(device.name, port.ifindex, PortStateEvent)

--- a/tests/statemodels/conftest.py
+++ b/tests/statemodels/conftest.py
@@ -11,7 +11,7 @@ def state() -> ZinoState:
 
 @pytest.fixture
 def port() -> Port:
-    return Port(ifindex=1, ifdescr="port")
+    return Port(ifindex=1, ifdescr="port", ifalias="portalias")
 
 
 @pytest.fixture

--- a/tests/statemodels/portstate_maintenance_test.py
+++ b/tests/statemodels/portstate_maintenance_test.py
@@ -96,11 +96,16 @@ class TestMatchesPortstate:
 
 @pytest.fixture
 def portstate_pm(request, device, port) -> PortStateMaintenance:
+    match_type = request.param
+    if match_type == MatchType.INTF_REGEXP:
+        match_expression = port.ifdescr
+    else:
+        match_expression = port.ifalias
     return PortStateMaintenance(
         start_time=datetime.datetime.now() - datetime.timedelta(days=1),
         end_time=datetime.datetime.now() + datetime.timedelta(days=1),
-        match_type=request.param,
-        match_expression=port.ifalias,
+        match_type=match_type,
+        match_expression=match_expression,
         match_device=device.name,
     )
 

--- a/tests/statemodels/portstate_maintenance_test.py
+++ b/tests/statemodels/portstate_maintenance_test.py
@@ -70,7 +70,7 @@ class TestMatchesEvent:
 class TestMatchesPortstate:
     @pytest.mark.parametrize("portstate_pm", [MatchType.REGEXP, MatchType.STR, MatchType.INTF_REGEXP], indirect=True)
     def test_should_return_false_for_non_matching_port(self, portstate_pm, device, port):
-        port.ifdescr = "wrongport"
+        port.ifalias = "wrongport"
         assert not portstate_pm.matches_portstate(device, port)
 
     @pytest.mark.parametrize("portstate_pm", [MatchType.REGEXP, MatchType.STR], indirect=True)
@@ -99,7 +99,7 @@ def portstate_pm(request, device, port) -> PortStateMaintenance:
         start_time=datetime.datetime.now() - datetime.timedelta(days=1),
         end_time=datetime.datetime.now() + datetime.timedelta(days=1),
         match_type=request.param,
-        match_expression=port.ifdescr,
+        match_expression=port.ifalias,
         match_device=device.name,
     )
 
@@ -112,7 +112,7 @@ def matching_portstate_pm(device, port) -> Iterator[PortStateMaintenance]:
             start_time=datetime.datetime.now() - datetime.timedelta(days=1),
             end_time=datetime.datetime.now() + datetime.timedelta(days=1),
             match_type=MatchType.STR,
-            match_expression=port.ifdescr,
+            match_expression=port.ifalias,
             match_device=device.name,
         )
 
@@ -125,6 +125,6 @@ def nonmatching_portstate_pm(device, port) -> Iterator[PortStateMaintenance]:
             start_time=datetime.datetime.now() - datetime.timedelta(days=1),
             end_time=datetime.datetime.now() + datetime.timedelta(days=1),
             match_type=MatchType.STR,
-            match_expression=port.ifdescr,
+            match_expression=port.ifalias,
             match_device=device.name,
         )

--- a/tests/statemodels/portstate_maintenance_test.py
+++ b/tests/statemodels/portstate_maintenance_test.py
@@ -70,7 +70,8 @@ class TestMatchesEvent:
 class TestMatchesPortstate:
     @pytest.mark.parametrize("portstate_pm", [MatchType.REGEXP, MatchType.STR, MatchType.INTF_REGEXP], indirect=True)
     def test_should_return_false_for_non_matching_port(self, portstate_pm, device, port):
-        port.ifalias = "wrongport"
+        port.ifalias = "wrongportalias"
+        port.ifdescr = "wrongportdescr"
         assert not portstate_pm.matches_portstate(device, port)
 
     @pytest.mark.parametrize("portstate_pm", [MatchType.REGEXP, MatchType.STR], indirect=True)


### PR DESCRIPTION
## Scope and purpose

Fixes #297

Original zino seems to use ifalias and ifdescr for planned maintenance matching, while intitial PM implementation used only ifdescr.
This PR changes it to use ifalias where applicable instead. 

Original zino code confuses me so wouldn't be a bad idea for someone else to take a look and see if this PR actually makes the correct changes

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
