### PR TITLE
Only override default config values if config file exists and is valid

### DIFF
--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -52,8 +52,13 @@ def main():
     init_event_loop(args)
 
 
-def load_config(args: argparse.Namespace) -> state.Configuration:
-    """Loads the configuration file, exiting the process if there are config errors"""
+def load_config(args: argparse.Namespace) -> Optional[state.Configuration]:
+    """
+    Loads the configuration file, exiting the process if there are config errors
+
+    Returns the configuration specified by the config file and None if no config file
+    name was specified as argument and no default config file exists
+    """
     try:
         return read_configuration(args.config_file or DEFAULT_CONFIG_FILE, args.polldevs)
     except OSError:

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -44,7 +44,9 @@ def main():
         level=logging.INFO if not args.debug else logging.DEBUG,
         format="%(asctime)s - %(levelname)s - %(name)s (%(threadName)s) - %(message)s",
     )
-    state.config = load_config(args)
+    config = load_config(args)
+    if config:
+        state.config = config
     apply_logging_config(state.config.logging)
     state.state = state.ZinoState.load_state_from_file(state.config.persistence.file) or state.ZinoState()
     init_event_loop(args)


### PR DESCRIPTION
## Scope and purpose

Fixes something overlooked in #315. In case no config file is given and none exists under the default name the function `load_config` returns `None`, which overrides the default values that `state.config` has before. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * the oversight has not made it into a release yet
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
  * but manually tested
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
