### PR TITLE
Upgrade pre-commit to towncrier 24.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: ruff
   - repo: https://github.com/twisted/towncrier
-    rev: 24.7.1
+    rev: 24.8.0
     hooks:
       - id: towncrier-check
         files: $changelog\.d/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ underlines = ["", "", ""]
 title_format = "## [{version}] - {project_date}"
 issue_format = "[#{issue}](https://github.com/Uninett/zino/issues/{issue})"
 wrap = false
-ignore = [".gitkeep"]
 
 [[tool.towncrier.type]]
 directory = "security"


### PR DESCRIPTION
## Scope and purpose

This version automatically ignores .gitkeep files. Therefore it reverts #334.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
