### PR TITLE
Make test suite run on tox v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "tox<4" tox-gh-actions coverage
+          python -m pip install tox tox-gh-actions coverage
           sudo apt-get install -y --no-install-recommends snmp libsnmp-dev
 
       - name: Test with tox

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ pip install -r requirements/dev.txt
 test suite. To run the test suite on all supported versions of Python, run:
 
 ```shell
-tox
+tox run
 ```
 
 ### Code style

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,5 +14,5 @@ retry
 ruff
 snmpsim>=1.0,!=1.1.6
 towncrier
-tox<4
+tox
 twine

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{39,310,311,312}
-skipsdist = True
 skip_missing_interpreters = True
 basepython = python3.11
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ setenv =
 
 passenv = HOME
 
-usedevelop = True
+package = editable
 
 commands =
     pytest -o junit_suite_name="{envname} unit tests" --cov={toxinidir}/src --cov-report=xml:reports/{envname}/coverage.xml --junitxml=reports/{envname}/unit-results.xml --verbose {posargs}


### PR DESCRIPTION
## Scope and purpose

#399 needs to merged first. 

Reference links:
https://tox.wiki/en/latest/upgrading.html
Using tox run instead of tox: https://tox.wiki/en/latest/upgrading.html#updating-usage-with-e
Setting package = editable instead of usedevelop = True: https://tox.wiki/en/latest/config.html#package
Conflict when using skipdist = True and usedevelop = True: https://github.com/tox-dev/tox/issues/2730


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
   - not visible to user
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [X] Added/changed documentation
* [X] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
