### PR TITLE
Add explanation section to documentation

### DIFF
--- a/changelog.d/435.added.md
+++ b/changelog.d/435.added.md
@@ -1,0 +1,1 @@
+Added explanation section to documentation covering Zino's history, core concepts, and technical architecture ([#435](https://github.com/Uninett/zino/issues/435))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ except ImportError:
 
 extensions = [
     'sphinx.ext.intersphinx',
+    'sphinxcontrib.mermaid',
 ]
 
 intersphinx_mapping = {

--- a/docs/explanation/architecture.rst
+++ b/docs/explanation/architecture.rst
@@ -1,0 +1,244 @@
+Technical Architecture
+======================
+
+This document describes how Zino is structured internally. Understanding the
+architecture helps when debugging issues, extending functionality, or
+integrating with other systems.
+
+High-Level Overview
+-------------------
+
+.. mermaid::
+
+   flowchart TB
+       subgraph Routers["Routers (SNMP devices)"]
+       end
+
+       Routers --> Traps["SNMP Traps<br/>(trapd)"]
+       Routers --> Polling["SNMP Polling<br/>(tasks)"]
+       Routers -.->|state queries| State
+
+       Traps --> State["ZinoState<br/>(events, devices)"]
+       Polling --> State
+
+       State --> Port8001["Port 8001<br/>(command)"]
+       State --> Port8002["Port 8002<br/>(notify)"]
+       State --> StateFile["State File<br/>(JSON)"]
+
+       Port8001 --> Clients["Client UIs<br/>(curitz, ritz, etc.)"]
+       Port8002 --> Clients
+
+Components
+----------
+
+Entry Point
+^^^^^^^^^^^
+
+The main entry point is ``zino.zino:main()``, invoked by the ``zino`` console
+script. On startup, it:
+
+1. Parses command-line arguments
+2. Loads configuration (``zino.toml``, if present)
+3. Initializes the SNMP backend
+4. Loads persisted state from the JSON file
+5. Starts the async event loop
+6. Schedules polling tasks for all configured devices
+7. Starts the API server and trap listener
+
+State Management
+^^^^^^^^^^^^^^^^
+
+``ZinoState`` (in ``zino.state``) is the central container for all runtime
+data:
+
+- **devices**: Cached state for each monitored router
+- **events**: All active and recently-closed events
+- **addresses**: IP-to-hostname reverse mapping
+- **planned_maintenances**: Active maintenance windows
+- **flapping**: Flap detection state per interface
+
+State is persisted to a JSON file periodically (default: every 5 minutes) and
+on shutdown. The file format is a direct JSON serialization of the Pydantic
+models.
+
+Task System
+^^^^^^^^^^^
+
+Polling is implemented through **tasks**—async functions scheduled to run
+periodically for each device. The base class ``Task`` (in ``zino.tasks.task``)
+provides common functionality; concrete tasks implement the ``run()`` method.
+
+**ReachableTask**
+    Checks basic SNMP connectivity. If a device becomes unreachable, creates a
+    reachability event. This runs first to avoid pointless polling of
+    unreachable devices.
+
+**LinkStateTask**
+    Polls interface table (IF-MIB) to detect link state changes. Compares
+    current state against cached state to identify transitions.
+
+**BGPStateMonitorTask**
+    Polls BGP peer tables to detect session state changes. Supports multiple
+    BGP styles (Juniper, Cisco, generic MIBs).
+
+**BFDTask**
+    Polls BFD session state. BFD provides sub-second failure detection, and
+    Zino tracks when sessions leave the "up" state.
+
+**JuniperAlarmTask**
+    Polls Juniper-specific chassis alarm MIBs. Only runs on devices identified
+    as Juniper equipment.
+
+Tasks are scheduled using APScheduler, with intervals defined per-device in
+``polldevs.cf``.
+
+SNMP Subsystem
+^^^^^^^^^^^^^^
+
+Zino supports two SNMP backends:
+
+**Net-SNMP** (default)
+    Uses the ``netsnmp`` Python bindings to the Net-SNMP C library. Faster and
+    more mature, but requires system libraries to be installed.
+
+**PySNMP**
+    Pure Python implementation. Easier to install (pip only) but somewhat
+    slower. Useful when Net-SNMP isn't available.
+
+The backend is selected via configuration and abstracted behind a common
+interface (``zino.snmp``), so tasks don't need to know which backend is in use.
+
+Trap Handling
+^^^^^^^^^^^^^
+
+The trap daemon (``zino.trapd``) listens for incoming SNMP traps on a
+configured port (default: 162, or 1162 for non-root operation).
+
+When a trap arrives, it's dispatched to **trap observers**—handler functions
+registered for specific trap types:
+
+- ``link_traps``: Handles linkUp/linkDown notifications
+- ``bgp_traps``: Handles BGP state change traps
+- ``bfd_traps``: Handles BFD session traps
+- ``logged_traps``: Logs traps for debugging
+- ``ignored_traps``: Explicitly ignores known-noisy traps
+
+Trap observers typically trigger immediate polling to confirm the reported
+state change before creating or updating events.
+
+API Server
+^^^^^^^^^^
+
+The API server (``zino.api``) provides two TCP interfaces:
+
+**Command Interface (port 8001)**
+    Implements the legacy Zino protocol—a text-based, SMTP-like protocol where
+    clients send commands and receive responses. Commands include:
+
+    - ``CASEIDS``: List all event IDs
+    - ``GETATTRS <id>``: Get event attributes
+    - ``SETSTATE <id> <state>``: Change event state
+    - ``ADDHIST <id>``: Add history entry
+    - ``PM ADD/LIST/CANCEL``: Manage planned maintenance
+
+    This protocol is preserved exactly from Zino 1 for backwards compatibility
+    with existing clients.
+
+**Notification Interface (port 8002)**
+    A simpler protocol for push notifications. Clients connect and authenticate,
+    then receive messages whenever events are created or modified. Message
+    format:
+
+    .. code-block:: text
+
+        %%<id> <state> <type>
+
+    Clients use this to maintain live views without polling.
+
+Authentication
+^^^^^^^^^^^^^^
+
+Both API ports require authentication. Credentials are stored in a ``secrets``
+file (configurable path), one username/password pair per line.
+
+The authentication protocol supports both simple password and challenge-response
+mechanisms, preventing password replay attacks.
+
+Event System
+^^^^^^^^^^^^
+
+The ``Events`` container (``zino.events``) manages the event lifecycle:
+
+- **Creating events**: Tasks call ``get_or_create_event()`` when detecting a
+  state change. If an event already exists for that (router, subindex, type)
+  tuple, it's returned; otherwise, a new one is created.
+
+- **Updating events**: Events are "checked out" for modification, then
+  "committed" back. This pattern allows atomic updates.
+
+- **Observers**: Components can register as event observers to be notified when
+  events change. The notification API uses this to push updates to clients.
+
+- **Archiving**: Closed events are eventually archived to the ``old-events/``
+  directory and removed from active state.
+
+Data Flow Example
+-----------------
+
+Here's how a typical link-down scenario flows through the system:
+
+1. **Trap arrives**: Router sends linkDown trap to port 162
+2. **Trap dispatch**: ``link_traps`` observer receives the trap
+3. **Immediate poll**: Observer triggers a poll of the affected interface
+4. **State comparison**: ``LinkStateTask`` compares new state against cache
+5. **Event creation**: Task calls ``get_or_create_event()`` for a portstate
+   event
+6. **Event committed**: New event is added to ``ZinoState.events``
+7. **Observer notification**: Event observers are called
+8. **Client notification**: Notification server pushes update to connected
+   clients
+9. **State persistence**: Next periodic dump saves the new event to JSON
+
+Configuration Files
+-------------------
+
+**polldevs.cf**
+    Required. Lists devices to monitor with their SNMP credentials and polling
+    intervals. Zino watches this file for changes and reloads automatically.
+
+**zino.toml**
+    Optional. Configures persistence paths, logging, SNMP backend selection,
+    and other operational parameters.
+
+**secrets**
+    Required for API access. Contains username/password pairs for client
+    authentication.
+
+Concurrency Model
+-----------------
+
+Zino uses Python's ``asyncio`` for concurrency:
+
+- Polling tasks run as coroutines, allowing many devices to be polled
+  concurrently without threads
+- The API server handles multiple client connections concurrently
+- SNMP operations are async (with appropriate backend support)
+
+APScheduler manages task timing, triggering coroutines at configured intervals.
+The scheduler runs in the same event loop as the API server and trap listener.
+
+Extending Zino
+--------------
+
+**Adding a new task type**
+    Create a new class inheriting from ``Task``, implement the ``run()`` method,
+    and register it in the scheduler setup.
+
+**Adding a new trap observer**
+    Create a module in ``zino/trapobservers/``, define handler functions with
+    appropriate decorators, and import the module in ``zino.py``.
+
+**Adding new event types**
+    Define a new event class in ``zino.statemodels`` inheriting from ``Event``,
+    add it to the type union in ``Events``, and create corresponding tasks or
+    trap observers.

--- a/docs/explanation/concepts.rst
+++ b/docs/explanation/concepts.rst
@@ -1,0 +1,223 @@
+Core Concepts
+=============
+
+Understanding Zino requires familiarity with a few central concepts. This
+document explains the mental model behind the system.
+
+Events (Cases)
+--------------
+
+The **event** is Zino's fundamental abstraction. When something noteworthy
+happens on the network—a link goes down, a BGP session drops, a router becomes
+unreachable—Zino creates an event to track it.
+
+Events are sometimes called **cases** (the terms are interchangeable). This
+terminology reflects their purpose: each event represents a case that needs
+attention, investigation, and eventual resolution by a human operator.
+
+An event is uniquely identified by:
+
+- **Router**: The device where the issue occurred
+- **Subindex**: What specifically is affected (e.g., an interface index, a BGP
+  peer address, an alarm type)
+- **Type**: The kind of event (portstate, BGP, BFD, alarm, reachability)
+
+This combination ensures that if the same link flaps repeatedly, Zino updates
+the existing event rather than creating duplicates.
+
+Event Types
+-----------
+
+Zino monitors several categories of network state:
+
+**Port State Events** (``portstate``)
+    Track interface/link status changes. Created when a link goes down or
+    enters an unexpected state. The subindex is the interface's ifIndex.
+
+**BGP Events** (``bgp``)
+    Track BGP peer session state. Created when a BGP session leaves the
+    ``established`` state. The subindex is the peer's IP address.
+
+**BFD Events** (``bfd``)
+    Track Bidirectional Forwarding Detection sessions. Created when BFD
+    detects a forwarding path failure. The subindex is the session
+    discriminator.
+
+**Alarm Events** (``alarm``)
+    Track Juniper chassis alarms (yellow and red). Created when a router
+    reports hardware alarms. The subindex is the alarm type.
+
+**Reachability Events** (``reachability``)
+    Track whether Zino can reach a router at all. Created when SNMP polling
+    fails repeatedly. No subindex (the whole device is affected).
+
+Event Lifecycle
+---------------
+
+Events progress through a defined set of states:
+
+.. mermaid::
+
+   stateDiagram-v2
+       [*] --> EMBRYONIC: new event created
+       EMBRYONIC --> OPEN: committed
+
+       OPEN --> WORKING: operator claims
+       OPEN --> WAITING: operator defers
+       OPEN --> IGNORED: operator ignores
+
+       WORKING --> WAITING: waiting on external
+       WORKING --> CONFIRM: condition cleared
+       WAITING --> WORKING: resuming work
+       WAITING --> CONFIRM: condition cleared
+
+       CONFIRM --> CLOSED: operator confirms
+       WORKING --> CLOSED: operator closes
+       WAITING --> CLOSED: operator closes
+
+       CLOSED --> [*]
+
+       note right of OPEN: Awaiting operator attention
+       note right of IGNORED: Acknowledged but not addressed
+
+**EMBRYONIC**
+    A newly created event that hasn't been committed yet. Internal state only.
+
+**OPEN**
+    The default state for new events. Indicates the issue needs attention.
+
+**WORKING**
+    An operator has claimed this event and is actively investigating.
+
+**WAITING**
+    The operator is waiting for something (vendor response, scheduled
+    maintenance window, etc.).
+
+**CONFIRM-WAIT**
+    Used when the underlying condition has cleared but the operator wants to
+    confirm stability before closing.
+
+**IGNORED**
+    The event is acknowledged but intentionally not being addressed (e.g.,
+    known issue, decommissioned equipment).
+
+**CLOSED**
+    The event is resolved. Closed events are archived and eventually removed
+    from active state.
+
+Events accumulate a **history log** as they progress, recording state changes,
+operator comments, and related network events.
+
+Devices
+-------
+
+A **device** (or router) is any SNMP-managed network equipment that Zino
+monitors. Devices are defined in the ``polldevs.cf`` configuration file, which
+specifies:
+
+- Device name (typically the DNS hostname)
+- SNMP community string
+- Polling interval
+
+Zino maintains **device state** for each router, tracking:
+
+- Known interfaces and their current states
+- BGP peer sessions
+- Chassis alarms (Juniper)
+- Whether the device was reachable in the last polling cycle
+
+This cached state allows Zino to detect *changes* rather than just current
+conditions.
+
+Polling and Traps
+-----------------
+
+Zino uses a **trap-directed polling** model:
+
+**SNMP Traps** (push)
+    Devices send unsolicited notifications when state changes occur. Traps
+    provide immediate notification but can be lost (UDP) or may not be
+    configured for all events.
+
+**SNMP Polling** (pull)
+    Zino periodically queries each device for its current state. Polling is
+    slower but reliable—it catches issues even if traps were never sent.
+
+The combination provides both speed and reliability:
+
+1. A trap arrives indicating a link went down
+2. Zino immediately polls the device to confirm
+3. If confirmed, an event is created or updated
+4. Periodic polling continues, catching any state changes that didn't generate
+   traps
+
+Planned Maintenance
+-------------------
+
+**Planned Maintenance** (PM) windows allow operators to suppress event creation
+during scheduled work. When a PM is active for a device or pattern:
+
+- State changes are still detected and logged
+- But new events may be suppressed or automatically marked as related to
+  maintenance
+- This prevents the NOC from being flooded with alerts during known work
+
+PMs are defined with:
+
+- Start and end times
+- Device name or pattern (glob matching)
+- Description of the maintenance activity
+
+Flapping Detection
+------------------
+
+A link that bounces up and down repeatedly is **flapping**. Flapping can
+generate excessive events and masks the real problem.
+
+Zino detects flapping by tracking state change frequency. When a port exceeds a
+threshold of transitions within a time window, Zino:
+
+1. Marks the port as ``flapping``
+2. Stops creating new events for each individual transition
+3. Creates or updates a single event noting the flapping condition
+
+When the port stabilizes (stays in one state long enough), the flapping
+designation is cleared.
+
+Notifications
+-------------
+
+Zino provides two API ports:
+
+**Port 8001 (Command Interface)**
+    The main API for querying and manipulating events. Clients connect here to
+    list events, get details, update states, and add comments.
+
+**Port 8002 (Notification Interface)**
+    A push notification channel. Clients connect and receive real-time updates
+    when events are created or modified. This allows UIs to update immediately
+    rather than polling.
+
+The notification model means clients can maintain a live view of network state
+without constant API queries.
+
+State Persistence
+-----------------
+
+Zino serializes its entire state to a JSON file (``zino-state.json`` by
+default) periodically and on shutdown. This includes:
+
+- All active events
+- Device state cache
+- Planned maintenance windows
+- Flapping state
+
+On startup, Zino loads this file and resumes where it left off. This means:
+
+- Events survive restarts
+- Recent state changes aren't lost
+- Zino can pick up monitoring without a full re-poll of all devices
+
+The state file also enables a simple redundancy model: a standby Zino server
+can periodically receive the state file from the primary and be ready to take
+over if needed.

--- a/docs/explanation/concepts.rst
+++ b/docs/explanation/concepts.rst
@@ -168,18 +168,39 @@ PMs are defined with:
 - Device name or pattern (glob matching)
 - Description of the maintenance activity
 
+
+Alerts and notifications
+------------------------
+
+As Zino only concerns itself with tracking state changes, it does not handle
+dispatching of notifications to end users. Notification systems must be
+implemented as Zino API clients.
+
+Once such official client, EMT (E-Mail Trigger), written in Tcl, is shipped in
+the `original Zino 1 source code
+<https://ftp.nordu.net/nordunet/NORDstat/zino-1.0.tar.gz>`_.
+
+These days, however, we recommend integrating Zino with `Argus
+<https://network.geant.org/argus/>`_, using `the zino-argus-glue service
+<https://github.com/Uninett/zino-argus-glue/>`_, and letting Argus handle
+notifications for you (as well as serving as your GUI for incident management).
+
+These clients both support automatic failover from a primary to a secondary
+Zino instance in redundant server configurations.
+
+
 Flapping Detection
 ------------------
 
 A link that bounces up and down repeatedly is **flapping**. Flapping can
-generate excessive events and masks the real problem.
+generate excessive log messages, masking the real problem.
 
 Zino detects flapping by tracking state change frequency. When a port exceeds a
 threshold of transitions within a time window, Zino:
 
 1. Marks the port as ``flapping``
-2. Stops creating new events for each individual transition
-3. Creates or updates a single event noting the flapping condition
+2. Stops adding event log messages for each individual transition
+3. Creates or updates a single event, noting the flapping condition
 
 When the port stabilizes (stays in one state long enough), the flapping
 designation is cleared.

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -1,0 +1,14 @@
+Explanation
+===========
+
+This section provides background information to help you understand Zino: what
+it is, why it exists, and how it works. Unlike the how-to guides, these
+documents are meant to be read away from the keyboard, to build a mental model
+of the system.
+
+.. toctree::
+   :maxdepth: 2
+
+   overview
+   concepts
+   architecture

--- a/docs/explanation/overview.rst
+++ b/docs/explanation/overview.rst
@@ -1,0 +1,121 @@
+What is Zino?
+=============
+
+**Zino Is Not OpenView.**
+
+That recursive acronym—a reference to HP OpenView (a dominant commercial network
+management platform of the 1990s)—captures both Zino's origin and its
+philosophy: a lightweight, focused alternative to heavyweight enterprise
+solutions. The self-referential name follows a tradition beloved by Unix
+hackers, in the spirit of GNU ("GNU's Not Unix").
+
+Origin and History
+------------------
+
+Zino was created in 1996 at `Uninett <https://www.uninett.no/>`_, the
+organization that operates the Norwegian national research and education
+network (NREN). The initiator and driving force behind Zino was Håvard Eidnes,
+who needed a practical tool to monitor the routers of a large backbone network
+connecting Norway's geographically dispersed universities and research
+institutions.
+
+The original implementation was written in Tcl using the Scotty extension
+(which provided SNMP capabilities), comprising approximately 5,000 lines of
+code. Despite its modest size, Zino proved remarkably effective and
+battle-tested over decades of production use.
+
+Adoption beyond Norway came in 1999 when SUNET (the Swedish NREN) began using
+Zino at their Network Operations Center. NORDUnet, the collaboration that
+interconnects the Nordic NRENs, also adopted Zino for monitoring its backbone.
+Today, Zino is used by Uninett (now Sikt), NORDUnet, SUNET, and FUNET (the
+Finnish NREN).
+
+The Python Rewrite
+------------------
+
+After nearly three decades of service, the original Tcl codebase faced
+challenges: the Tcl/Scotty ecosystem had become obscure, making maintenance
+difficult and onboarding new developers nearly impossible. In response,
+NORDUnet sponsored a complete rewrite in Python, with the goal that all Nordic
+NRENs would use the modernized version.
+
+This project—Zino 2—preserves the original's design philosophy and maintains
+backwards compatibility with the legacy client/server protocol, allowing
+existing tools like *Ritz* and *curitz* to continue working unchanged.
+
+The Problem Zino Solves
+-----------------------
+
+Zino occupies a specific niche in network monitoring: **state change tracking
+for backbone networks**.
+
+Unlike metric-focused systems (Prometheus, Graphite) that collect and graph
+time-series data, or availability monitors (Nagios, Icinga) that check whether
+services respond, Zino tracks *state transitions* in network infrastructure:
+
+- A link goes down (or comes back up)
+- A BGP session drops (or re-establishes)
+- A BFD session fails
+- A Juniper router raises a chassis alarm
+
+Each state change creates an **event** (also called a **case**) that persists
+until a human operator explicitly closes it. This human-in-the-loop design is
+intentional: backbone network issues often require investigation, coordination,
+and documentation before they can be considered resolved.
+
+Design Philosophy
+-----------------
+
+Several principles guide Zino's design:
+
+**Event-driven, not metric-driven**
+    Zino doesn't collect throughput statistics or graph bandwidth utilization.
+    It watches for state changes and creates cases that need attention. If you
+    want traffic graphs, use a complementary tool.
+
+**Human-in-the-loop**
+    Events don't auto-close when a link recovers. An operator must acknowledge
+    and close each case. This ensures issues are investigated, not just
+    observed, and creates an audit trail of network incidents.
+
+**Trap-directed polling**
+    Zino uses a hybrid approach: it listens for SNMP traps (immediate
+    notifications from devices) but also performs periodic polling. Traps
+    provide fast notification; polling provides confirmation and catches
+    issues where traps were lost or never sent. This "trust but verify"
+    model improves reliability.
+
+**Minimal footprint**
+    The original fit in 5,000 lines of Tcl. The Python rewrite is larger but
+    remains focused. Zino has few dependencies, runs as a single process, and
+    stores state in a simple JSON file. No database server required.
+
+**Protocol compatibility**
+    The legacy SMTP-like client/server protocol is preserved exactly, so
+    existing user interfaces and integrations continue to work.
+
+How Zino Fits In
+----------------
+
+A typical NREN monitoring stack might include:
+
+- **Traffic statistics**: Tools like nfsen, LibreNMS, or similar for bandwidth
+  and flow analysis
+- **Availability monitoring**: Nagios, Icinga, or similar for service checks
+- **Zino**: For router state monitoring and incident case management
+
+Zino complements rather than replaces these tools. Its strength is providing a
+focused, reliable view of backbone router health with a workflow designed for
+NOC operations.
+
+Acknowledgments
+---------------
+
+Zino exists thanks to:
+
+- **Håvard Eidnes**, creator and long-time maintainer of the original Tcl
+  implementation
+- **Uninett** (now Sikt), where Zino was born
+- **NORDUnet**, sponsor of the Python rewrite
+- The NOC teams at the Nordic NRENs who have used and refined Zino over three
+  decades

--- a/docs/explanation/overview.rst
+++ b/docs/explanation/overview.rst
@@ -27,8 +27,8 @@ battle-tested over decades of production use.
 Adoption beyond Norway came in 1999 when SUNET (the Swedish NREN) began using
 Zino at their Network Operations Center. NORDUnet, the collaboration that
 interconnects the Nordic NRENs, also adopted Zino for monitoring its backbone.
-Today, Zino is used by Uninett (now Sikt), NORDUnet, SUNET, and FUNET (the
-Finnish NREN).
+Today, Zino is used by Uninett (now Sikt), NORDUnet, SUNET, and RHNet (the
+Icelandic NREN).
 
 The Python Rewrite
 ------------------
@@ -53,6 +53,7 @@ Unlike metric-focused systems (Prometheus, Graphite) that collect and graph
 time-series data, or availability monitors (Nagios, Icinga) that check whether
 services respond, Zino tracks *state transitions* in network infrastructure:
 
+- A router is unreachable (or reachable again)
 - A link goes down (or comes back up)
 - A BGP session drops (or re-establishes)
 - A BFD session fails
@@ -75,7 +76,7 @@ Several principles guide Zino's design:
 
 **Human-in-the-loop**
     Events don't auto-close when a link recovers. An operator must acknowledge
-    and close each case. This ensures issues are investigated, not just
+    or comment and close each case. This ensures issues are investigated, not just
     observed, and creates an audit trail of network incidents.
 
 **Trap-directed polling**
@@ -86,14 +87,31 @@ Several principles guide Zino's design:
     model improves reliability.
 
 **Minimal footprint**
-    The original fit in 5,000 lines of Tcl. The Python rewrite is larger but
-    remains focused. Zino has few dependencies, runs as a single process, and
-    stores state in a simple JSON file. No database server required.
+    The original fit in about 5,000 lines of Tcl. The Python rewrite is
+    about 5100 lines as of this writing. Zino has few dependencies, runs as
+    a single process, and stores state in a simple JSON file. No database
+    server required.
 
-**Protocol compatibility**
-    The legacy SMTP-like client/server protocol is preserved exactly, so
-    existing user interfaces and integrations continue to work.
 
+**Client/server architecture**
+    Zino, by design, features *no* GUI: It is purely a back-end
+    monitor. Instead, Zino provides a simple, SMTP-like protocol for clients
+    to interact with the server. Zino 2 preserves the Zino 1 protocol, so
+    that existing user interfaces and integrations can continue to work.
+Zino user interfaces
+--------------------
+
+* **curitz** - a curses/terminal-based remote interface to Zino. Curitz is
+  implemented in Python and is easy to install and use. See the `curitz GitHub
+  repository for more information <https://github.com/Uninett/curitz/>`_.
+* **Argus** - a web based interface. `Argus is a general purpose incident
+  management tool <https://network.geant.org/argus/>`_ that can be integrated
+  with many monitoring tools.  A `two-way zino-argus integration is available
+  <https://github.com/Uninett/zino-argus-glue/>`_. 
+* **Ritz** - the original, X11-based *Remote Interface To Zino*, implemented in
+  Tcl. The Ritz client is part of the original Zino 1 codebase, which is
+  currently only available as `a tarball at the NORDUnet FTP site
+  <https://ftp.nordu.net/nordunet/NORDstat/zino-1.0.tar.gz>`_.
 How Zino Fits In
 ----------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,14 +6,26 @@
 Zino documentation
 ==================
 
-Zino is a robust network management system for large backbone networks.
+Zino is a robust network state monitor for large backbone networks, originally
+developed at Uninett in the 1990s and now rewritten in Python.
 
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Understanding Zino:
+
+   explanation/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Using Zino:
 
    installation
    configuration
-   development
    howtos
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contributing:
+
+   development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,10 @@ zinoconv = "zino.stateconverter.convertstate:main"
 zping = "zino.zping:main"
 
 [project.optional-dependencies]
-docs = ["sphinx>=2.2.0"]
+docs = ["sphinx>=2.2.0", "sphinxcontrib-mermaid>=0.9"]
 
 [dependency-groups]
-docs = ["sphinx>2.2.0"]
+docs = ["sphinx>2.2.0", "sphinxcontrib-mermaid>=0.9"]
 test = [
     "coverage",
     "pexpect",


### PR DESCRIPTION
## Scope and purpose

**WARNING**: This is "AI slop" - it was deliberately generated using AI in order to provoke the documentation thought process. This probably contains lots of inaccuracies and needs several rounds of review and updates before it could be considered good enough to merge or publish.

Remember, the HTML output can be previewed at https://zino--519.org.readthedocs.build/en/519/

Fixes #435.

Adds an "Explanation" section to the documentation following the DIATAXIS framework, providing conceptual documentation to help new users understand Zino's purpose, history, and design.

### This pull request
* adds/changes a dependency

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done