### PR TITLE
Explicitely exclude files from being linted by MegaLinter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,19 +29,10 @@ jobs:
         # More info at https://megalinter.io/flavors/
         uses: oxsecurity/megalinter/flavors/python@v7
         env:
-          # All available variables are described in documentation
-          # https://megalinter.io/configuration/
-          ENABLE_LINTERS: PYTHON_BLACK,PYTHON_ISORT,PYTHON_RUFF
-          # Make workflow fail even on non blocking errors
-          FORMATTERS_DISABLE_ERRORS: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Validate whole codebase on pushes and only changes on pull requests
           VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push'}}
-          # Tell the linter the location of the configuration file (pyproject.toml)
-          LINTER_RULES_PATH: .
-          PYTHON_BLACK_CONFIG_FILE: pyproject.toml
-          PYTHON_ISORT_CONFIG_FILE: pyproject.toml
-          PYTHON_RUFF_CONFIG_FILE: pyproject.toml
+
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         if: success() || failure()

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,7 +2,10 @@
 # MegaLinter GitHub Action configuration file
 # More info at https://megalinter.io
 name: MegaLinter
-on: [push, pull_request]
+on:
+  push:
+    branches: "master"
+  pull_request:
 
 jobs:
   megalinter:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,7 +39,6 @@ jobs:
           PYTHON_BLACK_CONFIG_FILE: pyproject.toml
           PYTHON_ISORT_CONFIG_FILE: pyproject.toml
           PYTHON_RUFF_CONFIG_FILE: pyproject.toml
-          FILTER_REGEX_EXCLUDE: .*src/zino/mibdumps/.*
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         if: success() || failure()

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,16 @@
+# All available variables are described in documentation
+# https://megalinter.io/configuration/
+
+LINTER_RULES_PATH: .
+
+ENABLE_LINTERS:
+  - PYTHON_BLACK
+  - PYTHON_ISORT
+  - PYTHON_RUFF
+
+# Make workflow fail even on non blocking errors
+FORMATTERS_DISABLE_ERRORS: false
+
+PYTHON_BLACK_CONFIG_FILE: pyproject.toml
+PYTHON_ISORT_CONFIG_FILE: pyproject.toml
+PYTHON_RUFF_CONFIG_FILE: pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,8 @@ write_to = "src/zino/version.py"
 
 [tool.black]
 line-length = 120
-exclude = '''
+# Exclude files even when passed directly as argument (for MegaLinter)
+force-exclude = '''
 (
   /(
       \.eggs         # exclude a few common directories in the
@@ -105,6 +106,8 @@ target-version = "py39"
 exclude = [
     "mibdumps"
 ]
+# Exclude files even when passed directly as argument (for MegaLinter)
+force-exclude = true
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Scope and purpose

MegaLinter passes a list of files to black and ruff without using `force-exclude` the linters did ignore the basic exclude configuration in that case, which is why `FILTER_REGEX_EXCLUDE` was needed. 

The issue I made in MegaLinter about that topic: https://github.com/oxsecurity/megalinter/issues/3915
Force-exclude in black configuration: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#force-exclude
Force-exclude in ruff configuration: https://docs.astral.sh/ruff/settings/#force-exclude

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
