### PR TITLE
Use correct configuration object in `main()`

### DIFF
--- a/changelog.d/458.fixed.md
+++ b/changelog.d/458.fixed.md
@@ -1,0 +1,1 @@
+Don't crash when default `zino.toml` is not found

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -48,9 +48,9 @@ def main():
         level=logging.INFO if not args.debug else logging.DEBUG,
         format="%(asctime)s - %(levelname)s - %(name)s (%(threadName)s) - %(message)s",
     )
-    config = load_config(args)
-    if config:
-        state.config = config
+    _config = load_config(args)
+    if _config:
+        state.config = _config
     apply_logging_config(state.config.logging)
 
     try:
@@ -64,9 +64,9 @@ def main():
         sys.exit(1)
 
     # Load the same SNMP and trap back-ends
-    snmp_backend = import_snmp_backend(config.snmp.backend)
+    snmp_backend = import_snmp_backend(state.config.snmp.backend)
     snmp_backend.init_backend()
-    import_trap_backend(config.snmp.backend)
+    import_trap_backend(state.config.snmp.backend)
 
     state.state = state.ZinoState.load_state_from_file(state.config.persistence.file) or state.ZinoState()
     init_event_loop(args)


### PR DESCRIPTION
## Scope and purpose

Fixes #458.

Parts of `main()` was referencing the incorrect config object when loading the configured SNMP back-end. The "official" running config is in the state module. It is only replaced if `load_config()` returns an actual config object.  `load_config()` returns an empty result if the default config file is not present, but raises an exception if an alternate non-existent config file was specified on the command line.

In order for startup without a config file to work, all config must be referenced via `state.config`.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] ~~Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->~~
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
