### PR TITLE
Add a `--version` argument to the zino cli

### DIFF
--- a/changelog.d/521.added.md
+++ b/changelog.d/521.added.md
@@ -1,0 +1,1 @@
+Added the `--version` option to the Zino CLI

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -17,7 +17,7 @@ from typing import Any, Optional
 import tzlocal
 from pydantic import ValidationError
 
-from zino import flaps, state
+from zino import flaps, state, version
 from zino.api.server import ZinoServer
 from zino.config import InvalidConfigurationError, read_configuration
 from zino.job_tracker import get_job_tracker
@@ -335,6 +335,11 @@ def _count_reachable_objects(*types):
 
 def parse_args(arguments=None):
     parser = argparse.ArgumentParser(description="Zino is not OpenView")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"zino {version.__version__}",
+    )
     parser.add_argument(
         "--polldevs",
         type=str,


### PR DESCRIPTION
## Scope and purpose

Working across multiple test instances, I found it quite annoying to figure out which version of zino was actually installed and available at any given time.  This adds the standard `--version` argument to the command line parser.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] ~~Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->~~
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
