### PR TITLE
Move `populate_by_name` to `Event` model

### DIFF
--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -245,6 +245,9 @@ class ReachabilityState(Enum):
 class Event(BaseModel):
     """Keeps track of event state"""
 
+    # Allow populating fields by name or alias
+    model_config = ConfigDict(populate_by_name=True)
+
     id: Optional[int] = None
 
     router: str
@@ -355,9 +358,6 @@ class PortStateEvent(Event):
 
 
 class BGPEvent(Event):
-    # Allow populating fields by name or alias
-    model_config = ConfigDict(populate_by_name=True)
-
     type: Literal["bgp"] = "bgp"
     remote_address: Optional[IPAddress] = Field(default=None, alias="remote-addr")
     remote_as: Optional[int] = Field(default=None, alias="remote-AS")
@@ -371,9 +371,6 @@ class BGPEvent(Event):
 
 
 class BFDEvent(Event):
-    # Allow populating fields by name or alias
-    model_config = ConfigDict(populate_by_name=True)
-
     type: Literal["bfd"] = "bfd"
     ifindex: Optional[int] = None
     bfdstate: Optional[BFDSessState] = Field(default=None, alias="bfdState")
@@ -393,9 +390,6 @@ class ReachabilityEvent(Event):
 
 
 class AlarmEvent(Event):
-    # Allow populating fields by name or alias
-    model_config = ConfigDict(populate_by_name=True)
-
     type: Literal["alarm"] = "alarm"
     alarm_type: Optional[AlarmType] = Field(default=None, alias="alarm-type")
     alarm_count: Optional[int] = Field(default=None, alias="alarm-count")


### PR DESCRIPTION
## Scope and purpose

Inspired by a meeting about [Pydantic aliases](https://docs.pydantic.dev/latest/concepts/alias/) today. That way not every model using aliases needs to explicitly declare it. 

Reference to what `populate_by_name` does: https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.populate_by_name

Related to #338, #335 and #352.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * just internal changes
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
