### PR TITLE
Reduce log level of "home address" changes to `DEBUG`

### DIFF
--- a/changelog.d/215.fixed.md
+++ b/changelog.d/215.fixed.md
@@ -1,0 +1,1 @@
+Log "home" address changes as DEBUG level information, to avoid unnecessary verbosity in VRRP setups

--- a/src/zino/tasks/addrs.py
+++ b/src/zino/tasks/addrs.py
@@ -62,7 +62,7 @@ class AddressMapTask(Task):
             if address not in state.addresses:
                 _logger.info("%s adds address %s", self.device.name, address)
             elif state.addresses[address] != self.device.name:
-                _logger.info("Home of %s changed from %s to %s", address, state.addresses[address], self.device.name)
+                _logger.debug("Home of %s changed from %s to %s", address, state.addresses[address], self.device.name)
 
             state.addresses[address] = self.device.name
 


### PR DESCRIPTION
## Scope and purpose

Fixes #215.

<!-- remove things that do not apply -->
### This pull request
* changes a log level from info to debug


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
