### PR TITLE
Revert using alias when dumping to state file

### DIFF
--- a/src/zino/state.py
+++ b/src/zino/state.py
@@ -40,7 +40,7 @@ class ZinoState(BaseModel):
         """Dumps the full state to a file in JSON format"""
         _log.debug("dumping state to %s", filename)
         with open(filename, "w") as statefile:
-            statefile.write(self.model_dump_json(exclude_none=True, indent=2, by_alias=True))
+            statefile.write(self.model_dump_json(exclude_none=True, indent=2))
 
     @classmethod
     @log_time_spent()


### PR DESCRIPTION
## Scope and purpose
Fixes a little mistake introduced in #328. We need the `by_alias` flag in `model_dump_simple_attrs`, since that is what is used by the API, but not when dumping to the state file. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * previous change is not part of a release yet
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
