### PR TITLE
Enable auto pytest-asyncio mode

### DIFF
--- a/tests/flaps_test.py
+++ b/tests/flaps_test.py
@@ -253,7 +253,7 @@ def state_with_flapstats_and_portstate_event(state_with_flapstats) -> ZinoState:
 
 
 class TestAgeSingleInterfaceFlappingState:
-    @pytest.mark.asyncio
+
     async def test_it_should_decrease_hist_val(self, state_with_flapstats, polldevs_dict):
         port: Port = next(iter(state_with_flapstats.devices.devices["localhost"].ports.values()))
         flapping_state = state_with_flapstats.flapping.interfaces[("localhost", port.ifindex)]
@@ -264,7 +264,6 @@ class TestAgeSingleInterfaceFlappingState:
         )
         assert flapping_state.hist_val < initial
 
-    @pytest.mark.asyncio
     async def test_when_flap_is_below_threshold_it_should_remove_flapping_state(
         self, mocked_out_poll_single_interface, state_with_flapstats, polldevs_dict
     ):
@@ -280,7 +279,7 @@ class TestAgeSingleInterfaceFlappingState:
 
 
 class TestStabilizeFlappingState:
-    @pytest.mark.asyncio
+
     async def test_when_no_event_exists_it_should_create_an_event(
         self, mocked_out_poll_single_interface, state_with_flapstats, polldevs_dict
     ):
@@ -296,7 +295,6 @@ class TestStabilizeFlappingState:
 
         assert len(state_with_flapstats.events.events) > 0
 
-    @pytest.mark.asyncio
     async def test_when_a_matching_event_exists_it_should_set_its_flapstate_to_stable(
         self, mocked_out_poll_single_interface, state_with_flapstats, polldevs_dict
     ):
@@ -325,7 +323,6 @@ class TestStabilizeFlappingState:
         assert updated_event
         assert updated_event.flapstate == FlapState.STABLE
 
-    @pytest.mark.asyncio
     async def test_when_a_matching_closed_event_exists_it_should_set_its_flapstate_to_stable(
         self, mocked_out_poll_single_interface, state_with_flapstats, polldevs_dict
     ):
@@ -356,7 +353,6 @@ class TestStabilizeFlappingState:
         assert closed_event
         assert closed_event.flapstate == FlapState.STABLE
 
-    @pytest.mark.asyncio
     async def test_when_port_is_unkown_it_should_still_log_the_change(
         self,
         mocked_out_poll_single_interface,
@@ -377,7 +373,6 @@ class TestStabilizeFlappingState:
         assert f"{fake_ifindex} stopped flapping" in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_age_flapping_states_should_age_all_flapping_states(monkeypatch, event_loop):
     future = event_loop.create_future()
     future.set_result(None)

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -48,38 +48,33 @@ def unreachable_snmp_client():
 
 
 class TestSNMPRequestsResponseTypes:
-    @pytest.mark.asyncio
+
     async def test_get(self, snmp_client):
         response = await snmp_client.get("SNMPv2-MIB", "sysUpTime", 0)
         assert isinstance(response.oid, OID)
         assert isinstance(response.value, int)
 
-    @pytest.mark.asyncio
     async def test_get2_should_return_symbolic_identifiers(self, snmp_client):
         response = await snmp_client.get2(("IF-MIB", "ifName", 1), ("IF-MIB", "ifAlias", 1))
         assert len(list(response)) == 2
         assert any(identifier == Identifier("IF-MIB", "ifName", OID(".1")) for identifier, _ in response)
         assert any(identifier == Identifier("IF-MIB", "ifAlias", OID(".1")) for identifier, _ in response)
 
-    @pytest.mark.asyncio
     async def test_when_mib_is_unkown_get2_should_raise_mibnotfounderror(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.get2(("FOOBAR-MIB", "ifName", 1), ("FOOBAR-MIB", "ifAlias", 1))
 
-    @pytest.mark.asyncio
     async def test_getnext(self, snmp_client):
         response = await snmp_client.getnext("SNMPv2-MIB", "sysUpTime")
         assert isinstance(response.oid, OID)
         assert isinstance(response.value, int)
 
-    @pytest.mark.asyncio
     async def test_getnext2_should_return_symbolic_identifiers(self, snmp_client):
         response = await snmp_client.getnext2(("IF-MIB", "ifName", "1"), ("IF-MIB", "ifAlias", "1"))
         assert len(list(response)) == 2
         assert any(identifier == Identifier("IF-MIB", "ifName", OID(".2")) for identifier, _ in response)
         assert any(identifier == Identifier("IF-MIB", "ifAlias", OID(".2")) for identifier, _ in response)
 
-    @pytest.mark.asyncio
     async def test_walk(self, snmp_client):
         response = await snmp_client.walk("SNMPv2-MIB", "sysUpTime")
         assert response
@@ -87,7 +82,6 @@ class TestSNMPRequestsResponseTypes:
             assert isinstance(mib_object.oid, OID)
             assert isinstance(mib_object.value, int)
 
-    @pytest.mark.asyncio
     async def test_getbulk(self, snmp_client):
         response = await snmp_client.getbulk("SNMPv2-MIB", "sysUpTime")
         assert response
@@ -95,7 +89,6 @@ class TestSNMPRequestsResponseTypes:
             assert isinstance(mib_object.oid, OID)
             assert isinstance(mib_object.value, int)
 
-    @pytest.mark.asyncio
     async def test_getbulk2_should_have_expected_response(self, snmp_client):
         variables = ("ifIndex", "ifDescr", "ifAlias")
         response = await snmp_client.getbulk2(*(("IF-MIB", var) for var in variables))
@@ -105,7 +98,6 @@ class TestSNMPRequestsResponseTypes:
             for ident, value in var_binds:
                 assert ident.object in variables
 
-    @pytest.mark.asyncio
     async def test_bulkwalk(self, snmp_client):
         response = await snmp_client.bulkwalk("SNMPv2-MIB", "sysUpTime")
         assert response
@@ -113,7 +105,6 @@ class TestSNMPRequestsResponseTypes:
             assert isinstance(mib_object.oid, OID)
             assert isinstance(mib_object.value, int)
 
-    @pytest.mark.asyncio
     async def test_sparsewalk_should_have_expected_response(self, snmp_client):
         variables = ("ifIndex", "ifDescr", "ifAlias")
         response = await snmp_client.sparsewalk(*(("IF-MIB", var) for var in variables))
@@ -124,56 +115,47 @@ class TestSNMPRequestsResponseTypes:
             for var, val in row.items():
                 assert var in variables
 
-    @pytest.mark.asyncio
     async def test_get_sysobjectid_should_be_tuple_of_ints(self, snmp_client):
         response = await snmp_client.get("SNMPv2-MIB", "sysObjectID", 0)
         assert isinstance(response.oid, OID)
         assert isinstance(response.value, OID)
         assert all(isinstance(i, int) for i in response.value)
 
-    @pytest.mark.asyncio
     async def test_get_named_value_should_return_symbolic_name(self, snmp_client):
         response = await snmp_client.getnext("SNMPv2-MIB", "snmpEnableAuthenTraps")
         assert response.value == "disabled"
 
 
 class TestUnknownMibShouldRaiseException:
-    @pytest.mark.asyncio
+
     async def test_get(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.get("NON-EXISTENT-MIB", "foo", 0)
 
-    @pytest.mark.asyncio
     async def test_getnext(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.getnext("NON-EXISTENT-MIB", "foo")
 
-    @pytest.mark.asyncio
     async def test_getnext2(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.getnext2(("NON-EXISTENT-MIB", "foo"))
 
-    @pytest.mark.asyncio
     async def test_walk(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.walk("NON-EXISTENT-MIB", "foo")
 
-    @pytest.mark.asyncio
     async def test_getbulk(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.getbulk("NON-EXISTENT-MIB", "foo")
 
-    @pytest.mark.asyncio
     async def test_bulkwalk(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.bulkwalk("NON-EXISTENT-MIB", "foo")
 
-    @pytest.mark.asyncio
     async def test_getbulk2(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.getbulk2(("NON-EXISTENT-MIB", "foo"))
 
-    @pytest.mark.asyncio
     async def test_sparsewalk(self, snmp_client):
         with pytest.raises(MibNotFoundError):
             await snmp_client.sparsewalk(("NON-EXISTENT-MIB", "foo"))
@@ -214,48 +196,40 @@ class TestMibResolver:
 
 
 class TestUnreachableDeviceShouldRaiseException:
-    @pytest.mark.asyncio
+
     async def test_get(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.get("SNMPv2-MIB", "sysUpTime", 0)
 
-    @pytest.mark.asyncio
     async def test_getnext(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.getnext("SNMPv2-MIB", "sysUpTime")
 
-    @pytest.mark.asyncio
     async def test_getnext2(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.getnext2(("SNMPv2-MIB", "sysUpTime"))
 
-    @pytest.mark.asyncio
     async def test_walk(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.walk("SNMPv2-MIB", "sysUpTime")
 
-    @pytest.mark.asyncio
     async def test_getbulk(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.getbulk("SNMPv2-MIB", "sysUpTime")
 
-    @pytest.mark.asyncio
     async def test_bulkwalk(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.bulkwalk("SNMPv2-MIB", "sysUpTime")
 
-    @pytest.mark.asyncio
     async def test_getbulk2(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.getbulk2(("SNMPv2-MIB", "sysUpTime"))
 
-    @pytest.mark.asyncio
     async def test_sparsewalk(self, unreachable_snmp_client):
         with pytest.raises(TimeoutError):
             await unreachable_snmp_client.sparsewalk(("SNMPv2-MIB", "sysUpTime"))
 
 
-@pytest.mark.asyncio
 async def test_get_object_that_does_not_exist_should_raise_exception(snmp_client):
     with pytest.raises(NoSuchNameError):
         await snmp_client.get("SNMPv2-MIB", "sysUpTime", 1)
@@ -278,7 +252,6 @@ class TestVarBindErrors:
     in the response to an SNMP command.
     """
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "error, exception",
         [

--- a/tests/tasks/test_addrs.py
+++ b/tests/tasks/test_addrs.py
@@ -9,12 +9,11 @@ from zino.tasks.addrs import AddressMapTask, validate_ipaddr
 
 
 class TestAddressMapTask:
-    @pytest.mark.asyncio
+
     async def test_it_should_run_without_error_on_reachable_device(self, address_task_with_dummy_device):
         result = await address_task_with_dummy_device.run()
         assert result is None
 
-    @pytest.mark.asyncio
     async def test_get_addrs_should_find_addresses(self, address_task_with_dummy_device):
         result = await address_task_with_dummy_device._get_addrs()
         assert result == {
@@ -26,7 +25,6 @@ class TestAddressMapTask:
             IPv4Address("128.0.0.4"),
         }
 
-    @pytest.mark.asyncio
     async def test_when_address_is_removed_it_should_update_the_state_accordingly(self, address_task_with_dummy_device):
         dead_address = IPv4Address("192.0.168.42")
 
@@ -40,7 +38,6 @@ class TestAddressMapTask:
         assert dead_address not in device.addresses
         assert dead_address not in state.addresses
 
-    @pytest.mark.asyncio
     async def test_when_address_is_taken_from_other_device_it_should_update_the_state_accordingly(
         self, address_task_with_dummy_device
     ):

--- a/tests/tasks/test_bfdtask.py
+++ b/tests/tasks/test_bfdtask.py
@@ -20,7 +20,6 @@ class TestJuniper:
         )
         assert state == bfd_state
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["juniper-bfd-up"], indirect=True)
     async def test_poll_juniper_returns_correct_ifdescr_to_state_mapping(self, task, bfd_state, device_port):
         result = await task._poll_juniper()
@@ -28,7 +27,6 @@ class TestJuniper:
         state = result.get(device_port.ifdescr)
         assert state == bfd_state
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["juniper-bfd-up"], indirect=True)
     async def test_when_single_index_is_given_then_poll_juniper_should_return_correct_ifdescr_to_state_mapping(
         self, task, bfd_state, device_port
@@ -39,7 +37,6 @@ class TestJuniper:
         assert state == bfd_state
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("task", ["juniper-bfd-up", "cisco-bfd-up"], indirect=True)
 async def test_task_updates_state_correctly(task, device_port, bfd_state):
     assert not device_port.bfd_state
@@ -47,7 +44,6 @@ async def test_task_updates_state_correctly(task, device_port, bfd_state):
     assert device_port.bfd_state == bfd_state
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("task", ["juniper-bfd-down", "cisco-bfd-down"], indirect=True)
 async def test_event_should_be_made_the_first_time_a_port_is_polled_if_state_is_not_up(task, device_port):
     assert not device_port.bfd_state
@@ -61,7 +57,6 @@ async def test_event_should_be_made_the_first_time_a_port_is_polled_if_state_is_
     assert event
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("task", ["juniper-bfd-up", "cisco-bfd-up"], indirect=True)
 async def test_event_should_not_be_made_the_first_time_a_port_is_polled_if_state_is_up(task, device_port):
     assert not device_port.bfd_state
@@ -75,7 +70,6 @@ async def test_event_should_not_be_made_the_first_time_a_port_is_polled_if_state
     assert not event
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("task", ["juniper-bfd-up", "cisco-bfd-up"], indirect=True)
 async def test_state_changing_should_create_event(task, device_port, bfd_state):
     down_state = BFDState(session_state=BFDSessState.DOWN, session_index=bfd_state.session_index)
@@ -86,7 +80,6 @@ async def test_state_changing_should_create_event(task, device_port, bfd_state):
     assert event
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("task", ["juniper-bfd-up", "cisco-bfd-up"], indirect=True)
 async def test_state_not_changing_should_not_create_event(task, device_port, bfd_state):
     device_port.bfd_state = bfd_state

--- a/tests/tasks/test_bgpstatemonitortask.py
+++ b/tests/tasks/test_bgpstatemonitortask.py
@@ -20,12 +20,11 @@ DEFAULT_UPTIME = 250
 
 
 class TestBGPStateMonitorTask:
-    @pytest.mark.asyncio
+
     @pytest.mark.parametrize("task", ["public", "juniper-bgp", "cisco-bgp", "general-bgp"], indirect=True)
     async def test_task_runs_without_errors(self, task):
         assert (await task.run()) is None
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["missing-info-bgp"], indirect=True)
     async def test_task_logs_missing_information(self, task, caplog):
         """Tests that the BGP state monitor task logs if necessary information for a BGP device is missing"""
@@ -34,7 +33,6 @@ class TestBGPStateMonitorTask:
 
         assert f"router {task.device.name} misses BGP variables" in caplog.text
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task", ["general-bgp-external-reset", "cisco-bgp-external-reset", "juniper-bgp-external-reset"], indirect=True
     )
@@ -57,7 +55,6 @@ class TestBGPStateMonitorTask:
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == DEFAULT_UPTIME
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task", ["general-bgp-external-reset", "cisco-bgp-external-reset", "juniper-bgp-external-reset"], indirect=True
     )
@@ -90,7 +87,6 @@ class TestBGPStateMonitorTask:
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == DEFAULT_UPTIME
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task", ["general-bgp-admin-down", "cisco-bgp-admin-down", "juniper-bgp-admin-down"], indirect=True
     )
@@ -117,7 +113,6 @@ class TestBGPStateMonitorTask:
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == 0
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task", ["general-bgp-admin-up", "cisco-bgp-admin-up", "juniper-bgp-admin-up"], indirect=True
     )
@@ -157,7 +152,6 @@ class TestBGPStateMonitorTask:
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == 0
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task", ["general-bgp-oper-down", "cisco-bgp-oper-down", "juniper-bgp-oper-down"], indirect=True
     )
@@ -183,7 +177,6 @@ class TestBGPStateMonitorTask:
         assert event.remote_as == DEFAULT_REMOTE_AS
         assert event.peer_uptime == 1000000
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task", ["general-bgp-oper-down", "cisco-bgp-oper-down", "juniper-bgp-oper-down"], indirect=True
     )
@@ -203,7 +196,6 @@ class TestBGPStateMonitorTask:
         assert event
         assert event.model_dump_json(exclude_none=True, indent=2, warnings="error")
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "task",
         ["general-bgp-oper-down-short", "cisco-bgp-oper-down-short", "juniper-bgp-oper-down-short"],
@@ -235,49 +227,42 @@ class TestBGPStateMonitorTask:
 
 
 class TestGetBGPStyle:
-    @pytest.mark.asyncio
+
     @pytest.mark.parametrize("task", ["juniper-bgp"], indirect=True)
     async def test_get_bgp_style_returns_correct_style_for_juniper(self, task):
         assert (await task._get_bgp_style()) == BGPStyle.JUNIPER
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["cisco-bgp"], indirect=True)
     async def test_get_bgp_style_returns_correct_style_for_cisco(self, task):
         assert (await task._get_bgp_style()) == BGPStyle.CISCO
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["general-bgp"], indirect=True)
     async def test_get_bgp_style_returns_correct_style_for_general(self, task):
         assert (await task._get_bgp_style()) == BGPStyle.GENERAL
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["public"], indirect=True)
     async def test_get_bgp_style_returns_correct_style_for_non_bgp_task(self, task):
         assert (await task._get_bgp_style()) is None
 
 
 class TestGetLocalAs:
-    @pytest.mark.asyncio
+
     @pytest.mark.parametrize("task", ["juniper-bgp"], indirect=True)
     async def test_get_local_as_returns_correct_value_for_juniper(self, task):
         assert (await task._get_local_as(bgp_style=BGPStyle.JUNIPER)) == 10
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["cisco-bgp"], indirect=True)
     async def test_get_local_as_returns_correct_value_for_cisco(self, task):
         assert (await task._get_local_as(bgp_style=BGPStyle.CISCO)) == 10
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["general-bgp"], indirect=True)
     async def test_get_local_as_returns_correct_value_for_general(self, task):
         assert (await task._get_local_as(bgp_style=BGPStyle.GENERAL)) == 10
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["public"], indirect=True)
     async def test_get_local_as_returns_none_for_non_existent_local_as(self, task):
         assert (await task._get_local_as(bgp_style=BGPStyle.GENERAL)) is None
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("task", ["public"], indirect=True)
     async def test_get_local_as_returns_none_for_non_existent_local_as_with_juniper_bgp_style(self, task):
         assert (await task._get_local_as(bgp_style=BGPStyle.JUNIPER)) is None

--- a/tests/tasks/test_juniperalarmtask.py
+++ b/tests/tasks/test_juniperalarmtask.py
@@ -9,11 +9,10 @@ from zino.tasks.juniperalarmtask import JuniperAlarmTask
 
 
 class TestJuniperalarmTask:
-    @pytest.mark.asyncio
+
     async def test_task_runs_without_errors(self, juniper_alarm_task):
         assert (await juniper_alarm_task.run()) is None
 
-    @pytest.mark.asyncio
     async def test_task_does_nothing_for_non_juniper_device(self, juniper_alarm_task):
         task = juniper_alarm_task
         device_state = task.state.devices.get(device_name=task.device.name)
@@ -23,7 +22,6 @@ class TestJuniperalarmTask:
 
         assert device_state.alarms is None
 
-    @pytest.mark.asyncio
     async def test_task_does_nothing_for_no_result(self, caplog, snmp_test_port):
         device = PollDevice(
             name="buick.lab.example.org",
@@ -45,7 +43,6 @@ class TestJuniperalarmTask:
             not in caplog.text
         )
 
-    @pytest.mark.asyncio
     async def test_task_logs_error_for_non_int_result(self, caplog, snmp_test_port):
         device = PollDevice(
             name="buick.lab.example.org",
@@ -67,7 +64,6 @@ class TestJuniperalarmTask:
         )
         assert "Yellow alarm count: value 0. Red alarm count: value 'buick'." in caplog.text
 
-    @pytest.mark.asyncio
     async def test_task_saves_alarm_count_in_device_state(self, juniper_alarm_task):
         task = juniper_alarm_task
         device_state = task.state.devices.get(device_name=task.device.name)
@@ -79,7 +75,6 @@ class TestJuniperalarmTask:
         assert device_state.alarms["yellow"] == 1
         assert device_state.alarms["red"] == 2
 
-    @pytest.mark.asyncio
     async def test_task_overrides_alarm_count_in_device_state(self, juniper_alarm_task):
         task = juniper_alarm_task
         device_state = task.state.devices.get(device_name=task.device.name)
@@ -94,7 +89,6 @@ class TestJuniperalarmTask:
         assert device_state.alarms["yellow"] == 1
         assert device_state.alarms["red"] == 2
 
-    @pytest.mark.asyncio
     async def test_task_creates_both_alarm_events_on_both_counts_changed(self, juniper_alarm_task):
         task = juniper_alarm_task
         device_state = task.state.devices.get(device_name=task.device.name)
@@ -110,7 +104,6 @@ class TestJuniperalarmTask:
         assert yellow_event.alarm_count == 1
         assert red_event.alarm_count == 2
 
-    @pytest.mark.asyncio
     async def test_task_creates_one_alarm_event_on_one_count_changed(self, juniper_alarm_task):
         task = juniper_alarm_task
         device_state = task.state.devices.get(device_name=task.device.name)
@@ -129,7 +122,6 @@ class TestJuniperalarmTask:
         assert red_event
         assert red_event.alarm_count == 2
 
-    @pytest.mark.asyncio
     async def test_task_creates_event_with_correct_log_on_initial_run(self, juniper_alarm_task):
         task = juniper_alarm_task
         device_state = task.state.devices.get(device_name=task.device.name)
@@ -147,7 +139,6 @@ class TestJuniperalarmTask:
         log_messages = [log_entry.message for log_entry in red_event.log]
         assert f"{juniper_alarm_task.device.name} red alarms went from 0 to 2" in log_messages
 
-    @pytest.mark.asyncio
     async def test_task_updates_alarm_events(self, juniper_alarm_task):
         task = juniper_alarm_task
         device_state = task.state.devices.get(device_name=task.device.name)
@@ -171,7 +162,6 @@ class TestJuniperalarmTask:
         assert new_yellow_event.alarm_count == 1
         assert new_red_event.alarm_count == 2
 
-    @pytest.mark.asyncio
     async def test_task_does_not_create_alarm_events_on_unchanged_alarm_count(self, juniper_alarm_task):
         task = juniper_alarm_task
         device_state = task.state.devices.get(device_name=task.device.name)
@@ -189,7 +179,6 @@ class TestJuniperalarmTask:
         assert not yellow_event
         assert not red_event
 
-    @pytest.mark.asyncio
     async def test_task_does_not_create_alarm_events_on_alarm_count_zero_on_first_run(self, snmp_test_port):
         device = PollDevice(
             name="buick.lab.example.org",

--- a/tests/tasks/test_linkstatetask.py
+++ b/tests/tasks/test_linkstatetask.py
@@ -15,13 +15,12 @@ from zino.tasks.linkstatetask import (
 
 
 class TestLinkStateTask:
-    @pytest.mark.asyncio
+
     async def test_run_should_not_create_event_if_links_are_up(self, linkstatetask_with_links_up):
         task = linkstatetask_with_links_up
         assert (await task.run()) is None
         assert len(task.state.events) == 0
 
-    @pytest.mark.asyncio
     async def test_run_should_create_event_if_at_least_one_link_is_down(self, linkstatetask_with_one_link_down):
         task = linkstatetask_with_one_link_down
         assert (await task.run()) is None
@@ -92,7 +91,6 @@ class TestBaseInterfaceRow:
         row = BaseInterfaceRow(index=42, descr="x", alias="x", admin_status="x", oper_status="x", last_change=0)
         assert row.is_sane()
 
-    @pytest.mark.asyncio
     async def test_poll_single_interface_should_update_state(self, linkstatetask_with_one_link_down):
         target_index = 2
         await linkstatetask_with_one_link_down.poll_single_interface(target_index)
@@ -104,7 +102,6 @@ class TestBaseInterfaceRow:
         assert port.ifdescr == "2"
         assert port.ifalias == "from a famous"
 
-    @pytest.mark.asyncio
     async def test_when_ifindex_is_1_poll_single_interface_should_not_crash(self, linkstatetask_with_one_link_down):
         """Regression test.  poll_single_interface constructs a GET-NEXT request by asking for the set of next values
         after ifindex-1 - but 0 indexes are illegal when encoding OIDs into tables.
@@ -112,7 +109,6 @@ class TestBaseInterfaceRow:
         target_index = 1
         assert await linkstatetask_with_one_link_down.poll_single_interface(target_index) is None
 
-    @pytest.mark.asyncio
     async def test_when_timeout_occurs_poll_single_interface_should_not_crash(self, linkstatetask_with_one_link_down):
         with patch.object(linkstatetask_with_one_link_down.snmp, "getnext2") as mock_getnext2:
             mock_getnext2.side_effect = TimeoutError

--- a/tests/tasks/test_reachabletask.py
+++ b/tests/tasks/test_reachabletask.py
@@ -5,14 +5,13 @@ from zino.tasks.errors import DeviceUnreachableError
 
 
 class TestReachableTask:
-    @pytest.mark.asyncio
+
     async def test_run_should_not_create_event_if_device_is_reachable(self, reachable_task):
         task = reachable_task
         assert (await task.run()) is None
         event = task.state.events.get(task.device.name, None, ReachabilityEvent)
         assert not event
 
-    @pytest.mark.asyncio
     async def test_run_should_create_event_if_device_is_unreachable(self, unreachable_task):
         task = unreachable_task
         with pytest.raises(DeviceUnreachableError):
@@ -20,19 +19,16 @@ class TestReachableTask:
         event = task.state.events.get(task.device.name, None, ReachabilityEvent)
         assert event
 
-    @pytest.mark.asyncio
     async def test_run_should_start_extra_job_if_device_is_unreachable(self, unreachable_task):
         with pytest.raises(DeviceUnreachableError):
             await unreachable_task.run()
         assert unreachable_task._extra_job_is_running()
 
-    @pytest.mark.asyncio
     async def test_run_should_not_start_extra_job_if_device_is_reachable(self, reachable_task):
         task = reachable_task
         assert (await task.run()) is None
         assert not task._extra_job_is_running()
 
-    @pytest.mark.asyncio
     async def test_run_should_update_event_to_reachable_when_device_is_reachable(self, reachable_task):
         task = reachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
@@ -43,7 +39,6 @@ class TestReachableTask:
         updated_event = task.state.events[event.id]
         assert updated_event.reachability == ReachabilityState.REACHABLE
 
-    @pytest.mark.asyncio
     async def test_run_should_update_event_to_noresponse_when_device_is_unreachable(self, unreachable_task):
         task = unreachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
@@ -55,7 +50,6 @@ class TestReachableTask:
         updated_event = task.state.events[event.id]
         assert updated_event.reachability == ReachabilityState.NORESPONSE
 
-    @pytest.mark.asyncio
     async def test_run_extra_job_should_update_event_to_reachable_when_device_is_reachable(self, reachable_task):
         task = reachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)
@@ -66,7 +60,6 @@ class TestReachableTask:
         updated_event = task.state.events[event.id]
         assert updated_event.reachability == ReachabilityState.REACHABLE
 
-    @pytest.mark.asyncio
     async def test_run_extra_job_should_not_update_event_when_device_is_unreachable(self, unreachable_task):
         task = unreachable_task
         event = task.state.events.create_event(task.device.name, None, ReachabilityEvent)

--- a/tests/tasks/test_run_all_tasks.py
+++ b/tests/tasks/test_run_all_tasks.py
@@ -9,11 +9,10 @@ from zino.tasks.task import Task
 
 
 class TestRunAllTasks:
-    @pytest.mark.asyncio
+
     async def test_does_not_raise_error_if_device_is_unreachable(self, unreachable_task):
         assert (await run_all_tasks(unreachable_task.device, unreachable_task.state)) is None
 
-    @pytest.mark.asyncio
     async def test_when_one_task_raises_device_unreachable_it_should_not_run_further_tasks(
         self, raising_task, non_raising_task
     ):
@@ -27,7 +26,7 @@ class TestRunAllTasks:
 
 
 class TestRunRegisteredTasks:
-    @pytest.mark.asyncio
+
     async def test_raises_error_if_device_is_unreachable(self, unreachable_task):
         """The rest of the registered tasks are cancelled as a result of this"""
         with pytest.raises(DeviceUnreachableError):

--- a/tests/tasks/test_task.py
+++ b/tests/tasks/test_task.py
@@ -8,7 +8,7 @@ from zino.tasks.reachabletask import ReachableTask
 
 
 class TestTask:
-    @pytest.mark.asyncio
+
     async def test_get_sysuptime_returns_uptime(self, snmpsim, snmp_test_port):
         device = PollDevice(
             name="buick.lab.example.org",
@@ -21,7 +21,6 @@ class TestTask:
         uptime = await task._get_uptime()
         assert uptime
 
-    @pytest.mark.asyncio
     async def test_get_sysuptime_raises_timeout_error(self):
         device = PollDevice(name="nonexist", address="127.0.0.1", community="invalid", port=666)
         state = ZinoState()

--- a/tests/tasks/test_vendor.py
+++ b/tests/tasks/test_vendor.py
@@ -8,7 +8,7 @@ from zino.tasks.vendor import VendorTask
 
 
 class TestVendorTask:
-    @pytest.mark.asyncio
+
     async def test_run_should_set_enterprise_id(self, snmpsim, snmp_test_port):
         device = PollDevice(name="localhost", address="127.0.0.1", community="public", port=snmp_test_port)
         state = ZinoState()
@@ -18,7 +18,6 @@ class TestVendorTask:
         # The "public" test fixture is from an HP switch
         assert state.devices[device.name].enterprise_id == 11
 
-    @pytest.mark.asyncio
     async def test_run_should_raise_exception_when_there_is_no_response(self):
         device = PollDevice(name="localhost", address="127.0.0.1", community="invalid", port=666)
         state = ZinoState()

--- a/tests/trapobservers/bfd_traps_test.py
+++ b/tests/trapobservers/bfd_traps_test.py
@@ -11,7 +11,7 @@ from zino.trapobservers.bfd_traps import BFDTrapObserver
 
 
 class TestBFDTrapObserver:
-    @pytest.mark.asyncio
+
     async def test_when_bfd_trap_is_received_it_should_poll_all_affected_sessions(
         self, bfd_session_down_trap, monkeypatch, event_loop
     ):
@@ -27,7 +27,6 @@ class TestBFDTrapObserver:
 
         assert bfdtask_run.call_count == 4
 
-    @pytest.mark.asyncio
     async def test_when_polldevs_config_is_missing_it_should_do_nothing(
         self, bfd_session_down_trap, monkeypatch, event_loop
     ):
@@ -41,7 +40,6 @@ class TestBFDTrapObserver:
 
         assert bfdtask_run.call_count == 0
 
-    @pytest.mark.asyncio
     async def test_when_malformed_bfd_trap_is_received_it_should_log_and_return(
         self,
         malformed_bfd_session_down_trap,

--- a/tests/trapobservers/bgp_traps_test.py
+++ b/tests/trapobservers/bgp_traps_test.py
@@ -10,7 +10,7 @@ from zino.trapobservers.bgp_traps import BgpTrapObserver
 
 
 class TestBgpTrapObserver:
-    @pytest.mark.asyncio
+
     async def test_when_backward_transition_trap_is_received_it_should_change_bgp_peer_state(
         self, backward_transition_trap
     ):
@@ -23,7 +23,6 @@ class TestBgpTrapObserver:
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ACTIVE
 
-    @pytest.mark.asyncio
     async def test_when_trap_is_missing_required_varbinds_it_should_do_nothing(self, backward_transition_trap):
         device = backward_transition_trap.agent.device
         peer = next(iter(device.bgp_peers.keys()))
@@ -36,7 +35,6 @@ class TestBgpTrapObserver:
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ESTABLISHED
 
-    @pytest.mark.asyncio
     async def test_when_trap_has_invalid_remote_addr_it_should_do_nothing(self, backward_transition_trap):
         device = backward_transition_trap.agent.device
         peer = next(iter(device.bgp_peers.keys()))
@@ -48,7 +46,6 @@ class TestBgpTrapObserver:
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ESTABLISHED
 
-    @pytest.mark.asyncio
     async def test_when_trap_has_invalid_oper_state_it_should_do_nothing(self, backward_transition_trap):
         device = backward_transition_trap.agent.device
         peer = next(iter(device.bgp_peers.keys()))
@@ -60,7 +57,6 @@ class TestBgpTrapObserver:
         assert len(device.bgp_peers) == 1
         assert device.bgp_peers[peer].oper_state == BGPOperState.ESTABLISHED
 
-    @pytest.mark.asyncio
     async def test_when_established_trap_is_received_it_should_just_log_it(self, established_trap, caplog):
         """This requirement is disputed until Håvard E confirms it"""
         observer = BgpTrapObserver(state=Mock())
@@ -68,7 +64,6 @@ class TestBgpTrapObserver:
             await observer.handle_trap(trap=established_trap)
             assert "BGP peer up" in caplog.text
 
-    @pytest.mark.asyncio
     async def test_when_trap_is_unknown_it_should_pass_it_on(self, established_trap):
         established_trap.name = "FOOBAR"
         observer = BgpTrapObserver(state=Mock())

--- a/tests/trapobservers/ignored_traps_test.py
+++ b/tests/trapobservers/ignored_traps_test.py
@@ -1,12 +1,10 @@
 from unittest.mock import Mock
 
-import pytest
-
 from zino.trapobservers.ignored_traps import IgnoreTraps
 
 
 class TestIgnoreTraps:
-    @pytest.mark.asyncio
+
     async def test_when_handle_trap_is_called_it_should_return_false(self):
         observer = IgnoreTraps(state=Mock())
         assert not await observer.handle_trap(trap=Mock())

--- a/tests/trapobservers/link_traps_test.py
+++ b/tests/trapobservers/link_traps_test.py
@@ -2,8 +2,6 @@ import logging
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
-import pytest
-
 from zino import flaps
 from zino.config.models import PollDevice
 from zino.statemodels import FlapState, InterfaceState, PortStateEvent
@@ -19,7 +17,7 @@ OID_IFOPERSTATUS = ".1.3.6.1.2.1.2.2.1.8"
 
 
 class TestLinkTrapObserver:
-    @pytest.mark.asyncio
+
     async def test_when_link_down_is_received_it_should_create_portstate_event(
         self, state_with_localhost_with_port, localhost_receiver
     ):
@@ -37,7 +35,6 @@ class TestLinkTrapObserver:
             "localhost", 1, PortStateEvent
         ), "no portstate event was created"
 
-    @pytest.mark.asyncio
     async def test_when_port_does_not_match_watch_pattern_it_should_ignore_link_traps(
         self, state_with_localhost_with_port, localhost_receiver
     ):
@@ -57,7 +54,6 @@ class TestLinkTrapObserver:
             "localhost", 1, PortStateEvent
         ), "linkDown for non-watched port was not ignored"
 
-    @pytest.mark.asyncio
     async def test_when_port_matches_ignore_pattern_it_should_ignore_link_traps(
         self, state_with_localhost_with_port, localhost_receiver
     ):
@@ -104,7 +100,6 @@ class TestLinkTrapObserver:
             localhost, localhost.ports[1], is_up=False
         ), "did not ignore redundant linkDown trap"
 
-    @pytest.mark.asyncio
     async def test_when_link_trap_is_missing_ifindex_value_it_should_ignore_trap_early(
         self, state_with_localhost_with_port
     ):
@@ -114,7 +109,6 @@ class TestLinkTrapObserver:
             assert not await observer.handle_trap(trap)
             assert not handle_link_transition.called, "handle_link_transition was called"
 
-    @pytest.mark.asyncio
     async def test_when_link_trap_refers_to_unknown_port_it_should_ignore_trap_early(
         self, state_with_localhost_with_port
     ):

--- a/tests/trapobservers/logged_traps_test.py
+++ b/tests/trapobservers/logged_traps_test.py
@@ -17,7 +17,6 @@ from zino.trapobservers.logged_traps import (
 
 class TestRestartTrapLogger:
     @pytest.mark.parametrize("trap_name", ["coldStart", "warmStart"])
-    @pytest.mark.asyncio
     async def test_when_handle_trap_is_called_it_should_log_trap_name(
         self, caplog, localhost_trap_originator, trap_name
     ):
@@ -29,7 +28,7 @@ class TestRestartTrapLogger:
 
 
 class TestCiscoReloadTrapLogger:
-    @pytest.mark.asyncio
+
     async def test_when_handle_trap_is_called_it_should_log_reload(
         self,
         caplog,
@@ -43,7 +42,7 @@ class TestCiscoReloadTrapLogger:
 
 
 class TestCiscoConfigManEventLogger:
-    @pytest.mark.asyncio
+
     async def test_when_handle_trap_is_called_it_should_log_config_change(
         self,
         caplog,
@@ -66,7 +65,7 @@ class TestCiscoConfigManEventLogger:
 
 
 class TestCiscoPimTrapLogger:
-    @pytest.mark.asyncio
+
     async def test_when_handle_trap_is_called_with_invalid_pim_register_it_should_log_it_correctly(
         self, caplog, localhost_trap_originator
     ):
@@ -89,7 +88,6 @@ class TestCiscoPimTrapLogger:
             await observer.handle_trap(trap=trap)
             assert "localhost PIM-invalid-register: from 10.0.0.1 group 10.0.0.2 RP 10.0.0.3" in caplog.text
 
-    @pytest.mark.asyncio
     async def test_when_trap_is_missing_error_origin_type_it_should_ignore_it(self, caplog, localhost_trap_originator):
         observer = CiscoPimTrapLogger(state=Mock())
         trap = TrapMessage(
@@ -109,7 +107,6 @@ class TestCiscoPimTrapLogger:
             await observer.handle_trap(trap=trap)
             assert "PIM-invalid" not in caplog.text
 
-    @pytest.mark.asyncio
     async def test_when_trap_error_origin_type_is_not_ipv4_it_should_ignore_it(self, caplog, localhost_trap_originator):
         observer = CiscoPimTrapLogger(state=Mock())
         trap = TrapMessage(
@@ -132,7 +129,7 @@ class TestCiscoPimTrapLogger:
 
 
 class TestOspfIfConfigErrorLogger:
-    @pytest.mark.asyncio
+
     async def test_when_handle_trap_is_called_with_ospf_config_error_it_should_log_it_correctly(
         self, caplog, localhost_trap_originator
     ):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -51,7 +51,7 @@ class TestParseIP:
 
 
 class TestReverseDNS:
-    @pytest.mark.asyncio
+
     async def test_should_return_reverse_dns_for_valid_ip(self, mock_dnsresolver):
         valid_ip = "8.8.8.8"
         reverse_dns_value = "reverse.dns.example.com"
@@ -69,7 +69,6 @@ class TestReverseDNS:
         result = await reverse_dns(valid_ip)
         assert result == reverse_dns_value
 
-    @pytest.mark.asyncio
     async def test_should_return_none_for_invalid_ip(self, mock_dnsresolver):
         invalid_ip = "0.0.0.0"
 

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -133,7 +133,6 @@ def test_when_unprivileged_user_asks_for_privileged_port_zino_should_exit_with_e
         )
 
 
-@pytest.mark.asyncio
 @patch("zino.zino.switch_to_user")
 async def test_when_args_specify_user_zino_init_event_loop_should_attempt_to_switch_users(switch_to_user, event_loop):
     """Detect attempt to user switching by patching in a mock exception.  This is to avoid setting up the full Zino

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,9 @@ skipsdist = True
 skip_missing_interpreters = True
 basepython = python3.9
 
+[pytest]
+asyncio_mode = auto
+
 [gh-actions]
 python =
     3.9: py39


### PR DESCRIPTION
## Scope and purpose

The only async system we are using in Zino is asyncio, so all async test functions and fixtures can be assumed to be asyncio without the need for an explicit marker.

This PR enables auto-asyncio mode and removes all obsolete explicit test markers.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
