### PR TITLE
Stop considering closed events as duplicates of open events in `Events.commit()`

### DIFF
--- a/changelog.d/481.fixed.md
+++ b/changelog.d/481.fixed.md
@@ -1,0 +1,1 @@
+Stop considering closed events as duplicates of open events during closed event modification

--- a/src/zino/events.py
+++ b/src/zino/events.py
@@ -151,10 +151,11 @@ class Events(BaseModel):
             old_event = self.events[event.id]
         self.record_downtime(event, old_event)
         index = EventIndex(event.router, event.subindex, type(event))
-        # verify that we're not attempting to replace an unrelated event in the index
-        indexed_event = self._events_by_index.get(index, event)
-        if indexed_event.id != event.id:
-            raise EventExistsError(f"{index} belongs to {indexed_event.id}, cannot commit {event.id} over it")
+        # verify that we're not attempting to replace an unrelated event in the index of open events
+        if event.state != EventState.CLOSED:
+            indexed_event = self._events_by_index.get(index, event)
+            if indexed_event.id != event.id:
+                raise EventExistsError(f"{index} belongs to {indexed_event.id}, cannot commit {event.id} over it")
         self.events[event.id] = event
 
         # If event is set to closed, move it to the closed index and set updated


### PR DESCRIPTION
## Scope and purpose

Fixes #481


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
