### PR TITLE
Suppress initial interface down alarms with config option

### DIFF
--- a/changelog.d/257.added.md
+++ b/changelog.d/257.added.md
@@ -1,0 +1,1 @@
+Add config option to suppress initial interface down events

--- a/src/zino/config/models.py
+++ b/src/zino/config/models.py
@@ -71,6 +71,7 @@ class Polling(BaseModel):
 
     file: ExistingFileName = POLLFILE
     period: int = 1
+    suppress_initial_down_alarms: bool = False
 
 
 class Configuration(BaseModel):

--- a/tests/tasks/test_linkstatetask.py
+++ b/tests/tasks/test_linkstatetask.py
@@ -28,6 +28,14 @@ class TestLinkStateTask:
         assert (await task.run()) is None
         assert len(task.state.events) == 1
 
+    async def test_run_should_not_create_event_if_suppress_initial_down_alarms_config_is_true(
+        self, linkstatetask_with_one_link_down
+    ):
+        task = linkstatetask_with_one_link_down
+        with patch("zino.state.config.polling.suppress_initial_down_alarms", True):
+            assert (await task.run()) is None
+        assert len(task.state.events) == 0
+
     def test_when_patterns_are_empty_interface_should_not_be_ignored(self, task_with_dummy_device):
         data = BaseInterfaceRow(
             index=2, descr="GigabitEthernet1/2", alias="uplink", admin_status="up", oper_status="up", last_change=0

--- a/zino.toml.example
+++ b/zino.toml.example
@@ -26,6 +26,10 @@ file = "polldevs.cf"
 # default 1 min
 period = 1
 
+# If on the first start of Zino interface-down alarms should be created
+# default False
+suppress_initial_down_alarms = False
+
 # Logging configuration is optional, but if specified, it will override the
 # default logging config of Zino.  This is a TOML representation of the default
 # logging configuration dictionary, whose full documentation is available at


### PR DESCRIPTION
## Scope and purpose

Closes #257. 

This is how I interpreted this issue: We have a config option that if it is set to true the first time a `PortStateEvent` would be created with the interface down state nothing happens instead.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [X] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
