### PR TITLE
Raise exception on illegal event replacement

### DIFF
--- a/changelog.d/+no-duplicate-events.fixed.md
+++ b/changelog.d/+no-duplicate-events.fixed.md
@@ -1,0 +1,1 @@
+Ensure duplicate events cannot be created, even under race conditions

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -151,6 +151,10 @@ class Events(BaseModel):
             old_event = self.events[event.id]
         self.record_downtime(event, old_event)
         index = EventIndex(event.router, event.subindex, type(event))
+        # verify that we're not attempting to replace an unrelated event in the index
+        indexed_event = self._events_by_index.get(index, event)
+        if indexed_event.id != event.id:
+            raise EventExistsError(f"{index} belongs to {indexed_event.id}, cannot commit {event.id} over it")
         self.events[event.id] = event
 
         # If event is set to closed, move it to the closed index and set updated

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -44,6 +44,14 @@ class TestEvents:
         with pytest.raises(EventExistsError):
             events.create_event("foobar", None, ReachabilityEvent)
 
+    def test_committing_identically_keyed_but_separate_events_should_raise(self):
+        events = Events()
+        index = EventIndex("foobar", None, ReachabilityEvent)
+        event1 = events.get_or_create_event(*index)
+        event2 = events.get_or_create_event(*index)
+        events.commit(event1)
+        assert pytest.raises(EventExistsError, events.commit, event2)
+
     def test_event_should_be_gettable_by_id(self):
         events = Events()
         event = events.create_event("foobar", None, ReachabilityEvent)


### PR DESCRIPTION
## Scope and purpose

It was possible to commit identical events (Zino <= 2.1.0), as long as their IDs were different. This was in fact happening due to a race condition in BFD event handling: Both the polling task and the trap handler relinquish control to the event loop between getting a new event and committing, allowing two identical BFD events to be created, but with different IDs.

It should not be possible to use the `commit()` method to commit two identically-keyed events with different IDs.  This ensures `commit()` raises an exception if this happens.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
