### PR TITLE
Ensure existing loggers aren't disabled 

### DIFF
--- a/changelog.d/404.fixed.md
+++ b/changelog.d/404.fixed.md
@@ -1,0 +1,1 @@
+Ensure error messages are printed as they should be on zino startup

--- a/src/zino/config/models.py
+++ b/src/zino/config/models.py
@@ -92,6 +92,7 @@ class Configuration(BaseModel):
     snmp: SNMPConfiguration = SNMPConfiguration()
     logging: dict[str, Any] = {
         "version": 1,
+        "disable_existing_loggers": False,
         "loggers": {
             "root": {"level": "INFO", "handlers": ["console"]},
             "apscheduler": {"level": "WARNING"},

--- a/tests/bin_test.py
+++ b/tests/bin_test.py
@@ -27,3 +27,10 @@ def test_when_interrupted_by_ctrl_c_zino_should_exit_cleanly(zino_conf):
     process.wait()
 
     assert process.returncode == 0, f"Process exited with code {process.returncode}"
+
+
+def test_when_run_from_empty_directory_it_should_log_error_and_exit(tmp_path_factory):
+    cwd = tmp_path_factory.mktemp("empty")
+    expected_error = b"No such file or directory: 'secrets'"
+    result = subprocess.run(["zino", "--trap-port", "0"], cwd=cwd, capture_output=True)
+    assert expected_error in result.stderr

--- a/zino.toml.example
+++ b/zino.toml.example
@@ -38,6 +38,7 @@ backend = "netsnmp"
 #
 #[logging]
 #version = 1
+#disable_existing_loggers = false
 #
 #[logging.loggers.root]
 #level = "INFO"


### PR DESCRIPTION
## Scope and purpose

Fixes #404.

This ensures existing loggers aren't disabled by the call to `dictConfig()` when the default logging configuration is parsed.  Without this, Zino would stop on errors without printing any error messages if it ran with its default config (i.e. no config file was found).

### This pull request

* updates the default logging configuration
* updates the example configuration
* adds regression testing for #404 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
