### PR TITLE
Fork child process for state dumps

### DIFF
--- a/changelog.d/468.fixed.md
+++ b/changelog.d/468.fixed.md
@@ -1,0 +1,1 @@
+State serialization now runs in a forked child process, preventing `PanicException` from concurrent modification of state data structures during JSON serialization.

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -179,6 +179,7 @@ async def fork_and_dump_state(filename: str):
         try:
             state.state.dump_state_to_file(filename)
         except Exception:
+            _log.exception("State dump failed in child process")
             os._exit(1)
         os._exit(0)
     else:

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -225,7 +225,7 @@ def setup_initial_job_schedule(loop: AbstractEventLoop, args: argparse.Namespace
     # Schedule state dumping as often as configured in
     # 'config.persistence.period' and reschedule whenever events are committed
     scheduler.add_job(
-        func=state.state.dump_state_to_file,
+        func=fork_and_dump_state,
         trigger="interval",
         args=(state.config.persistence.file,),
         id=STATE_DUMP_JOB_ID,

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -174,7 +174,7 @@ async def fork_and_dump_state(filename: str):
         return
 
     pid = os.fork()
-    if pid == 0:
+    if pid == 0:  # pragma: no cover
         # Child process — serialize and exit
         try:
             state.state.dump_state_to_file(filename)

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -393,6 +393,16 @@ class TestDumpStateWithFork:
         zino._reap_dump_child()
         assert zino._dump_child_pid == 0
 
+    def test_reap_dump_child_should_log_error_when_child_killed_by_signal(self, caplog):
+        fake_pid = 99999
+        zino._dump_child_pid = fake_pid
+        signal_status = signal.SIGKILL  # On Linux, WIFSIGNALED status for SIGKILL
+        with patch("os.waitpid", return_value=(fake_pid, signal_status)):
+            with caplog.at_level(logging.ERROR):
+                zino._reap_dump_child()
+        assert zino._dump_child_pid == 0
+        assert f"killed by signal {signal.SIGKILL}" in caplog.text
+
     def test_reap_dump_child_should_handle_child_process_error(self):
         """_reap_dump_child should handle ChildProcessError gracefully."""
         zino._dump_child_pid = 99999999


### PR DESCRIPTION
## Scope and purpose

Fixes #468. If accepted, this makes #365 obsolete.

State serialization (`model_dump_json`) runs in a thread pool by default (in order to avoid blocking the event loop), which can cause intermittent `PanicException`s ("dictionary changed size during iteration") when the main thread modifies state data structures concurrently.

This PR adds `fork_and_dump_state`, an async wrapper that forks a child process to serialize state. The child inherits a copy-on-write memory snapshot, so it can serialize at leisure while the parent continues unblocked. Being a coroutine, `APScheduler` runs it on the event loop thread (not in the thread pool), and `os.fork()` itself is effectively instantaneous.

`dump_state_to_file` is unchanged and remains directly testable.

This serialization trick is inspired by Redis BGSAVE.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~