### PR TITLE
Check actual event type and not PmType

### DIFF
--- a/changelog.d/344.fixed.md
+++ b/changelog.d/344.fixed.md
@@ -1,1 +1,1 @@
-Fix using wrong value to check if event is correct subclass
+When matching an event to a planned maintenance check that event is of the correct subclass

--- a/changelog.d/344.fixed.md
+++ b/changelog.d/344.fixed.md
@@ -1,0 +1,1 @@
+Fix using wrong value to check if event is correct subclass

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -544,7 +544,7 @@ class PortStateMaintenance(PlannedMaintenance):
 
     def matches_event(self, event: Event, state: "ZinoState") -> bool:
         """Returns true if `event` will be affected by this planned maintenance"""
-        if event.type != PmType.PORTSTATE:
+        if not isinstance(event, PortStateEvent):
             return False
         device = state.devices[event.router]
         port = device.ports[event.ifindex]


### PR DESCRIPTION
## Scope and purpose

Fixes a bug where it compares the type of event to a planned maintenance type, which makes no sense. Instead it should check if the event is an instance of the correct event subclass.

This bug luckily did not actually have any impact on the behaviour, since it checks if `event.type` equals `"portstate"`, which effectively does the same as checking `isinstance(event, PortstateEvent)`, which is why this was not picked up by any tests 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
