### PR TITLE
Reduce log level of unresolvable trap variables

### DIFF
--- a/changelog.d/+reduce-loglevel-for-unresolvable-traps.changed.md
+++ b/changelog.d/+reduce-loglevel-for-unresolvable-traps.changed.md
@@ -1,0 +1,1 @@
+Log unresolvable trap variables as debug level messages rather than error level (to avoid noisy logs)

--- a/src/zino/trapd/netsnmpy_backend.py
+++ b/src/zino/trapd/netsnmpy_backend.py
@@ -67,7 +67,7 @@ class TrapReceiver(TrapReceiverBase):
             try:
                 identifier, value = _convert_snmp_variable(variable)
             except ValueError:
-                _logger.error(
+                _logger.debug(
                     "Could not resolve SNMP variable %s: %s (Maybe MIB not loaded?)", variable, variable.value
                 )
                 return


### PR DESCRIPTION
## Scope and purpose

This reduces the log level from ERROR to DEBUG for trap variables that cannot be resolved from the loaded MIB modules.  As per @he32's suggestion, this becomes too noisy, since many routers send strange traps to Zino.



## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] ~~Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->~~
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
