### PR TITLE
Lock apscheduler dependency to 3.11

### DIFF
--- a/changelog.d/+lock-apscheduler-version.changed.md
+++ b/changelog.d/+lock-apscheduler-version.changed.md
@@ -1,0 +1,1 @@
+Lock `apscheduler` version requirement to latest stable series

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: System :: Networking :: Monitoring",
 ]
 dependencies = [
-    "apscheduler",
+    "apscheduler~=3.11",
     "pydantic>=2.7.0",
     "pysnmp~=6.2",
     "aiodns",


### PR DESCRIPTION
## Scope and purpose

@he32 reports that only 3.11 would work properly on NetBSD. 3.11 is the latest stable release.

Also, the 4.0 version is currently in pre-release and warns against backward-incompatible changes with no current migration path, so let's avoid that for now.

### This pull request
* adds a version requirement to the existing `apscheduler` dependency

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] ~~Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->~~
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
