### PR TITLE
Remove list of development tools from list of optional runtime requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,17 @@ zinoconv save-state.tcl zino-state.json
 
 ## Developing Zino
 
+### Development tools
+
+A bunch of tools needed or recommended to have available when developing Zino
+and/or running its test suite are listed in the requirements file
+[requirements/dev.txt](./requirements/dev.txt).  These can be installed to your
+development virtualenv using `pip` (or `uv pip`):
+
+```sh
+pip install -r requirements/dev.txt
+```
+
 ### Running tests
 
 [tox](https://tox.wiki/) and [pytest](https://pytest.org/) are used to run the

--- a/changelog.d/399.fixed.md
+++ b/changelog.d/399.fixed.md
@@ -1,0 +1,1 @@
+Removed development tools from list of optional package runtime requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,23 +41,6 @@ zinoconv = "zino.stateconverter.convertstate:main"
 
 [project.optional-dependencies]
 docs = ["sphinx>=2.2.0"]
-dev = [
-    "black",
-    "build",
-    "coverage",
-    "ipython",
-    "isort",
-    "pre-commit",
-    "pytest",
-    "pytest-asyncio<0.22.0",
-    "pytest-timeout",
-    "retry",
-    "ruff",
-    "snmpsim>=1.0",
-    "towncrier",
-    "tox<4",
-    "twine",
-]
 
 [tool.setuptools]
 include-package-data = true

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ pytest-asyncio<0.22.0
 pytest-timeout
 retry
 ruff
-snmpsim>=1.0
+snmpsim>=1.0,!=1.1.6
 towncrier
 tox<4
 twine

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,18 @@
+# Development "requirements".  These are tools that are extremely useful or
+# even required to run the test suite, but not at all required by Zino at
+# runtime:
+black
+build
+coverage
+ipython
+isort
+pre-commit
+pytest
+pytest-asyncio<0.22.0
+pytest-timeout
+retry
+ruff
+snmpsim>=1.0
+towncrier
+tox<4
+twine


### PR DESCRIPTION
## Scope and purpose

Optional dependencies in `pyproject.toml` are taken to mean "optional *runtime* dependencies" by Python build and packaging tools.  The list of `dev` optional dependencies are definitely *not runtime* dependencies in any way, shape or form, so this removes them from package metadata and relegates them to a simple requirements file.



## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
