### PR TITLE
Do async reverse_dns call before creating event

### DIFF
--- a/changelog.d/+async-before-event-creation.fixed.md
+++ b/changelog.d/+async-before-event-creation.fixed.md
@@ -1,0 +1,1 @@
+Do async command (reverse DNS) before creating event instead of in the middle of event creation.

--- a/src/zino/tasks/bfdtask.py
+++ b/src/zino/tasks/bfdtask.py
@@ -69,6 +69,10 @@ class BFDTask(Task):
         port.bfd_state = new_state
 
     async def _create_or_update_event(self, port: Port, new_state: BFDState):
+        neigh_rnds = None
+        if new_state.session_addr:
+            neigh_rnds = await reverse_dns(str(new_state.session_addr))
+
         event = self.state.events.get_or_create_event(self.device.name, port.ifindex, BFDEvent)
 
         event.ifindex = port.ifindex
@@ -78,9 +82,7 @@ class BFDTask(Task):
         event.bfdix = new_state.session_index
         event.bfddiscr = new_state.session_discr
         event.bfdaddr = new_state.session_addr
-
-        if event.bfdaddr:
-            event.neigh_rdns = await reverse_dns(str(event.bfdaddr))
+        event.neigh_rdns = neigh_rnds
 
         log = f"changed BFD state to {new_state.session_state} on port {port.ifdescr}"
         event.lastevent = log


### PR DESCRIPTION
## Scope and purpose

Creating an event then doing an async call before committing it can cause issues with race conditions if an event with same index is made elsewhere while waiting for the response. Related to #474


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [ ] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
