### PR TITLE
Add option to suppress `portstate` events for new interfaces

### DIFF
--- a/changelog.d/+suppress-portstate-for-new-ports.changed.md
+++ b/changelog.d/+suppress-portstate-for-new-ports.changed.md
@@ -1,0 +1,1 @@
+Default to *not* create `portstate` events for newly discovered interfaces

--- a/changelog.d/257.added.md
+++ b/changelog.d/257.added.md
@@ -1,0 +1,1 @@
+Added new config option to suppress `portstate` event generation for newly discovered interfaces

--- a/src/zino/config/models.py
+++ b/src/zino/config/models.py
@@ -80,6 +80,14 @@ class SNMPConfiguration(BaseModel):
     backend: Literal["pysnmp", "netsnmp"] = "netsnmp"
 
 
+class EventConfiguration(BaseModel):
+    """Options to control how events are created"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    make_events_for_new_interfaces: bool = False
+
+
 class Configuration(BaseModel):
     """Class for keeping track of the configuration set by zino.toml"""
 
@@ -91,6 +99,7 @@ class Configuration(BaseModel):
     persistence: Persistence = Persistence()
     polling: Polling = Polling()
     snmp: SNMPConfiguration = SNMPConfiguration()
+    event: EventConfiguration = EventConfiguration()
     logging: dict[str, Any] = {
         "version": 1,
         "disable_existing_loggers": False,

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -4,6 +4,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+import zino.state
 from zino.oid import OID
 from zino.scheduler import get_scheduler
 from zino.snmp.base import SparseWalkResponse
@@ -47,6 +48,7 @@ class LinkStateTask(Task):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._scheduler = get_scheduler()
+        self._make_events_for_new_interfaces = zino.state.config.event.make_events_for_new_interfaces
 
     async def run(self):
         poll_list = [("IF-MIB", column) for column in BASE_POLL_LIST]
@@ -108,9 +110,10 @@ class LinkStateTask(Task):
                 raise MissingInterfaceTableData(self.device.name, data.index, attr)
 
         state = f"admin{data.admin_status.capitalize()}"
-        # A special tweak so that we report ports in oper-down (but admin-up) state first time we see them
-        if not port.state and data.oper_status != "up" and state != "adminDown":
-            port.state = InterfaceState.UNKNOWN
+        if not port.state and self._make_events_for_new_interfaces:
+            # This is the first time we see this port
+            if data.oper_status != "up" and state != "adminDown":
+                port.state = InterfaceState.UNKNOWN
         if state == "adminUp":
             state = data.oper_status
         state = InterfaceState(state)

--- a/tests/tasks/test_linkstatetask.py
+++ b/tests/tasks/test_linkstatetask.py
@@ -22,10 +22,21 @@ class TestLinkStateTask:
         assert (await task.run()) is None
         assert len(task.state.events) == 0
 
-    async def test_run_should_create_event_if_at_least_one_link_is_down(self, linkstatetask_with_one_link_down):
+    async def test_given_event_suppression_config_of_true_when_one_link_is_down_then_run_should_create_event(
+        self, linkstatetask_with_one_link_down
+    ):
         task = linkstatetask_with_one_link_down
+        task._make_events_for_new_interfaces = True
         assert (await task.run()) is None
         assert len(task.state.events) == 1
+
+    async def test_given_event_suppression_config_of_false_when_one_link_is_down_then_run_should_not_create_event(
+        self, linkstatetask_with_one_link_down
+    ):
+        task = linkstatetask_with_one_link_down
+        task._make_events_for_new_interfaces = False
+        assert (await task.run()) is None
+        assert len(task.state.events) == 0
 
     def test_when_patterns_are_empty_interface_should_not_be_ignored(self, task_with_dummy_device):
         data = BaseInterfaceRow(
@@ -81,6 +92,7 @@ class TestLinkStateTask:
     @pytest.mark.asyncio
     async def test_when_event_is_new_it_should_set_lasttrans(self, linkstatetask_with_one_link_down):
         task = linkstatetask_with_one_link_down
+        task._make_events_for_new_interfaces = True
         await task.run()
         event = task.state.events.get(task.device.name, 2, PortStateEvent)
         assert event.lasttrans

--- a/zino.toml.example
+++ b/zino.toml.example
@@ -31,6 +31,10 @@ period = 1
 # library to be installed on your system).  "pysnmp" selects the pure Python library PySNMP, which is less performant.
 backend = "netsnmp"
 
+[event]
+# Whether to create portstate events for newly discovered interfaces that are operationally down
+make_events_for_new_interfaces = false
+
 # Logging configuration is optional, but if specified, it will override the
 # default logging config of Zino.  This is a TOML representation of the default
 # logging configuration dictionary, whose full documentation is available at


### PR DESCRIPTION
## Scope and purpose

Fixes #257.

This adds a new `make_events_for_new_interfaces` boolean option to a new `[event]` section of the `zino.toml` configuration file.  It sets the default value to `false`, thereby reversing Zino's previous behavior: A newly discovered interface that is `adminUp` but `operDown` will *not* generate a new `portstate` event.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [x] Added/changed documentation (example config file)
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
