### PR TITLE
Use fullstring matching in `PlannedMaintenance`

### DIFF
--- a/changelog.d/450.fixed.md
+++ b/changelog.d/450.fixed.md
@@ -1,0 +1,1 @@
+Use fullstring matching for regexp matches in PlannedMaintenance

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -530,7 +530,7 @@ class DeviceMaintenance(PlannedMaintenance):
         would be affected by this planned maintenance
         """
         if self.match_type == MatchType.REGEXP:
-            return regex_match(self.match_expression, device.name)
+            return regex_search(self.match_expression, device.name)
         if self.match_type == MatchType.STR:
             return string_match(self.match_expression, device.name)
         if self.match_type == MatchType.EXACT:
@@ -580,12 +580,12 @@ class PortStateMaintenance(PlannedMaintenance):
         would be affected by this planned maintenance
         """
         if self.match_type == MatchType.REGEXP:
-            return regex_match(self.match_expression, port.ifalias)
+            return regex_search(self.match_expression, port.ifalias)
         if self.match_type == MatchType.STR:
             return string_match(self.match_expression, port.ifalias)
         if self.match_type == MatchType.INTF_REGEXP:
-            if regex_match(self.match_device, device.name):
-                return regex_match(self.match_expression, port.ifdescr)
+            if regex_search(self.match_device, device.name):
+                return regex_search(self.match_expression, port.ifdescr)
         return False
 
     def get_matching(self, state: "ZinoState") -> Iterator[Sequence[Union[str, int]]]:
@@ -620,8 +620,8 @@ def string_match(pattern: str, string: str) -> bool:
     return fnmatch.fnmatch(string, pattern)
 
 
-def regex_match(pattern: str, string: str) -> bool:
+def regex_search(pattern: str, string: str) -> bool:
     """Matches `string` against regex expression `pattern`.
     Returns true if there is a match.
     """
-    return bool(re.match(pattern, string))
+    return bool(re.search(pattern, string))

--- a/tests/statemodels/device_maintenance_test.py
+++ b/tests/statemodels/device_maintenance_test.py
@@ -66,9 +66,18 @@ class TestMatchesDevice:
     def test_should_return_true_if_device_name_matches_expression(self, device, device_pm):
         assert device_pm.matches_device(device)
 
+    @pytest.mark.parametrize("device_pm", [MatchType.REGEXP], indirect=True)
+    def test_should_return_true_if_device_name_matches_start_of_regexp_expression(self, device, device_pm):
+        assert device_pm.matches_device(device)
+
+    @pytest.mark.parametrize("device_pm", [MatchType.REGEXP], indirect=True)
+    def test_should_return_true_if_device_name_matches_not_start_of_regexp_expression(self, device, device_pm):
+        device.name = "blabla" + device.name
+        assert device_pm.matches_device(device)
+
     @pytest.mark.parametrize("device_pm", [MatchType.EXACT, MatchType.REGEXP, MatchType.STR], indirect=True)
     def test_should_return_false_if_device_name_does_not_match_expression(self, device, device_pm):
-        device.name = "wrongdevice"
+        device.name = "wrong"
         assert not device_pm.matches_device(device)
 
     @pytest.mark.parametrize("device_pm", [MatchType.INTF_REGEXP], indirect=True)

--- a/tests/statemodels/planned_maintenance_test.py
+++ b/tests/statemodels/planned_maintenance_test.py
@@ -40,3 +40,15 @@ def pm() -> PlannedMaintenance:
         match_expression="device",
         match_device=None,
     )
+
+
+@pytest.fixture
+def regexp_pm() -> PlannedMaintenance:
+    return PlannedMaintenance(
+        start_time=datetime.datetime.now() - datetime.timedelta(days=1),
+        end_time=datetime.datetime.now() + datetime.timedelta(days=1),
+        type=PmType.DEVICE,
+        match_type=MatchType.REGEXP,
+        match_expression="device",
+        match_device=None,
+    )

--- a/tests/statemodels/portstate_maintenance_test.py
+++ b/tests/statemodels/portstate_maintenance_test.py
@@ -70,12 +70,19 @@ class TestMatchesEvent:
 class TestMatchesPortstate:
     @pytest.mark.parametrize("portstate_pm", [MatchType.REGEXP, MatchType.STR, MatchType.INTF_REGEXP], indirect=True)
     def test_should_return_false_for_non_matching_port(self, portstate_pm, device, port):
-        port.ifalias = "wrongportalias"
-        port.ifdescr = "wrongportdescr"
+        port.ifalias = "wrong"
+        port.ifdescr = "wrong"
         assert not portstate_pm.matches_portstate(device, port)
 
     @pytest.mark.parametrize("portstate_pm", [MatchType.REGEXP, MatchType.STR], indirect=True)
     def test_regexp_and_str_should_return_true_for_matching_port(self, portstate_pm, device, port):
+        assert portstate_pm.matches_portstate(device, port)
+
+    @pytest.mark.parametrize("portstate_pm", [MatchType.REGEXP], indirect=True)
+    def test_regexp_should_return_true_for_matching_port_not_at_start_of_regexp_expression(
+        self, portstate_pm, device, port
+    ):
+        port.ifalias = "blabla" + port.ifalias
         assert portstate_pm.matches_portstate(device, port)
 
     @pytest.mark.parametrize("portstate_pm", [MatchType.INTF_REGEXP], indirect=True)
@@ -86,7 +93,7 @@ class TestMatchesPortstate:
     def test_intf_regexp_match_type_should_return_false_for_matching_port_and_non_matching_device(
         self, portstate_pm, device, port
     ):
-        device.name = "wrongdevice"
+        device.name = "wrong"
         assert not portstate_pm.matches_portstate(device, port)
 
     @pytest.mark.parametrize("portstate_pm", [MatchType.EXACT], indirect=True)

--- a/tests/statemodels/statemodels_test.py
+++ b/tests/statemodels/statemodels_test.py
@@ -11,6 +11,7 @@ from zino.statemodels import (
     EventState,
     LogEntry,
     ReachabilityEvent,
+    regex_search,
 )
 from zino.time import now
 
@@ -161,6 +162,17 @@ class TestDeviceStates:
         result = states.get(router)
         assert isinstance(result, DeviceState)
         assert router in states
+
+
+class TestRegexSearch:
+    def test_when_string_matches_not_at_the_beginning_it_should_return_true(self):
+        assert regex_search("device", "blabla_device")
+
+    def test_when_string_matches_at_the_beginning_it_should_return_true(self):
+        assert regex_search("device", "device")
+
+    def test_when_string_does_not_match_it_should_return_false(self):
+        assert not regex_search("device", "wrong")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Scope and purpose

Fixes #450 

Changes `re.match` to `re.search `so it uses uses fullstring matching.
updates existing tests and adds new ones to cover this

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
