### PR TITLE
Delete device from state if not in polldevs

### DIFF
--- a/changelog.d/471.added.md
+++ b/changelog.d/471.added.md
@@ -1,0 +1,1 @@
+Delete state for devices not defined in polldevs.cf

--- a/src/zino/scheduler.py
+++ b/src/zino/scheduler.py
@@ -81,9 +81,10 @@ def load_polldevs(polldevs_conf: str) -> Tuple[Set, Set, Set, dict[str, str]]:
     for device in deleted_devices:
         del state.polldevs[device]
 
-    # Update event state
+    # Update event/device state
     unmonitored_devices = set(state.state.devices.devices) - set(devices)
     close_events_for_devices(unmonitored_devices)
+    delete_devicestate_for_devices(unmonitored_devices)
 
     state.pollfile_mtime = modified_time
 
@@ -149,3 +150,9 @@ def close_events_for_devices(devices: Sequence[str]):
             checked_out_event.set_state(EventState.CLOSED)
             checked_out_event.add_log(f"Router {event.router} is no longer being monitored")
             state.state.events.commit(checked_out_event)
+
+
+def delete_devicestate_for_devices(devices: Sequence[str]):
+    """Deletes `DeviceState` for the given devices."""
+    for device in devices:
+        del state.state.devices.devices[device]

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -61,6 +61,16 @@ class TestLoadPolldevs:
 
     @patch("zino.state.polldevs", dict())
     @patch("zino.state.pollfile_mtime", None)
+    def test_when_device_is_not_in_polldevs_it_should_be_deleted_from_state(self, polldevs_conf):
+        with patch("zino.state.state", ZinoState()) as state:
+            # this creates a DeviceState called removed-gw (removed-gw is not in polldevs_conf)
+            state.devices.get("removed-gw")
+            assert "removed-gw" in state.devices
+            scheduler.load_polldevs(polldevs_conf)
+            assert "removed-gw" not in state.devices
+
+    @patch("zino.state.polldevs", dict())
+    @patch("zino.state.pollfile_mtime", None)
     @patch("zino.state.state", ZinoState())
     def test__or_deleted_devices_on_invalid_configuration(self, invalid_polldevs_conf):
         new_devices, deleted_devices, changed_devices, _ = scheduler.load_polldevs(invalid_polldevs_conf)
@@ -236,6 +246,13 @@ def test_close_events_for_devices_should_close_events_for_given_devices(state_wi
         scheduler.close_events_for_devices(["localhost"])
         event = state.events.get_closed_event(*event_index)
         assert event.state == EventState.CLOSED
+
+
+def test_delete_devicestate_for_devices_should_delete_devicestates_for_given_devices(state_with_localhost):
+    with patch("zino.state.state", state_with_localhost) as state:
+        assert "localhost" in state.devices
+        scheduler.delete_devicestate_for_devices(["localhost"])
+        assert "localhost" not in state.devices
 
 
 @pytest.fixture


### PR DESCRIPTION
## Scope and purpose

Fixes #471

Deletes the state for all devices that are not defined in polldevs.cf.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
