### PR TITLE
Log warning if secrets file is readable by other users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ old-events/
 polldevs.cf
 zino-state.json
 zino.toml
+
+# avoid accidental commit of the secrets file
+secrets

--- a/changelog.d/280.added.md
+++ b/changelog.d/280.added.md
@@ -1,0 +1,1 @@
+Log warning if `secrets` file is world-readable

--- a/src/zino/utils.py
+++ b/src/zino/utils.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import os
+import stat
 from functools import wraps
 from ipaddress import ip_address
 from time import time
@@ -63,3 +65,10 @@ def log_time_spent(logger: Union[logging.Logger, str] = __name__, level: int = l
         return wrapper
 
     return actual_decorator
+
+
+def file_is_world_readable(file: str) -> bool:
+    """Returns a boolean value indicating if a file is readable by other users than its owner"""
+    st_mode = getattr(os.stat(path=file), "st_mode", None)
+
+    return bool(st_mode & stat.S_IROTH)


### PR DESCRIPTION
## Scope and purpose

Fixes #280.
I did not add an test that it actually logs the warning, but I manually tested it and added tests for the utils function. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
