### PR TITLE
Upload code coverage to SonarQube

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -61,6 +61,32 @@ jobs:
             echo "BASE_SHA=$base_sha" >> $GITHUB_ENV
           fi
 
+      - name: Read base name file
+        if: ${{ hashFiles('artifacts/extra/base_name') != '' }}
+        run: |
+          base_name=$(cat artifacts/extra/base_name)
+          re='^[0-9a-zA-Z._\/\-]+$'
+          if [[ $base_name =~ $re ]] ; then
+            echo "BASE_NAME=$base_name" >> $GITHUB_ENV
+          fi
+
+      - name: SonarQube Scan for Pull Request
+        uses: SonarSource/sonarqube-scan-action@v5
+        if: github.event.workflow_run.event == 'pull_request'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
+            -Dsonar.pullrequest.base=${{ env.BASE_NAME }}
+
+      - name: SonarQube Scan for Push
+        uses: SonarSource/sonarqube-scan-action@v5
+        if: github.event.workflow_run.event == 'push'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,13 +61,14 @@ jobs:
           path: |
             reports/**/*
 
-  upload-pr-number-base-sha:
-    name: Save PR number and base SHA in artifact
+  upload-pr-info:
+    name: Save extra PR info in artifact
     runs-on: ubuntu-latest
     if: ${{ github.event.number && always() }}
     env:
       PR_NUMBER: ${{ github.event.number }}
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      BASE_NAME: ${{ github.base_ref }}
     steps:
       - name: Make PR number file
         run: |
@@ -76,7 +77,10 @@ jobs:
       - name: Make base SHA file
         run: |
           echo $BASE_SHA > ./extra/base_sha
-      - name: Upload PR number file and base SHA file
+      - name: Make base name file
+        run: |
+          echo $BASE_NAME > ./extra/base_name
+      - name: Upload PR info files
         uses: actions/upload-artifact@v4
         with:
           name: extra

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -7,7 +7,7 @@ sonar.sources=src
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-sonar.python.version=3.9, 3.10, 3.11
+sonar.python.version=3.9, 3.10, 3.11, 3.12
 sonar.tests=tests
 
 sonar.exclusions=src/zino/snmp/mibdumps/**

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -11,3 +11,6 @@ sonar.python.version=3.9, 3.10, 3.11
 sonar.tests=tests
 
 sonar.exclusions=src/zino/snmp/mibdumps/**
+
+# Path for coverage files in the GitHub actions workflow
+sonar.python.coverage.reportPaths=artifacts/**/coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ exclude_also = [
     "raise NotImplementedError",
 ]
 
+[tool.coverage.run]
+source = ["src"]
+omit = ["**/zino/version.py"]
 
 [tool.towncrier]
 directory = "changelog.d"

--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,4 @@ passenv = HOME
 package = editable
 
 commands =
-    pytest -o junit_suite_name="{envname} unit tests" --cov={toxinidir}/src --cov-report=xml:reports/{envname}/coverage.xml --junitxml=reports/{envname}/unit-results.xml --verbose {posargs}
+    pytest -o junit_suite_name="{envname} unit tests" --cov={toxinidir}/src --cov-report=xml:reports/{envname}/coverage.xml --cov-config=pyproject.toml --junitxml=reports/{envname}/unit-results.xml --verbose {posargs}


### PR DESCRIPTION
## Scope and purpose

To try out if [SonarQube](https://sonarcloud.io/) is a good alternative to [CodeCov](https://app.codecov.io/) this will upload the already by coverage generated reports to SonarQube. I followed this tutorial: https://docs.sonarsource.com/sonarqube-cloud/enriching/test-coverage/python-test-coverage/

This does not yet set any restrictions on the code coverage, for now it will only be displayed among the other code scanning results. It can later be added for the workflow step/code analysis to fail if the coverage is lower that before for a pull request or other restrictions. For that a new Quality Gate needs to be created and applied. [Quality Gates reference](https://docs.sonarsource.com/sonarqube-server/latest/quality-standards-administration/managing-quality-gates/introduction-to-quality-gates/)

This has been tested in another, private repository. To see if it actually works in Zino we will have to blindly merge this PR and see if it works.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  - only workflow/devex changes
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
