### PR TITLE
Set width in float formatting of flapping logs

### DIFF
--- a/src/zino/trapobservers/link_traps.py
+++ b/src/zino/trapobservers/link_traps.py
@@ -121,7 +121,7 @@ class LinkTrapObserver(TrapObserver):
         event.flaps = flap.flaps
         msg = (
             f'{device.name}: intf "{port.ifdescr}" ix {port.ifindex} ({port.ifalias}) flapping, '
-            f"{event.flaps} flaps, penalty {flap.hist_val:.2f}"
+            f"{event.flaps} flaps, penalty {flap.hist_val:5.2f}"
         )
         _logger.info(msg)
         event.add_log(msg)


### PR DESCRIPTION
## Scope and purpose

This was missed in #284, but is done like this in Zino1.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * only microscopic changes to logging/event log
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
