### PR TITLE
Use microseconds in job name timestamps

### DIFF
--- a/changelog.d/+microsecond-timestamps-in-jobnames.fixed.md
+++ b/changelog.d/+microsecond-timestamps-in-jobnames.fixed.md
@@ -1,0 +1,1 @@
+Use microsecond timestamps in job identifiers where it is likely that two instances of the same one-shot job may be scheduled within a single second (to avoid `ConflictingError` esceptions observed in logs)

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -422,7 +422,7 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
 
         scheduler = get_scheduler()
 
-        timestamp_suffix = datetime.now().strftime("%H%M%S")
+        timestamp_suffix = datetime.now().strftime("%H%M%S.%f")
         job_name = f"{router_name}-api-triggered"
         job_id = f"{job_name}-{timestamp_suffix}"
         scheduler.add_job(

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -147,7 +147,7 @@ class LinkStateTask(Task):
     ):
         """Schedules a verification of a single port at a given time in the future"""
         verification_time = datetime.datetime.now() + deadline
-        timestamp_suffix = verification_time.strftime("%H%M%S")
+        timestamp_suffix = verification_time.strftime("%H%M%S.%f")
         job_name = f"{self.device.name}-{reason}-{ifindex}-state"
         job_id = f"{job_name}-{timestamp_suffix}"
         self._scheduler.add_job(


### PR DESCRIPTION
## Scope and purpose

Apparently, naming jobs down to the second isn't actually unique enough: While it is highly unlikely that two `POLLRTR` requests will come in from the API at the same second, it is likely that two link-state traps for the same port will arrive within the same second. The latter appears to be the case in production, which results in `apscheduler.jobstores.base.ConflictingIdError` being raised.

This adds microseconds to the timestamp used in a job name, which should be unique enough for most purposes ;-)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] ~~Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->~~
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
