### PR TITLE
Close events for removed routers on startup

### DIFF
--- a/changelog.d/470.fixed.md
+++ b/changelog.d/470.fixed.md
@@ -1,0 +1,1 @@
+Close events for removed routers on startup as well as during runtime


### PR DESCRIPTION
## Scope and purpose

Fixes #470. 

Closes events for all devices in the state that are not also defined as routers in polldevs.cf.
This should fix the issue of not closing events on startup, and only working for devices removed from polldevs.cf during runtime.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
