### PR TITLE
Add zping CLI utility

### DIFF
--- a/changelog.d/528.added.md
+++ b/changelog.d/528.added.md
@@ -1,0 +1,1 @@
+Add `zping` CLI utility to check if a Zino daemon is alive by querying its SNMP agent for uptime.

--- a/docs/howtos/using-zping.rst
+++ b/docs/howtos/using-zping.rst
@@ -1,0 +1,30 @@
+==========================================
+How to: Check a Zino daemon with ``zping``
+==========================================
+
+``zping`` is a small command-line utility that asks a running Zino 2
+daemon for its uptime via SNMP. It is intended as a quick, manual
+liveness check from the shell.
+
+Basic usage
+===========
+
+Query a Zino agent on the default address (``127.0.0.1:8000``)::
+
+    $ zping
+    Zino is alive (uptime: 2 days, 3 hours, 17 minutes)
+
+Specify a host and port::
+
+    $ zping zino.example.org 8000
+
+Useful options:
+
+``--community``
+    SNMP v2c community string (default: ``public``).
+
+``--timeout``
+    Timeout in seconds for the SNMP request (default: ``5``).
+
+Exit codes: ``0`` on a valid response (printed to stdout), ``1`` on any
+failure (diagnostic written to stderr).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dynamic = ["version"]
 [project.scripts]
 zino = "zino.zino:main"
 zinoconv = "zino.stateconverter.convertstate:main"
+zping = "zino.zping:main"
 
 [project.optional-dependencies]
 docs = ["sphinx>=2.2.0"]

--- a/src/zino/zping.py
+++ b/src/zino/zping.py
@@ -1,0 +1,126 @@
+"""Query a Zino daemon's SNMP agent to check if it is alive and report its uptime.
+
+This module provides both a reusable async function for querying Zino's uptime via SNMP,
+and a CLI entry point for quick health checks.
+"""
+
+import argparse
+import asyncio
+import sys
+
+from pysnmp.hlapi.asyncio import (
+    CommunityData,
+    ContextData,
+    ObjectIdentity,
+    ObjectType,
+    SnmpEngine,
+    UdpTransportTarget,
+    getCmd,
+)
+
+# ZINO-MIB::zinoUpTime.0
+ZINO_UPTIME_OID = "1.3.6.1.4.1.2428.130.1.1.1.0"
+
+SECONDS_PER_MINUTE = 60
+SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
+SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
+
+_UPTIME_UNITS = (
+    (SECONDS_PER_DAY, "day", "days"),
+    (SECONDS_PER_HOUR, "hour", "hours"),
+    (SECONDS_PER_MINUTE, "minute", "minutes"),
+    (1, "second", "seconds"),
+)
+
+
+def main():
+    """CLI entry point for zping."""
+    parser = argparse.ArgumentParser(description="Check if a Zino daemon is alive by querying its SNMP agent")
+    parser.add_argument("host", nargs="?", default="127.0.0.1", help="Host to query (default: 127.0.0.1)")
+    parser.add_argument("port", nargs="?", type=int, default=8000, help="UDP port (default: 8000)")
+    parser.add_argument("--community", default="public", help="SNMP community (default: public)")
+    parser.add_argument("--timeout", type=int, default=5, help="Timeout in seconds (default: 5)")
+    args = parser.parse_args()
+
+    try:
+        uptime = asyncio.run(
+            get_zino_uptime(host=args.host, port=args.port, community=args.community, timeout=args.timeout)
+        )
+    except ZpingError as error:
+        print(f"Zino is not reachable at {args.host}:{args.port} ({error})", file=sys.stderr)
+        raise SystemExit(1)
+
+    print(f"Zino is alive (uptime: {format_uptime(uptime)})")
+
+
+async def get_zino_uptime(
+    host: str = "127.0.0.1", port: int = 8000, community: str = "public", timeout: int = 5
+) -> int:
+    """Query a Zino SNMP agent for its uptime.
+
+    :param host: Hostname or IP address of the Zino agent
+    :param port: UDP port the Zino SNMP agent listens on
+    :param community: SNMP community string
+    :param timeout: Timeout in seconds for the SNMP request
+    :return: Uptime in seconds
+    :raises ZpingError: When the agent is unreachable or returns an error
+    """
+    snmp_engine = SnmpEngine()
+
+    try:
+        error_indication, error_status, error_index, var_binds = await getCmd(
+            snmp_engine,
+            CommunityData(community),
+            UdpTransportTarget((host, port), timeout=timeout, retries=0),
+            ContextData(),
+            ObjectType(ObjectIdentity(ZINO_UPTIME_OID)),
+        )
+    except Exception as exc:
+        snmp_engine.closeDispatcher()
+        raise ZpingError(f"SNMP request failed: {exc}") from exc
+
+    snmp_engine.closeDispatcher()
+
+    if error_indication:
+        raise ZpingError(str(error_indication))
+    if error_status:
+        raise ZpingError(
+            f"SNMP error: {error_status.prettyPrint()} at {var_binds[int(error_index) - 1][0] if error_index else '?'}"
+        )
+    if not var_binds:
+        raise ZpingError("Empty response from agent")
+
+    _, value = var_binds[0]
+    return int(value)
+
+
+def format_uptime(seconds: int) -> str:
+    """Format an uptime value in seconds to a human-readable string.
+
+    Zero-valued components are omitted. For example, 90061 seconds becomes
+    ``"1 day, 1 hour, 1 second"`` (skipping minutes since they are zero).
+
+    :param seconds: Uptime in seconds (non-negative)
+    :return: Human-readable uptime string
+    """
+    if seconds < 0:
+        raise ValueError("Uptime cannot be negative")
+    if seconds == 0:
+        return "0 seconds"
+
+    parts = []
+    remainder = seconds
+    for unit_seconds, singular, plural in _UPTIME_UNITS:
+        count, remainder = divmod(remainder, unit_seconds)
+        if count:
+            parts.append(f"{count} {singular if count == 1 else plural}")
+
+    return ", ".join(parts)
+
+
+class ZpingError(Exception):
+    """Raised when a Zino uptime query fails."""
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_zping.py
+++ b/tests/test_zping.py
@@ -1,0 +1,156 @@
+"""Tests for the zping module."""
+
+import asyncio
+import subprocess
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from zino.zping import (
+    SECONDS_PER_DAY,
+    SECONDS_PER_HOUR,
+    SECONDS_PER_MINUTE,
+    ZpingError,
+    format_uptime,
+    get_zino_uptime,
+    main,
+)
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0, "0 seconds"),
+        (1, "1 second"),
+        (
+            1 * SECONDS_PER_DAY + 2 * SECONDS_PER_HOUR + 3 * SECONDS_PER_MINUTE + 4,
+            "1 day, 2 hours, 3 minutes, 4 seconds",
+        ),
+        (5 * SECONDS_PER_DAY + 3 * SECONDS_PER_HOUR + 7, "5 days, 3 hours, 7 seconds"),
+        (2 * SECONDS_PER_DAY + 30 * SECONDS_PER_MINUTE, "2 days, 30 minutes"),
+    ],
+)
+def test_when_format_uptime_is_called_then_it_should_render_human_readable_string(seconds, expected):
+    assert format_uptime(seconds) == expected
+
+
+def test_when_seconds_is_negative_then_format_uptime_should_raise_value_error():
+    with pytest.raises(ValueError, match="negative"):
+        format_uptime(-1)
+
+
+class TestGetZinoUptimeAgainstRealAgent:
+    """End-to-end tests that exercise the SNMP protocol against a real Zino agent subprocess."""
+
+    @pytest.mark.asyncio
+    async def test_when_agent_is_running_then_it_should_return_uptime_as_int(self, running_agent):
+        uptime = await get_zino_uptime(host="127.0.0.1", port=running_agent, timeout=2)
+        assert isinstance(uptime, int)
+        assert uptime >= 0
+
+    @pytest.mark.asyncio
+    async def test_when_no_agent_listens_then_it_should_raise_zping_error(self, unused_udp_port):
+        with pytest.raises(ZpingError):
+            await get_zino_uptime(host="127.0.0.1", port=unused_udp_port, timeout=1)
+
+
+class TestGetZinoUptimeProtocolCorners:
+    """Mocked tests for SNMP response shapes that a real Zino agent will not produce.
+
+    These cover defensive branches in ``get_zino_uptime`` (SNMP error PDUs, empty
+    var-bind lists). They cannot reasonably be triggered against a real agent, so
+    the SNMP layer is mocked here — the assertions are about how ``get_zino_uptime``
+    *interprets* such responses, not about the protocol exchange itself.
+    """
+
+    @pytest.mark.asyncio
+    @patch("zino.zping.SnmpEngine")
+    async def test_when_response_is_empty_then_it_should_raise_zping_error(self, _engine):
+        with patch("zino.zping.getCmd", new_callable=AsyncMock, return_value=(None, None, None, [])):
+            with pytest.raises(ZpingError, match="Empty response"):
+                await get_zino_uptime()
+
+    @pytest.mark.asyncio
+    @patch("zino.zping.SnmpEngine")
+    async def test_when_error_status_is_set_then_it_should_raise_zping_error(self, _engine):
+        error_status = MagicMock()
+        error_status.__bool__.return_value = True
+        error_status.prettyPrint.return_value = "noSuchName"
+        var_binds = [(MagicMock(__str__=lambda self: "1.3.6.1.4.1.2428.130.1.1.1.0"), None)]
+        with patch(
+            "zino.zping.getCmd",
+            new_callable=AsyncMock,
+            return_value=(None, error_status, 1, var_binds),
+        ):
+            with pytest.raises(ZpingError, match="noSuchName"):
+                await get_zino_uptime()
+
+    @pytest.mark.asyncio
+    @patch("zino.zping.SnmpEngine")
+    async def test_when_snmp_raises_exception_then_it_should_wrap_as_zping_error(self, _engine):
+        with patch("zino.zping.getCmd", new_callable=AsyncMock, side_effect=OSError("synthetic")):
+            with pytest.raises(ZpingError, match="SNMP request failed"):
+                await get_zino_uptime()
+
+    @pytest.mark.asyncio
+    @patch("zino.zping.SnmpEngine")
+    async def test_when_error_status_has_no_index_then_it_should_use_placeholder(self, _engine):
+        error_status = MagicMock()
+        error_status.__bool__.return_value = True
+        error_status.prettyPrint.return_value = "genErr"
+        with patch(
+            "zino.zping.getCmd",
+            new_callable=AsyncMock,
+            return_value=(None, error_status, 0, []),
+        ):
+            with pytest.raises(ZpingError, match=r"genErr at \?"):
+                await get_zino_uptime()
+
+
+class TestMain:
+    """Tests for the CLI entry point.
+
+    ``asyncio.run`` is patched so these tests don't create and tear down an event loop
+    — that would clear the current-loop pointer that ``pytest-asyncio<0.22`` relies on,
+    breaking unrelated async tests later in the suite. The unit under test here is the
+    argparse + stdout + exit-code wiring, not the loop.
+    """
+
+    def test_when_main_succeeds_then_it_should_print_uptime(self, capsys, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["zping"])
+        with patch("zino.zping.asyncio.run", return_value=42):
+            main()
+        captured = capsys.readouterr()
+        assert "Zino is alive" in captured.out
+        assert "42 seconds" in captured.out
+
+    def test_when_main_fails_then_it_should_exit_with_error(self, capsys, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["zping"])
+        with patch("zino.zping.asyncio.run", side_effect=ZpingError("boom")):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "not reachable" in captured.err
+        assert "boom" in captured.err
+
+
+@pytest.fixture
+async def running_agent(unused_udp_port):
+    """Start the Zino SNMP agent as a subprocess and give it a moment to come up."""
+    process = subprocess.Popen(
+        [sys.executable, "-m", "zino.snmp.agent", "--port", str(unused_udp_port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    await asyncio.sleep(1)
+    try:
+        yield unused_udp_port
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()


### PR DESCRIPTION
## Scope and purpose

Adds a `zping` CLI tool that queries a Zino daemon's built-in SNMP agent for `ZINO-MIB::zinoUpTime.0` to check if it is alive and report its uptime in human-readable format.

### This pull request
* adds a new CLI command

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~