### PR TITLE
Fix Net-SNMP resource leakage issues

### DIFF
--- a/changelog.d/+debug-log-snmp-details.added.md
+++ b/changelog.d/+debug-log-snmp-details.added.md
@@ -1,0 +1,1 @@
+Added debug logging of low-level SNMP session details to debug low-level OS resource management problems

--- a/src/zino/snmp/netsnmpy_backend.py
+++ b/src/zino/snmp/netsnmpy_backend.py
@@ -79,6 +79,10 @@ class SNMP:
         )
         self.session.open()
 
+    def __del__(self):
+        """Ensures Net-SNMP resources are properly released when sessions are garbage collected"""
+        self.session.close()
+
     async def get(self, *oid: str) -> MibObject:
         """SNMP-GETs the given oid
         Example usage:

--- a/src/zino/snmp/netsnmpy_backend.py
+++ b/src/zino/snmp/netsnmpy_backend.py
@@ -65,7 +65,20 @@ def init_backend():
 
 
 class SNMP:
-    """Represents an SNMP management session for a single device"""
+    """Represents an SNMP management session for a single device.
+
+    Net-SNMP allocates low-level resources for each session, so it is important to close the session when done with
+    it.  The initial Zino 2 codebase did not expect to have to manage low-level resources, so all SNMP operations of
+    this class will implicitly open an unopened or closed session - which means that some parts of Zino *will* have
+    to manage resource de-allocation.
+
+    Complete job runs should manage the session as a context manager, but tasks that schedule SNMP operations outside
+    of the main job loop should be careful to also manage their own resources.
+
+    Example context manager usage:
+    >>> with SNMP(device) as snmp:
+    >>>     uptime = await snmp.get("SNMPv2-MIB", "sysUpTime", 0)
+    """
 
     def __init__(self, device: PollDevice):
         self.device = device
@@ -77,11 +90,30 @@ class SNMP:
             timeout=device.timeout,
             retries=device.retries,
         )
-        self.session.open()
+        self._is_open = False
 
-    def __del__(self):
-        """Ensures Net-SNMP resources are properly released when sessions are garbage collected"""
-        self.session.close()
+    def open(self):
+        """Opens a low-level SNMP session"""
+        if not self._is_open:
+            self.session.open()
+            self._is_open = True
+
+    def close(self):
+        """Closes a low-level SNMP session"""
+        if self._is_open:
+            self.session.close()
+            self._is_open = False
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def _open_if_closed(self):
+        if not self._is_open:
+            self.open()
 
     async def get(self, *oid: str) -> MibObject:
         """SNMP-GETs the given oid
@@ -93,6 +125,7 @@ class SNMP:
         :return: A MibObject representing the resulting MIB variable
         """
         objid = resolve_symbol(oid)
+        self._open_if_closed()
         var_binds = await self.session.aget(objid)
         result = var_binds[0]
         self._raise_varbind_errors(result)
@@ -109,6 +142,7 @@ class SNMP:
         :return: A list of MibObject instances representing the resulting MIB variables
         """
         oids = [resolve_symbol(var) for var in variables]
+        self._open_if_closed()
         var_binds = await self.session.aget(*oids)
         return [_convert_snmp_variable(v) for v in var_binds]
 
@@ -132,6 +166,7 @@ class SNMP:
         :return: A MibObject representing the resulting MIB variable
         """
         objid = resolve_symbol(oid)
+        self._open_if_closed()
         var_binds = await self.session.agetnext(objid)
         result = var_binds[0]
         self._raise_varbind_errors(result)
@@ -155,6 +190,7 @@ class SNMP:
         :return: A sequence of MibObject instances representing the resulting MIB variables
         """
         oids = [resolve_symbol(var) for var in variables]
+        self._open_if_closed()
         var_binds = await self.session.agetnext(*oids)
         return [_convert_snmp_variable(v) for v in var_binds]
 
@@ -170,6 +206,7 @@ class SNMP:
         results = []
         root_oid = resolve_symbol(oid)
         current_oid = root_oid
+        self._open_if_closed()
         while True:
             response = await self.session.agetnext(current_oid)
             var_bind = response[0]
@@ -190,6 +227,7 @@ class SNMP:
         :return: A list of MibObjects representing the resulting MIB variables
         """
         objid = resolve_symbol(oid)
+        self._open_if_closed()
         var_binds = await self.session.agetbulk(objid, max_repetitions=max_repetitions)
         return [MibObject(*var_bind) for var_bind in var_binds]
 
@@ -210,6 +248,7 @@ class SNMP:
         :return: A sequence of two-tuples that represent the response varbinds
         """
         oid_objects = [resolve_symbol(v) for v in variables]
+        self._open_if_closed()
         var_binds = await self.session.agetbulk(*oid_objects, max_repetitions=max_repetitions)
 
         query_count = len(variables)
@@ -229,6 +268,7 @@ class SNMP:
         """
         results = []
         start_oid = query_oid = resolve_symbol(oid)
+        self._open_if_closed()
         while True:
             response = await self.session.agetbulk(query_oid, max_repetitions=max_repetitions)
             if not response:
@@ -257,6 +297,7 @@ class SNMP:
         query_objects = roots = [resolve_symbol(symbol) for symbol in variables]
         results: dict[OID, dict[str, Any]] = defaultdict(dict)
 
+        self._open_if_closed()
         while True:
             query_objects = await self._sparsewalk_iteration(roots, query_objects, results, max_repetitions)
             if not query_objects:

--- a/src/zino/snmp/pysnmp_backend.py
+++ b/src/zino/snmp/pysnmp_backend.py
@@ -85,6 +85,15 @@ class SNMP:
     def __init__(self, device: PollDevice):
         self.device = device
 
+    # SNMP objects are expected to provide a context manager interface for allocating and releasing low-level
+    # resources.  There are no low-level resources to manage in PySNMP, so these next two methods are empty:
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return
+
     async def get(self, *oid: str) -> MibObject:
         """SNMP-GETs the given oid
         Example usage:

--- a/src/zino/tasks/__init__.py
+++ b/src/zino/tasks/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+from zino.snmp import get_snmp_session
 from zino.tasks.errors import DeviceUnreachableError
 
 _log = logging.getLogger(__name__)
@@ -7,7 +8,8 @@ _log = logging.getLogger(__name__)
 
 async def run_all_tasks(device, state):
     try:
-        await run_registered_tasks(device, state)
+        with get_snmp_session(device):
+            await run_registered_tasks(device, state)
     except DeviceUnreachableError:
         _log.debug(f"Device {device.name} could not be reached. Any remaining tasks have been cancelled.")
 

--- a/src/zino/tasks/reachabletask.py
+++ b/src/zino/tasks/reachabletask.py
@@ -39,7 +39,9 @@ class ReachableTask(Task):
 
     async def _run_extra_job(self):
         try:
-            await self._get_uptime()
+            # This runs outside a job context, so we need to ensure we clean up low-level SNMP resources
+            with self.snmp:
+                await self._get_uptime()
         except TimeoutError:
             return
         else:

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -2,6 +2,7 @@
 import argparse
 import asyncio
 import errno
+import gc
 import grp
 import logging
 import logging.config
@@ -9,6 +10,7 @@ import os
 import pwd
 import sys
 from asyncio import AbstractEventLoop
+from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Any, Optional
 
@@ -182,6 +184,12 @@ def setup_initial_job_schedule(loop: AbstractEventLoop, args: argparse.Namespace
         minutes=30,
     )
 
+    scheduler.add_job(
+        func=log_snmp_session_stats,
+        trigger="interval",
+        minutes=1,
+    )
+
     if args.stop_in:
         _log.info("Instructed to stop in %s seconds", args.stop_in)
         scheduler.add_job(func=loop.stop, trigger="date", run_date=datetime.now() + timedelta(seconds=args.stop_in))
@@ -253,6 +261,47 @@ def reschedule_dump_state(log_msg: str) -> None:
     if job.next_run_time > next_run:
         _log.debug("%s, Rescheduling state dump from %s to %s", log_msg, job.next_run_time, next_run)
         job.modify(next_run_time=next_run)
+
+
+def log_snmp_session_stats():
+    """Logs debug information about the current number of SNMP session objects"""
+    logger = logging.getLogger("zino.snmp")
+    if not logger.isEnabledFor(logging.DEBUG):
+        return  # Skip potentially expensive count operations if debug logging is not enabled
+
+    backend = import_snmp_backend()
+    log_low_level = "netsnmpy" in backend.__name__
+
+    from zino.snmp import SNMP, _snmp_sessions
+
+    device_count = len(state.state.devices)
+    reusable = len(_snmp_sessions) if _snmp_sessions else 0
+
+    msg = "(SNMP) session update: routers=%d, reusable (zino)=%d, gc reachable (high-level)=%d"
+    if log_low_level:
+        from netsnmpy.session import Session
+
+        counts = _count_reachable_objects(SNMP, Session)
+        counts = counts[SNMP], counts[Session]
+        msg += ", gc reachable (low-level)=%d"
+    else:
+        counts = _count_reachable_objects(SNMP)
+        counts = (counts[SNMP],)
+
+    logger.debug(msg, device_count, reusable, *counts)
+
+
+def _count_reachable_objects(*types):
+    """Returns the number of objects of the given types that are currently reachable by the garbage collector.
+
+    Designed to do a single pass over all objects in memory, for some semblance of efficiency.
+    """
+    counts = defaultdict(int)
+    for obj in gc.get_objects():
+        for t in types:
+            if isinstance(obj, t):
+                counts[t] += 1
+    return counts
 
 
 def parse_args(arguments=None):

--- a/tests/snmp/netsnmpy_backend_test.py
+++ b/tests/snmp/netsnmpy_backend_test.py
@@ -24,7 +24,8 @@ from zino.snmp.netsnmpy_backend import SNMP, init_backend, resolve_symbol
 @pytest.fixture(scope="session")
 def snmp_client(snmpsim, snmp_test_port):
     device = PollDevice(name="buick.lab.example.org", address="127.0.0.1", port=snmp_test_port)
-    return SNMP(device)
+    with SNMP(device) as snmp:
+        yield snmp
 
 
 @pytest.fixture(scope="session")

--- a/tests/snmp/pysnmp_backend_test.py
+++ b/tests/snmp/pysnmp_backend_test.py
@@ -316,3 +316,8 @@ class TestInitBackend:
     def test_it_should_initialize_an_snmp_engine_instance(self):
         init_backend()
         assert pysnmp_backend._local.snmp_engine is not None
+
+
+def test_snmp_object_should_be_usable_as_context_manager(snmp_client):
+    with snmp_client as context:
+        assert context is snmp_client


### PR DESCRIPTION
## Scope and purpose

After #394 and friends were merged, running Zino with the 222 routers of the Uninett research network revealed that Zino was leaking low-level file descriptors.

This adds more in-depth debug logging of how SNMP sessions are re-used and garbage collected, so that the issue can be properly debugged.

It also fixes the inherent leakage problem by adding more control of resource management to the `SNMP` implementations.  See commit logs for more details.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
