### PR TITLE
Disable towncrier check on dependabot PRs

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   towncrier:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     name: Towncrier check
     steps:


### PR DESCRIPTION
## Scope and purpose

Avoids the towncrier check to fail each time dependabot creates a pull request to update GitHub actions versions (which will anyway not have a news fragment). 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  * only a change in a workflow
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
