### PR TITLE
Implement an SNMP back-end selection option in `zino.toml`

### DIFF
--- a/src/zino/config/models.py
+++ b/src/zino/config/models.py
@@ -3,7 +3,7 @@
 from ipaddress import IPv4Address, IPv6Address
 from os import R_OK, access
 from os.path import isfile
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict
 from pydantic.functional_validators import AfterValidator
@@ -73,6 +73,12 @@ class Polling(BaseModel):
     period: int = 1
 
 
+class SNMPConfiguration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    backend: Literal["pysnmp", "netsnmp"] = "netsnmp"
+
+
 class Configuration(BaseModel):
     """Class for keeping track of the configuration set by zino.toml"""
 
@@ -83,6 +89,7 @@ class Configuration(BaseModel):
     authentication: Authentication = Authentication()
     persistence: Persistence = Persistence()
     polling: Polling = Polling()
+    snmp: SNMPConfiguration = SNMPConfiguration()
     logging: dict[str, Any] = {
         "version": 1,
         "loggers": {

--- a/src/zino/getuptime.py
+++ b/src/zino/getuptime.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 
 from zino.config.polldevs import read_polldevs
-from zino.snmp import SNMP
+from zino.snmp import import_snmp_backend
 from zino.state import config
 
 _log = logging.getLogger(__name__)
@@ -23,7 +23,8 @@ async def run(args: argparse.Namespace):
     devices, _ = read_polldevs(config.polling.file)
     device = devices[args.router]
 
-    snmp = SNMP(device)
+    backend = import_snmp_backend(config.snmp.backend)
+    snmp = backend.SNMP(device)
     response = await snmp.get("SNMPv2-MIB", "sysUpTime", 0)
     _log.info("Response from %s: %r", device.name, int(response))
 

--- a/src/zino/getuptime.py
+++ b/src/zino/getuptime.py
@@ -24,9 +24,10 @@ async def run(args: argparse.Namespace):
     device = devices[args.router]
 
     backend = import_snmp_backend(config.snmp.backend)
+    backend.init_backend()
     snmp = backend.SNMP(device)
     response = await snmp.get("SNMPv2-MIB", "sysUpTime", 0)
-    _log.info("Response from %s: %r", device.name, int(response))
+    _log.info("Response from %s: %r", device.name, response.value)
 
 
 def parse_args():

--- a/src/zino/snmp/__init__.py
+++ b/src/zino/snmp/__init__.py
@@ -1,30 +1,64 @@
 """Zino SNMP back-ends"""
 
+import importlib
+import logging
 import os.path
+from types import ModuleType
+from typing import TYPE_CHECKING
 from weakref import WeakValueDictionary
 
 from zino.config.models import PollDevice
+from zino.snmp.base import SNMPBackendNotLoaded
 
-# Select one of the two SNMP back-ends:
-# from .pysnmp_backend import *  # noqa
-from .netsnmpy_backend import *  # noqa
-from .netsnmpy_backend import SNMP
+if TYPE_CHECKING:
+    from zino.snmp.pysnmp_backend import SNMP
 
+
+_logger = logging.getLogger(__name__)
 _snmp_sessions = WeakValueDictionary()
+_selected_backend = None
+_BACKEND_MAP = {"pysnmp": "pysnmp_backend", "netsnmp": "netsnmpy_backend", None: "netsnmpy_backend"}
 
 
-def get_snmp_session(device: PollDevice) -> SNMP:
+def import_snmp_backend(backend: str = None) -> ModuleType:
+    """Import and return the selected SNMP back-end. The first time this is called,
+    the back-end is selectable, but defaults to "netsnmp".  Subsequent calls that omit backend will
+    return the back-end that was selected by the first call.
+    """
+    global _selected_backend, _snmp
+
+    if backend is None and _selected_backend is not None:
+        return _selected_backend
+
+    module_name = _BACKEND_MAP.get(backend)
+    if not module_name:
+        raise ValueError(f"Unknown SNMP backend: {backend}")
+
+    _logger.info("Loading SNMP backend: %s (%s)", backend, module_name)
+    module = importlib.import_module(f"zino.snmp.{module_name}")
+    if _selected_backend is None:
+        _selected_backend = module
+        # Hack to import all public symbols from the module into the current namespace
+        globals().update({name: getattr(module, name) for name in dir(module) if not name.startswith("_")})
+    return module
+
+
+def get_snmp_session(device: PollDevice) -> "SNMP":
     """Create or re-use an existing SNMP session for a device.
 
     This keeps a registry of existing/re-usable SNMP sessions so we avoid duplicate instances and over-use of sockets
     """
+    global _selected_backend
+    if _selected_backend is None:
+        raise SNMPBackendNotLoaded()
+
     if _snmp_sessions is None:  # Tests suite may disable session re-use
-        return SNMP(device)
+        return _selected_backend.SNMP(device)
     # We generate a session key based on every attribute that affects how the SNMP session is set up:
     key = (device.address, device.community, device.hcounters)
     session = _snmp_sessions.get(key)
     if not session:
-        session = _snmp_sessions[key] = SNMP(device)
+        session = _snmp_sessions[key] = _selected_backend.SNMP(device)
     return session
 
 

--- a/src/zino/snmp/base.py
+++ b/src/zino/snmp/base.py
@@ -63,3 +63,15 @@ class NoSuchInstanceError(VarBindError):
 
 class EndOfMibViewError(VarBindError):
     """Raised if end of MIB view is encountered"""
+
+
+class SNMPBackendError(SnmpError):
+    """Base class for SNMP back-end specific errors"""
+
+
+class SNMPBackendNotLoaded(SNMPBackendError):
+    """No SNMP back-end has been loaded yet"""
+
+
+class SNMPBackendVersionError(SNMPBackendError):
+    """The available SNMP back-end library version is incompatible with the required version"""

--- a/src/zino/snmp/pysnmp_backend.py
+++ b/src/zino/snmp/pysnmp_backend.py
@@ -61,7 +61,11 @@ def init_backend():
 
 
 def get_new_snmp_engine() -> SnmpEngine:
-    """Returns a new SnmpEngine object with Zino's directory of MIB modules loaded"""
+    """Returns a new SnmpEngine object with Zino's directory of MIB modules loaded.
+
+    The SNMP engine is a PySNMP specific object.  This may be useful when working directly with PySNMP, but it is not
+    part of the high-level API that an SNMP back-end module needs to export.
+    """
     snmp_engine = SnmpEngine()
     mib_builder = snmp_engine.getMibBuilder()
     mib_builder.addMibSources(builder.DirMibSource(MIB_SOURCE_DIR))

--- a/src/zino/snmp/pysnmp_backend.py
+++ b/src/zino/snmp/pysnmp_backend.py
@@ -55,6 +55,11 @@ def _get_engine():
     return _local.snmp_engine
 
 
+def init_backend():
+    """Initializes the PySNMP backend"""
+    _get_engine()
+
+
 def get_new_snmp_engine() -> SnmpEngine:
     """Returns a new SnmpEngine object with Zino's directory of MIB modules loaded"""
     snmp_engine = SnmpEngine()

--- a/src/zino/trapd/__init__.py
+++ b/src/zino/trapd/__init__.py
@@ -1,6 +1,29 @@
 """Zino SNMP trap daemon back-ends"""
 
-# This is where we switch between back-ends, for now
-# from zino.trapd.pysnmp_backend import *  # noqa
+import importlib
+from types import ModuleType
 
-from zino.trapd.netsnmpy_backend import *  # noqa
+_selected_backend = None
+_BACKEND_MAP = {"pysnmp": "pysnmp_backend", "netsnmp": "netsnmpy_backend", None: "netsnmpy_backend"}
+
+
+def import_trap_backend(backend: str = None) -> ModuleType:
+    """Import and return the selected SNMP trap back-end. The first time this is
+    called, the back-end is selectable, but defaults to "netsnmp".  Subsequent calls
+    that omit backend will return the back-end that was selected by the first call.
+    """
+    global _selected_backend, _snmp
+
+    if backend is None and _selected_backend is not None:
+        return _selected_backend
+
+    module_name = _BACKEND_MAP.get(backend)
+    if not module_name:
+        raise ValueError(f"Unknown SNMP trap backend: {backend}")
+
+    module = importlib.import_module(f"zino.trapd.{module_name}")
+    if _selected_backend is None:
+        _selected_backend = module
+        # Hack to import all public symbols from the module into the current namespace
+        globals().update({name: getattr(module, name) for name in dir(module) if not name.startswith("_")})
+    return module

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,13 @@ from zino.trapd import netsnmpy_backend, pysnmp_backend
 def pytest_configure(config):
     import os
 
+    # Load the default SNMP back-end for the test suite.  Tests for specific back-end will import directly from those.
+    from zino.snmp import import_snmp_backend
+    from zino.trapd import import_trap_backend
+
+    import_snmp_backend()
+    import_trap_backend()
+
     from netsnmpy import netsnmp
 
     from zino.snmp import get_vendored_mib_directory

--- a/tests/getuptime_test.py
+++ b/tests/getuptime_test.py
@@ -1,0 +1,30 @@
+"""Simple tests for the getuptime example program"""
+
+import subprocess
+
+import pytest
+
+
+def test_get_uptime_should_run_without_error(polldevs_with_localhost, snmpsim):
+    confdir = polldevs_with_localhost.parent
+    assert subprocess.check_call(["python3", "-m", "zino.getuptime", "localhost"], cwd=confdir) == 0
+
+
+@pytest.fixture
+def polldevs_with_localhost(zino_conf, snmp_test_port):
+    polldevs_conf = zino_conf.parent.joinpath("polldevs.cf")
+    with open(polldevs_conf, "w") as conf:
+        conf.write(
+            f"""# polldevs test config
+            default interval: 10
+            default community: public
+            default domain: uninett.no
+            default statistics: yes
+            default hcounters: yes
+
+            name: localhost
+            address: 127.0.0.1
+            port: {snmp_test_port}
+            """
+        )
+    yield polldevs_conf

--- a/tests/snmp/pysnmp_backend_test.py
+++ b/tests/snmp/pysnmp_backend_test.py
@@ -13,6 +13,7 @@ from pysnmp.proto.rfc1905 import EndOfMibView, NoSuchInstance, NoSuchObject
 
 from zino.config.models import PollDevice
 from zino.oid import OID
+from zino.snmp import pysnmp_backend
 from zino.snmp.base import (
     EndOfMibViewError,
     ErrorIndication,
@@ -23,7 +24,7 @@ from zino.snmp.base import (
     NoSuchNameError,
     NoSuchObjectError,
 )
-from zino.snmp.pysnmp_backend import SNMP
+from zino.snmp.pysnmp_backend import SNMP, init_backend
 
 
 @pytest.fixture(scope="session")
@@ -309,3 +310,9 @@ class TestSubtreeIsSupported:
     async def test_when_agent_does_not_have_subtree_it_should_return_false(self, snmp_client):
         response = await snmp_client.subtree_is_supported("BFD-STD-MIB", "bfdSessTable")
         assert not response
+
+
+class TestInitBackend:
+    def test_it_should_initialize_an_snmp_engine_instance(self):
+        init_backend()
+        assert pysnmp_backend._local.snmp_engine is not None

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -1,7 +1,11 @@
+from unittest.mock import Mock
 from weakref import WeakValueDictionary
 
+import pytest
+
+import zino.snmp
 from zino.config.models import PollDevice
-from zino.snmp import get_snmp_session
+from zino.snmp import get_snmp_session, import_snmp_backend
 
 
 class TestGetSnmpSession:
@@ -13,3 +17,26 @@ class TestGetSnmpSession:
             session1 = get_snmp_session(device)
             session2 = get_snmp_session(device)
             assert session1 is session2
+
+    def test_when_reuse_is_disabled_it_should_return_new_session(self):
+        device = PollDevice(name="localhost", address="127.0.0.1", community="public", hcounters=True)
+        session1 = get_snmp_session(device)
+        session2 = get_snmp_session(device)
+        assert session1 is not session2
+
+    def test_when_backend_is_not_loaded_it_should_raise(self, monkeypatch):
+        with monkeypatch.context() as patch:
+            patch.setattr("zino.snmp._selected_backend", None)
+            with pytest.raises(zino.snmp.SNMPBackendNotLoaded):
+                get_snmp_session(Mock())
+
+
+class TestImportSnmpBackend:
+    def test_when_backend_is_already_selected_and_argument_is_empty_it_should_return_already_loaded_backend(self):
+        assert zino.snmp._selected_backend is not None  # conftest should already have loaded a backend
+        module = import_snmp_backend()
+        assert module == zino.snmp._selected_backend
+
+    def test_when_backend_is_unknown_it_should_raise_value_error(self):
+        with pytest.raises(ValueError):
+            import_snmp_backend("nonexistent-foobar")

--- a/zino.toml.example
+++ b/zino.toml.example
@@ -26,6 +26,11 @@ file = "polldevs.cf"
 # default 1 min
 period = 1
 
+[snmp]
+# Zino supports two SNMP back-ends: "netsnmp" and "pysnmp".  The default is "netsnmp" (which requires the Net-SNMP C
+# library to be installed on your system).  "pysnmp" selects the pure Python library PySNMP, which is less performant.
+backend = "netsnmp"
+
 # Logging configuration is optional, but if specified, it will override the
 # default logging config of Zino.  This is a TOML representation of the default
 # logging configuration dictionary, whose full documentation is available at


### PR DESCRIPTION
## Scope and purpose

Part of fix for #383.  Dependent on #394 and #395.

This adds an option `snmp.backend` to the configuration file `zino.toml` (defaulting to the new `netsnmp-cffi` back-end).

Since `netsnmp-cffi` is a new back-end, still in development, this allows users to optionally go back to the original PySNMP-based back-end in case they experience stability issues with the new solution.


### This pull request
* adds an option configuration option to `zino.toml`
* changes how SNMP back-ends are selected/loaded


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
