### PR TITLE
Fix wrong match_expression value

### DIFF
--- a/tests/statemodels/device_maintenance_test.py
+++ b/tests/statemodels/device_maintenance_test.py
@@ -88,26 +88,26 @@ def device_pm(request, device) -> DeviceMaintenance:
 
 
 @pytest.fixture
-def matching_device_pm(device, port) -> Iterator[DeviceMaintenance]:
+def matching_device_pm(device) -> Iterator[DeviceMaintenance]:
     with patch("zino.statemodels.DeviceMaintenance.matches_device") as mock:
         mock.return_value = True
         yield DeviceMaintenance(
             start_time=datetime.datetime.now() - datetime.timedelta(days=1),
             end_time=datetime.datetime.now() + datetime.timedelta(days=1),
             match_type=MatchType.STR,
-            match_expression=port.ifdescr,
+            match_expression=device.name,
             match_device=None,
         )
 
 
 @pytest.fixture
-def nonmatching_device_pm(device, port) -> Iterator[DeviceMaintenance]:
+def nonmatching_device_pm(device) -> Iterator[DeviceMaintenance]:
     with patch("zino.statemodels.DeviceMaintenance.matches_device") as mock:
         mock.return_value = False
         yield DeviceMaintenance(
             start_time=datetime.datetime.now() - datetime.timedelta(days=1),
             end_time=datetime.datetime.now() + datetime.timedelta(days=1),
             match_type=MatchType.STR,
-            match_expression=port.ifdescr,
+            match_expression=device.name,
             match_device=None,
         )


### PR DESCRIPTION
## Scope and purpose

This PR fixes an error in a fixture where match_expression for the fixture is set to port descr, but should be
device name instead. It doesnt really matter much since the code that actually does matching is mocked in this instance,
but why not just fix it

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
