### PR TITLE
Use new `snmpversion` config field to decide SNMP version

### DIFF
--- a/changelog.d/397.changed.md
+++ b/changelog.d/397.changed.md
@@ -1,0 +1,1 @@
+Use new snmpversion config field to decide which SNMP version to use.

--- a/polldevs.cf.example
+++ b/polldevs.cf.example
@@ -11,6 +11,7 @@
 default interval: 5
 default community: public
 default domain: example.org
+default snmpversion: v2c
 
 # Example router, with a higher scheduling priority.  Interfaces whose name
 # matches the regular expression `pe-` will be not be monitored:

--- a/src/zino/config/models.py
+++ b/src/zino/config/models.py
@@ -42,7 +42,8 @@ class PollDevice(BaseModel):
     retries: int = 3
     domain: str = None
     statistics: bool = True
-    hcounters: bool = True  # basically default to SNMP v2c
+    hcounters: bool = True  # Not used but kept for compatibility with old config files
+    snmpversion: Literal["v1", "v2c"] = "v2c"
     do_bgp: bool = True
     port: int = 161
 

--- a/src/zino/snmp/__init__.py
+++ b/src/zino/snmp/__init__.py
@@ -55,7 +55,7 @@ def get_snmp_session(device: PollDevice) -> "SNMP":
     if _snmp_sessions is None:  # Tests suite may disable session re-use
         return _selected_backend.SNMP(device)
     # We generate a session key based on every attribute that affects how the SNMP session is set up:
-    key = (device.address, device.community, device.hcounters)
+    key = (device.address, device.community, device.snmpversion)
     session = _snmp_sessions.get(key)
     if not session:
         session = _snmp_sessions[key] = _selected_backend.SNMP(device)

--- a/src/zino/snmp/netsnmpy_backend.py
+++ b/src/zino/snmp/netsnmpy_backend.py
@@ -86,7 +86,7 @@ class SNMP:
             host=device.address,
             port=device.port,
             community=device.community,
-            version=self.snmp_version,
+            version=device.snmpversion,
             timeout=device.timeout,
             retries=device.retries,
         )
@@ -355,11 +355,6 @@ class SNMP:
     def _var_bind_to_mibobject(var_bind: tuple[OID, Any]) -> MibObject:
         oid, value = var_bind
         return MibObject(oid=oid, value=value)
-
-    @property
-    def snmp_version(self) -> str:
-        """Returns the preferred SNMP version of this device as a string"""
-        return "v2c" if self.device.hcounters else "v1"
 
 
 def _convert_snmp_variable(variable: SNMPVariable) -> SNMPVarBind:

--- a/src/zino/snmp/pysnmp_backend.py
+++ b/src/zino/snmp/pysnmp_backend.py
@@ -455,7 +455,7 @@ class SNMP:
     @property
     def mp_model(self) -> int:
         """Returns the preferred SNMP version of this device as a PySNMP mpModel value"""
-        return 1 if self.device.hcounters else 0
+        return 1 if self.device.snmpversion == "v2c" else 0
 
     @property
     def community_data(self) -> CommunityData:

--- a/tests/config/polldevs_test.py
+++ b/tests/config/polldevs_test.py
@@ -30,6 +30,11 @@ class TestReadPolldevs:
         assert all(device.community == "foobar" for device in result.values())
         assert all(device.domain == "uninett.no" for device in result.values())
 
+    def test_when_hcounters_is_in_config_it_should_parse_correctly(self, polldevs_conf_with_hcounters):
+        result, _ = read_polldevs(polldevs_conf_with_hcounters)
+        assert len(result) == 2
+        assert all(device.hcounters for device in result.values())
+
 
 class TestReadInvalidPolldevs:
     def test_should_raise_exception(self, invalid_polldevs_conf):
@@ -129,6 +134,30 @@ def missing_device_address_polldevs_conf(tmp_path):
             default snmpversion: v2c
 
             name: example-gw
+            """
+        )
+    yield name
+
+
+@pytest.fixture
+def polldevs_conf_with_hcounters(tmp_path):
+    name = tmp_path.joinpath("polldevs.cf")
+    with open(name, "w") as conf:
+        conf.write(
+            """# polldevs test config
+            default interval: 5
+            default community: foobar
+            default domain: uninett.no
+            default statistics: yes
+            default snmpversion: v2c
+            default hcounters: yes
+
+            name: example-gw
+            address: 10.0.42.1
+            hcounters: yes
+
+            name: example-gw2
+            address: 10.0.43.1
             """
         )
     yield name

--- a/tests/config/polldevs_test.py
+++ b/tests/config/polldevs_test.py
@@ -126,7 +126,7 @@ def missing_device_address_polldevs_conf(tmp_path):
             default community: foobar
             default domain: uninett.no
             default statistics: yes
-            default hcounters: yes
+            default snmpversion: v2c
 
             name: example-gw
             """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def polldevs_conf(tmp_path):
             default community: foobar
             default domain: uninett.no
             default statistics: yes
-            default hcounters: yes
+            default snmpversion: v2c
 
             name: example-gw
             address: 10.0.42.1
@@ -83,7 +83,7 @@ def polldevs_conf_with_single_router(tmp_path):
             default community: foobar
             default domain: uninett.no
             default statistics: yes
-            default hcounters: yes
+            default snmpversion: v2c
 
             name: example-gw
             address: 10.0.42.1
@@ -102,7 +102,7 @@ def polldevs_conf_with_no_routers(tmp_path):
             default community: foobar
             default domain: uninett.no
             default statistics: yes
-            default hcounters: yes
+            default snmpversion: v2c
             """
         )
     yield name

--- a/tests/getuptime_test.py
+++ b/tests/getuptime_test.py
@@ -20,7 +20,7 @@ def polldevs_with_localhost(zino_conf, snmp_test_port):
             default community: public
             default domain: uninett.no
             default statistics: yes
-            default hcounters: yes
+            default snmpversion: v2c
 
             name: localhost
             address: 127.0.0.1

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -70,7 +70,7 @@ class TestLoadPolldevs:
                 default community: barfoo
                 default domain: uninett.no
                 default statistics: yes
-                default hcounters: yes
+                default snmpversion: v2c
 
                 name: example-gw
                 address: 10.0.42.1
@@ -98,7 +98,7 @@ class TestLoadPolldevs:
                 default community: barfoo
                 default domain: uninett.no
                 default statistics: yes
-                default hcounters: yes
+                default snmpversion: v2c
 
                 name: example-gw
                 address: 10.0.42.1
@@ -129,7 +129,7 @@ class TestLoadPolldevs:
                 default community: foobar
                 default domain: uninett.no
                 default statistics: yes
-                default hcounters: yes
+                default snmpversion: v2c
 
                 name: example-gw
                 address: 10.0.42.1

--- a/tests/snmp/pysnmp_backend_test.py
+++ b/tests/snmp/pysnmp_backend_test.py
@@ -282,7 +282,7 @@ class TestPDUErrors:
     """Tests for handling error flags in response PDUs."""
 
     async def test_when_snmpv1_variable_does_not_exist_it_should_raise_error(self, snmp_client):
-        snmp_client.device.hcounters = False  # force SNMPv1
+        snmp_client.device.snmpversion = "v1"  # force SNMPv1
         with pytest.raises(NoSuchNameError):
             await snmp_client.get("SNMPv2-MIB", "sysUpTime", 999)
 

--- a/tests/snmp_test.py
+++ b/tests/snmp_test.py
@@ -13,13 +13,13 @@ class TestGetSnmpSession:
         # Temporarily enable session re-use (which is otherwise disabled for testing purposes)
         with monkeypatch.context() as patch:
             patch.setattr("zino.snmp._snmp_sessions", WeakValueDictionary())
-            device = PollDevice(name="localhost", address="127.0.0.1", community="public", hcounters=True)
+            device = PollDevice(name="localhost", address="127.0.0.1", community="public", snmpversion="v2c")
             session1 = get_snmp_session(device)
             session2 = get_snmp_session(device)
             assert session1 is session2
 
     def test_when_reuse_is_disabled_it_should_return_new_session(self):
-        device = PollDevice(name="localhost", address="127.0.0.1", community="public", hcounters=True)
+        device = PollDevice(name="localhost", address="127.0.0.1", community="public", snmpversion="v2c")
         session1 = get_snmp_session(device)
         session2 = get_snmp_session(device)
         assert session1 is not session2


### PR DESCRIPTION
## Scope and purpose

Fixes #397.

Replaces hcounters for this purpose, but hcounters is kept as a valid value in the config so old configs that uses hcounters doesnt cause it to crash.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation (Changed example config file)
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
