### PR TITLE
Skip BFD conversion by default in `zinoconv`

### DIFF
--- a/changelog.d/+skip-bfd-conversion.changed.md
+++ b/changelog.d/+skip-bfd-conversion.changed.md
@@ -1,0 +1,1 @@
+`zinoconv` now skips BFD session state and BFD events by default. Use `--include-bfd` to opt in.

--- a/tests/stateconverter/convertstate_test.py
+++ b/tests/stateconverter/convertstate_test.py
@@ -26,9 +26,15 @@ def test_state_should_be_parsed_without_crashing(save_state_path):
     assert state
 
 
+def test_bfd_events_should_not_be_present_by_default(save_state_path):
+    state = create_state(save_state_path)
+    for event in state.events.events.values():
+        assert not isinstance(event, BFDEvent), "BFD events should be skipped by default"
+
+
 class TestEvents:
     def test_bfd_event_should_be_created_correctly(self, save_state_path):
-        state = create_state(save_state_path)
+        state = create_state(save_state_path, include_bfd=True)
         event = state.events.checkout(200)
         assert isinstance(event, BFDEvent)
         assert event.type == "bfd"
@@ -119,17 +125,17 @@ def test_jnx_alarms_should_be_set_correctly(save_state_path):
 
 class TestBFD:
     def test_sess_addr_should_be_set_correctly(self, save_state_path):
-        state = create_state(save_state_path)
+        state = create_state(save_state_path, include_bfd=True)
         device = state.devices.get("blaafjell-gw2")
         device.ports[30].bfd_state.session_addr is None
 
     def test_sess_discr_should_be_set_correctly(self, save_state_path):
-        state = create_state(save_state_path)
+        state = create_state(save_state_path, include_bfd=True)
         device = state.devices.get("blaafjell-gw2")
         device.ports[30].bfd_state.session_discr == 0
 
     def test_sess_state_should_be_set_correctly(self, save_state_path):
-        state = create_state(save_state_path)
+        state = create_state(save_state_path, include_bfd=True)
         device = state.devices.get("blaafjell-gw2")
         device.ports[30].bfd_state.session_state == BFDSessState.DOWN
 


### PR DESCRIPTION
## Scope and purpose

BFD events from Zino 1 don't necessarily make sense in Zino 2. `zinoconv` now skips BFD session state and BFD events by default. A new `--include-bfd` flag allows opting in if needed.

### This pull request
* changes the CLI interface of `zinoconv` (adds `--include-bfd` flag)

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [X] Added/amended tests for new/changed code
* ~~[ ] Added/changed documentation~~
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* ~~[ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~