### PR TITLE
Test that Zino exits cleanly on keyboard interrupt

### DIFF
--- a/tests/bin_test.py
+++ b/tests/bin_test.py
@@ -1,7 +1,9 @@
 """Tests for the various helper/development binaries and scripts in the zino package"""
 
 import os
+import signal
 import subprocess
+import time
 
 
 def test_zino_help_screen_runs_without_error():
@@ -16,3 +18,12 @@ def test_getuptime_help_runs_without_error(polldevs_conf, monkeypatch):
 def test_polltest_help_runs_without_error(polldevs_conf, monkeypatch):
     monkeypatch.chdir(os.path.dirname(polldevs_conf))
     assert subprocess.check_call(["python", "-m", "zino.polltest", "-h"]) == 0
+
+
+def test_when_interrupted_by_ctrl_c_zino_should_exit_cleanly(zino_conf):
+    process = subprocess.Popen(["zino", "--trap-port", "0"], cwd=zino_conf.parent)
+    time.sleep(1)
+    process.send_signal(signal.SIGINT)
+    process.wait()
+
+    assert process.returncode == 0, f"Process exited with code {process.returncode}"


### PR DESCRIPTION
## Scope and purpose

We lack coverage of `zino.zino` on this particular point, and CodeCov complains about the same lines of code whenever we move them around.

This tries to test the behavior to fix the coverage issue.

### This pull request
* adds a test

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [ ] Linted/formatted the code with black, ruff and isort, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
