### PR TITLE
Fetch updated package list before installing deps when running GitHub tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions coverage
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends snmp libsnmp-dev
 
       - name: Test with tox


### PR DESCRIPTION
## Scope and purpose

GitHub seems to currently have an outdated package list, which makes the installation of libsnmp-dev fail.

Example: https://github.com/Uninett/zino/actions/runs/18964591042/job/54158637292


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
