### PR TITLE
Add straps/nmtrapd trap multiplexer support

### DIFF
--- a/changelog.d/362.added.md
+++ b/changelog.d/362.added.md
@@ -1,0 +1,1 @@
+Added support for receiving SNMP traps through a straps or nmtrapd trap multiplexer as an alternative to direct UDP binding.

--- a/changelog.d/362.changed.md
+++ b/changelog.d/362.changed.md
@@ -1,0 +1,1 @@
+The minimum required version of netsnmp-cffi is now 0.2.0.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,6 +61,63 @@ The ``[process]`` section controls process-level behavior.
    the SNMP trap port 162) are bound. This can be overridden by the ``--user``
    command-line option. Default: not set (no privilege dropping).
 
+.. _configuring-trap-reception:
+
+Configuring trap reception
+--------------------------
+
+By default, Zino binds directly to a UDP port (default 162) to receive SNMP
+traps.  This requires Zino to start as root (or with the
+``CAP_NET_BIND_SERVICE`` capability on Linux).
+
+Alternatively, Zino can receive traps through an external SNMP trap
+multiplexer.  A trap multiplexer can run as root and bind to port 162, then
+re-broadcasts incoming raw trap packets to connected clients.  This allows Zino
+(and an arbitrary number of other programs) to receive traps without having
+elevated privileges.
+
+Two multiplexer protocols are supported:
+
+``straps``
+   The original trap multiplexer from the `Scotty
+   <https://github.com/flightaware/scotty>`_ project (version 2.1.x).  It
+   creates a UNIX domain socket at ``/tmp/.straps-<port>`` (e.g.
+   ``/tmp/.straps-162``) and forwards framed trap packets to all connected
+   clients.  The straps source can be found in the `scotty 2.1.11 tarball
+   <https://fossies.org/linux/misc/old/scotty-2.1.11.tar.gz>`_ at
+   ``tnm/snmp/straps.c`` — it is a self-contained C program with no external
+   dependencies.
+
+``nmtrapd``
+   The newer variant from `FlightAware's scotty fork
+   <https://github.com/flightaware/scotty>`_.  It uses a TCP socket on
+   localhost port 1702 instead of a UNIX domain socket.  The source is at
+   ``tnm/unix/nmtrapd.c`` in the repository.
+
+To use a trap multiplexer, configure the ``[snmp.trap]`` section:
+
+.. code-block:: toml
+   :caption: zino.toml
+
+   [snmp.trap]
+   source = "straps"
+   # straps_socket = "/tmp/.straps-162"  # default
+
+For nmtrapd:
+
+.. code-block:: toml
+   :caption: zino.toml
+
+   [snmp.trap]
+   source = "nmtrapd"
+   # nmtrapd_host = "localhost"  # default
+   # nmtrapd_port = 1702  # default
+
+When using a multiplexer, the ``--trap-port`` command-line option is ignored.
+Zino will automatically reconnect if the multiplexer connection is lost, and
+includes a watchdog that detects silent connections (inspired by Zino 1's
+``TrapWatchdog``).
+
 .. _configuring-logging:
 
 Configuring logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pysnmp~=6.2",
     "aiodns>=3.6.1",
     "tomli; python_version < '3.11'",
-    "netsnmp-cffi>=0.1.4",
+    "netsnmp-cffi>=0.2.0",
 ]
 dynamic = ["version"]
 

--- a/src/zino/config/models.py
+++ b/src/zino/config/models.py
@@ -80,6 +80,10 @@ class TrapConfiguration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     require_community: list[str] = []
+    source: Literal["direct", "straps", "nmtrapd"] = "direct"
+    straps_socket: Optional[str] = None
+    nmtrapd_host: str = "localhost"
+    nmtrapd_port: int = 1702
 
 
 class AgentConfiguration(BaseModel):

--- a/src/zino/trapd/netsnmpy_backend.py
+++ b/src/zino/trapd/netsnmpy_backend.py
@@ -21,38 +21,15 @@ from zino.trapd.base import (
 _logger = logging.getLogger(__name__)
 
 
-class TrapReceiver(TrapReceiverBase):
-    """Zino Adapter for SNMP trap reception using netsnmp-cffi.
+class NetsnmpTrapProcessorMixin:
+    """Mixin that converts netsnmpy SNMPTrap objects into Zino TrapMessages and dispatches them.
 
-    Zino 1 accepts traps with any community string, as long as its origin is any one of the devices configured in
-    the pollfile.  The PySNMP back-end will only accept traps with one of the configured community strings.  *This*
-    back-end, however, will accept and pass on traps with any community string until `add_community()` is called
-    to configure at least one filter.
+    This mixin is shared between the direct UDP trap receiver and the straps/nmtrapd relay backend.
+    It expects to be mixed into a class that inherits from TrapReceiverBase.
     """
 
-    def __init__(
-        self,
-        address: str = "0.0.0.0",
-        port: int = 162,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
-        state: Optional[zino.state.ZinoState] = None,
-        polldevs: Optional[Dict[str, PollDevice]] = None,
-    ):
-        super().__init__(address, port, loop, state, polldevs)
-        self._session = SNMPTrapSession(ip_address(address), port)
-
-    async def open(self):
-        """Opens the UDP transport socket and starts receiving traps"""
-        self._session.add_observer(self.trap_received)
-        self._session.open()
-        _logger.info("Listening for incoming SNMP traps on %r", (self.address, self.port))
-
-    def close(self):
-        """Closes the running SNMP engine and its associated ports"""
-        self._session.close()
-
-    def trap_received(self, trap: SNMPTrap):
-        """Callback function that receives all trap messages from the Net-SNMP transport"""
+    def process_snmp_trap(self, trap: SNMPTrap):
+        """Processes a netsnmpy SNMPTrap: verifies it, converts variables, and dispatches to observers."""
         router = self._lookup_device(trap.source)
         # netsnmpy doesn't currently provide the source port:
         origin = TrapOriginator(address=trap.source, port=None, device=router)
@@ -97,6 +74,7 @@ class TrapReceiver(TrapReceiverBase):
         asyncio.ensure_future(self.dispatch_trap(zino_trap))
 
     def _verify_trap(self, netsnmp_trap: SNMPTrap, origin: TrapOriginator) -> bool:
+        """Verifies that an SNMPTrap is from a known device and has required fields."""
         if not origin.device:
             _logger.debug("ignored trap from %s (not a box we monitor?)", origin.address)
             return False
@@ -116,3 +94,38 @@ class TrapReceiver(TrapReceiverBase):
             return False
 
         return True
+
+
+class TrapReceiver(NetsnmpTrapProcessorMixin, TrapReceiverBase):
+    """Zino Adapter for SNMP trap reception using netsnmp-cffi.
+
+    Zino 1 accepts traps with any community string, as long as its origin is any one of the devices configured in
+    the pollfile.  The PySNMP back-end will only accept traps with one of the configured community strings.  *This*
+    back-end, however, will accept and pass on traps with any community string until `add_community()` is called
+    to configure at least one filter.
+    """
+
+    def __init__(
+        self,
+        address: str = "0.0.0.0",
+        port: int = 162,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        state: Optional[zino.state.ZinoState] = None,
+        polldevs: Optional[Dict[str, PollDevice]] = None,
+    ):
+        super().__init__(address, port, loop, state, polldevs)
+        self._session = SNMPTrapSession(ip_address(address), port)
+
+    async def open(self):
+        """Opens the UDP transport socket and starts receiving traps"""
+        self._session.add_observer(self.trap_received)
+        self._session.open()
+        _logger.info("Listening for incoming SNMP traps on %r", (self.address, self.port))
+
+    def close(self):
+        """Closes the running SNMP engine and its associated ports"""
+        self._session.close()
+
+    def trap_received(self, trap: SNMPTrap):
+        """Callback function that receives all trap messages from the Net-SNMP transport"""
+        self.process_snmp_trap(trap)

--- a/src/zino/trapd/straps_backend.py
+++ b/src/zino/trapd/straps_backend.py
@@ -1,0 +1,262 @@
+"""SNMP trap reception via straps/nmtrapd trap multiplexer.
+
+This module provides an alternative trap receiver that reads SNMP trap packets from a straps (UNIX
+domain socket) or nmtrapd (TCP) trap multiplexer, instead of binding directly to a UDP port.
+
+The straps/nmtrapd multiplexer runs as root and binds to UDP port 162.  It re-broadcasts incoming
+raw SNMP trap packets to connected clients, prefixed with a header containing the original sender's
+IP address, port, and the length of the SNMP packet data.  This allows multiple unprivileged
+programs to receive traps simultaneously.
+
+See https://github.com/Uninett/zino/issues/362 for background.
+"""
+
+import asyncio
+import logging
+import struct
+import time
+from ipaddress import IPv4Address
+from typing import Dict, Optional
+
+from netsnmpy.trapsession import parse_raw_trap
+
+import zino.state
+from zino.config.models import PollDevice, TrapConfiguration
+from zino.trapd.base import TrapReceiverBase
+from zino.trapd.netsnmpy_backend import NetsnmpTrapProcessorMixin
+
+_logger = logging.getLogger(__name__)
+
+# Watchdog defaults (inspired by Zino 1's TrapWatchdog in trap.tcl)
+WATCHDOG_CHECK_INTERVAL = 60  # seconds
+WATCHDOG_SILENCE_THRESHOLD = 300  # seconds (5 minutes)
+
+# Reconnect backoff on connection loss
+RECONNECT_BASE_DELAY = 1  # seconds
+RECONNECT_MAX_DELAY = 60  # seconds
+
+
+class StrapsFrameReader:
+    """Reads straps-framed SNMP trap packets from an asyncio StreamReader.
+
+    straps uses a 10-byte header:
+    - 4 bytes: sender IP address (network byte order)
+    - 2 bytes: sender port (network byte order)
+    - 4 bytes: SNMP packet length (host byte order)
+    """
+
+    HEADER_SIZE = 10
+
+    async def read_frame(self, reader: asyncio.StreamReader) -> tuple[IPv4Address, int, bytes]:
+        """Reads a single framed trap packet from the stream.
+
+        :return: Tuple of (source_address, source_port, raw_pdu_bytes).
+        :raises asyncio.IncompleteReadError: If the connection is closed mid-frame.
+        """
+        header = await reader.readexactly(self.HEADER_SIZE)
+        addr_bytes, port = struct.unpack("!4sH", header[:6])
+        (length,) = struct.unpack("=I", header[6:10])
+        source_addr = IPv4Address(addr_bytes)
+        pdu_data = await reader.readexactly(length)
+        return source_addr, port, pdu_data
+
+
+class NmtrapdFrameReader:
+    """Reads nmtrapd-framed SNMP trap packets from an asyncio StreamReader.
+
+    nmtrapd uses a 12-byte header:
+    - 1 byte: version (always 0)
+    - 1 byte: unused (always 0)
+    - 2 bytes: sender port (network byte order)
+    - 4 bytes: sender IP address (network byte order)
+    - 4 bytes: SNMP packet length (network byte order)
+    """
+
+    HEADER_SIZE = 12
+
+    async def read_frame(self, reader: asyncio.StreamReader) -> tuple[IPv4Address, int, bytes]:
+        """Reads a single framed trap packet from the stream.
+
+        :return: Tuple of (source_address, source_port, raw_pdu_bytes).
+        :raises asyncio.IncompleteReadError: If the connection is closed mid-frame.
+        """
+        header = await reader.readexactly(self.HEADER_SIZE)
+        _version, _unused, port, addr_int, length = struct.unpack("!BBHII", header)
+        source_addr = IPv4Address(addr_int)
+        pdu_data = await reader.readexactly(length)
+        return source_addr, port, pdu_data
+
+
+class StrapsTrapReceiver(NetsnmpTrapProcessorMixin, TrapReceiverBase):
+    """Trap receiver that reads from a straps/nmtrapd SNMP trap multiplexer.
+
+    Instead of binding directly to a UDP port, this receiver connects to a UNIX domain socket
+    (straps) or TCP socket (nmtrapd) and reads pre-framed raw SNMP trap packets.  The raw packets
+    are decoded using Net-SNMP's ``snmp_parse()`` via netsnmpy's ``parse_raw_trap()``, then
+    processed through the same pipeline as the direct UDP receiver.
+    """
+
+    def __init__(
+        self,
+        trap_config: TrapConfiguration,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        state: Optional[zino.state.ZinoState] = None,
+        polldevs: Optional[Dict[str, PollDevice]] = None,
+    ):
+        super().__init__(loop=loop, state=state, polldevs=polldevs)
+        self._trap_config = trap_config
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        self._reader_task: Optional[asyncio.Task] = None
+        self._watchdog_task: Optional[asyncio.Task] = None
+        self._last_trap_time: float = time.monotonic()
+        self._reconnect_failures: int = 0
+        self._closing: bool = False
+
+        if trap_config.source == "straps":
+            self._frame_reader = StrapsFrameReader()
+        else:
+            self._frame_reader = NmtrapdFrameReader()
+
+    # -- Public API --
+
+    async def open(self):
+        """Starts the straps/nmtrapd receiver.
+
+        The initial connection to the multiplexer is attempted in the background, so Zino can
+        start even if the multiplexer is not yet available.
+        """
+        self._reader_task = asyncio.ensure_future(self._read_loop())
+        self._watchdog_task = asyncio.ensure_future(self._watchdog_loop())
+
+    def close(self):
+        """Closes the socket connection and stops the reader task."""
+        self._closing = True
+        if self._reader_task and not self._reader_task.done():
+            self._reader_task.cancel()
+        if self._watchdog_task and not self._watchdog_task.done():
+            self._watchdog_task.cancel()
+        self._close_connection()
+
+    # -- Main loops (started by open) --
+
+    async def _read_loop(self):
+        """Continuously reads and processes trap frames from the multiplexer socket.
+
+        When the connection is lost, immediately attempts to reconnect with exponential backoff.
+        """
+        while not self._closing:
+            if self._reader is None:
+                await self._reconnect_with_backoff()
+                continue
+            try:
+                source_addr, source_port, pdu_data = await self._frame_reader.read_frame(self._reader)
+                self._last_trap_time = time.monotonic()
+                self._reconnect_failures = 0
+                self._process_raw_trap(pdu_data, source_addr)
+            except asyncio.IncompleteReadError:
+                if self._closing:
+                    return
+                _logger.warning("Connection to %s multiplexer lost (EOF)", self._trap_config.source)
+                await self._reconnect_with_backoff()
+            except Exception:
+                if self._closing:
+                    return
+                _logger.exception("Error reading from %s multiplexer", self._trap_config.source)
+                await self._reconnect_with_backoff()
+
+    def _process_raw_trap(self, pdu_data: bytes, source_addr: IPv4Address):
+        """Parses a raw SNMP PDU and processes it through the standard trap pipeline."""
+        try:
+            trap = parse_raw_trap(pdu_data, source_addr)
+        except ValueError:
+            _logger.warning("Failed to parse raw SNMP PDU from %s (length %d)", source_addr, len(pdu_data))
+            return
+        self.process_snmp_trap(trap)
+
+    async def _reconnect_with_backoff(self):
+        """Attempts to reconnect to the multiplexer with exponential backoff."""
+        delay = RECONNECT_BASE_DELAY
+        while not self._closing:
+            try:
+                _logger.info("Reconnecting to %s in %ds...", self._trap_config.source, delay)
+                await asyncio.sleep(delay)
+                if self._closing:
+                    return
+                await self._connect()
+                _logger.info("Reconnected to %s multiplexer", self._trap_config.source)
+                return
+            except OSError as error:
+                _logger.warning("Reconnect to %s failed: %s", self._trap_config.source, error)
+                delay = min(delay * 2, RECONNECT_MAX_DELAY)
+
+    async def _watchdog_loop(self):
+        """Periodically checks for trap reception silence and reconnects if needed.
+
+        Inspired by Zino 1's TrapWatchdog (trap.tcl): if no trap has been received for more than 5
+        minutes, tear down and re-establish the connection.  The failure counter resets when traps
+        start flowing again.
+        """
+        while not self._closing:
+            await asyncio.sleep(WATCHDOG_CHECK_INTERVAL)
+            if self._closing:
+                return
+
+            elapsed = time.monotonic() - self._last_trap_time
+            if elapsed < WATCHDOG_SILENCE_THRESHOLD:
+                _logger.debug("TrapWatchdog: traps OK (last received %.0fs ago)", elapsed)
+                continue
+
+            _logger.warning(
+                "TrapWatchdog: no SNMP traps received for %.0fs, reconnecting to %s",
+                elapsed,
+                self._trap_config.source,
+            )
+            self._reconnect_failures += 1
+
+            if self._reader_task and not self._reader_task.done():
+                self._reader_task.cancel()
+                try:
+                    await self._reader_task
+                except asyncio.CancelledError:
+                    pass  # Expected: we just cancelled this task
+
+            try:
+                await self._connect()
+                self._reader_task = asyncio.ensure_future(self._read_loop())
+            except OSError as error:
+                _logger.error(
+                    "TrapWatchdog: failed to reconnect to %s: %s",
+                    self._trap_config.source,
+                    error,
+                )
+
+    # -- Connection management (used by the above) --
+
+    async def _connect(self):
+        """Establishes a connection to the straps/nmtrapd socket."""
+        self._close_connection()
+
+        if self._trap_config.source == "straps":
+            socket_path = self._trap_config.straps_socket or "/tmp/.straps-162"
+            _logger.info("Connecting to straps UNIX socket at %s", socket_path)
+            self._reader, self._writer = await asyncio.open_unix_connection(socket_path)
+        else:
+            host = self._trap_config.nmtrapd_host
+            port = self._trap_config.nmtrapd_port
+            _logger.info("Connecting to nmtrapd at %s:%d", host, port)
+            self._reader, self._writer = await asyncio.open_connection(host, port)
+
+        self._last_trap_time = time.monotonic()
+        self._reconnect_failures = 0
+        _logger.info("Receiving SNMP traps via %s multiplexer", self._trap_config.source)
+
+    def _close_connection(self):
+        """Closes the current socket connection, if any."""
+        if self._writer:
+            try:
+                self._writer.close()
+            except Exception:
+                pass
+            self._writer = None
+        self._reader = None

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -111,10 +111,25 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
     if not loop:
         loop = asyncio.get_event_loop()
 
-    if args.trap_port:
+    trap_config = state.config.snmp.trap
+    if trap_config.source in ("straps", "nmtrapd"):
+        from zino.trapd.straps_backend import StrapsTrapReceiver
+
+        trap_receiver = StrapsTrapReceiver(trap_config=trap_config, loop=loop, state=state.state)
+        for community in trap_config.require_community:
+            trap_receiver.add_community(community)
+        trap_receiver.auto_subscribe_observers()
+
+        try:
+            loop.run_until_complete(trap_receiver.open())
+        except OSError as error:
+            _log.fatal("Failed to connect to %s trap multiplexer: %s", trap_config.source, error)
+            sys.exit(1)
+
+    elif args.trap_port:
         trap_backend = import_trap_backend()
         trap_receiver = trap_backend.TrapReceiver(port=args.trap_port, loop=loop, state=state.state)
-        for community in state.config.snmp.trap.require_community:
+        for community in trap_config.require_community:
             trap_receiver.add_community(community)
         trap_receiver.auto_subscribe_observers()
 

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -120,11 +120,7 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
             trap_receiver.add_community(community)
         trap_receiver.auto_subscribe_observers()
 
-        try:
-            loop.run_until_complete(trap_receiver.open())
-        except OSError as error:
-            _log.fatal("Failed to connect to %s trap multiplexer: %s", trap_config.source, error)
-            sys.exit(1)
+        loop.run_until_complete(trap_receiver.open())
 
     elif args.trap_port:
         trap_backend = import_trap_backend()

--- a/tests/config/models_test.py
+++ b/tests/config/models_test.py
@@ -1,7 +1,14 @@
 import pydantic
 import pytest
 
-from zino.config.models import AgentConfiguration, Configuration, PollDevice, ProcessConfiguration, SNMPConfiguration
+from zino.config.models import (
+    AgentConfiguration,
+    Configuration,
+    PollDevice,
+    ProcessConfiguration,
+    SNMPConfiguration,
+    TrapConfiguration,
+)
 
 
 class TestPollDevice:
@@ -42,6 +49,28 @@ class TestAgentConfiguration:
         assert isinstance(snmp_config.agent, AgentConfiguration)
         assert snmp_config.agent.enabled is True
         assert snmp_config.agent.port == 8000
+
+
+class TestTrapConfiguration:
+    def test_when_source_is_omitted_then_default_should_be_direct(self):
+        config = TrapConfiguration()
+        assert config.source == "direct"
+
+    def test_when_source_is_straps_then_config_should_accept_it(self):
+        config = TrapConfiguration(source="straps")
+        assert config.source == "straps"
+
+    def test_when_source_is_nmtrapd_then_config_should_accept_it(self):
+        config = TrapConfiguration(source="nmtrapd")
+        assert config.source == "nmtrapd"
+
+    def test_when_straps_socket_is_set_then_config_should_store_it(self):
+        config = TrapConfiguration(source="straps", straps_socket="/var/run/straps.sock")
+        assert config.straps_socket == "/var/run/straps.sock"
+
+    def test_when_source_is_invalid_then_it_should_raise_validation_error(self):
+        with pytest.raises(pydantic.ValidationError):
+            TrapConfiguration(source="bogus")
 
 
 class TestProcessConfiguration:

--- a/tests/trapd/test_straps_backend.py
+++ b/tests/trapd/test_straps_backend.py
@@ -1,0 +1,411 @@
+"""Tests for the straps/nmtrapd trap multiplexer backend."""
+
+import asyncio
+import ipaddress
+import struct
+import time
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import pytest_asyncio
+
+from zino.config.models import TrapConfiguration
+from zino.state import ZinoState
+from zino.trapd.straps_backend import (
+    NmtrapdFrameReader,
+    StrapsFrameReader,
+    StrapsTrapReceiver,
+)
+
+# The same BER-encoded SNMPv2c coldStart trap used in netsnmp-cffi tests
+SNMPV2C_COLDSTART_TRAP = bytes.fromhex(
+    "305402010104067075626c6963a74702034ff374020100020100303a300e06082b060102010103004302"
+    "30393017060a2b06010603010104010006092b0601060301010501300f060a2b060102010202010101"
+    "02012a"
+)
+
+
+class TestStrapsFrameReader:
+    async def test_when_reading_valid_frame_then_it_should_extract_source_address(self):
+        frame = make_straps_frame("10.0.0.1", 162, SNMPV2C_COLDSTART_TRAP)
+        reader = asyncio.StreamReader()
+        reader.feed_data(frame)
+        addr, port, pdu = await StrapsFrameReader().read_frame(reader)
+        assert addr == ipaddress.IPv4Address("10.0.0.1")
+
+    async def test_when_reading_valid_frame_then_it_should_extract_source_port(self):
+        frame = make_straps_frame("10.0.0.1", 4242, SNMPV2C_COLDSTART_TRAP)
+        reader = asyncio.StreamReader()
+        reader.feed_data(frame)
+        addr, port, pdu = await StrapsFrameReader().read_frame(reader)
+        assert port == 4242
+
+    async def test_when_reading_valid_frame_then_it_should_extract_raw_pdu(self):
+        frame = make_straps_frame("10.0.0.1", 162, SNMPV2C_COLDSTART_TRAP)
+        reader = asyncio.StreamReader()
+        reader.feed_data(frame)
+        addr, port, pdu = await StrapsFrameReader().read_frame(reader)
+        assert pdu == SNMPV2C_COLDSTART_TRAP
+
+    async def test_when_connection_closes_mid_frame_then_it_should_raise_incomplete_read(self):
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"\x00\x01\x02")
+        reader.feed_eof()
+        with pytest.raises(asyncio.IncompleteReadError):
+            await StrapsFrameReader().read_frame(reader)
+
+
+class TestNmtrapdFrameReader:
+    async def test_when_reading_valid_frame_then_it_should_extract_source_address(self):
+        frame = make_nmtrapd_frame("10.0.0.1", 162, SNMPV2C_COLDSTART_TRAP)
+        reader = asyncio.StreamReader()
+        reader.feed_data(frame)
+        addr, port, pdu = await NmtrapdFrameReader().read_frame(reader)
+        assert addr == ipaddress.IPv4Address("10.0.0.1")
+
+    async def test_when_reading_valid_frame_then_it_should_extract_source_port(self):
+        frame = make_nmtrapd_frame("10.0.0.1", 4242, SNMPV2C_COLDSTART_TRAP)
+        reader = asyncio.StreamReader()
+        reader.feed_data(frame)
+        addr, port, pdu = await NmtrapdFrameReader().read_frame(reader)
+        assert port == 4242
+
+    async def test_when_reading_valid_frame_then_it_should_extract_raw_pdu(self):
+        frame = make_nmtrapd_frame("10.0.0.1", 162, SNMPV2C_COLDSTART_TRAP)
+        reader = asyncio.StreamReader()
+        reader.feed_data(frame)
+        addr, port, pdu = await NmtrapdFrameReader().read_frame(reader)
+        assert pdu == SNMPV2C_COLDSTART_TRAP
+
+    async def test_when_connection_closes_mid_frame_then_it_should_raise_incomplete_read(self):
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"\x00\x01\x02")
+        reader.feed_eof()
+        with pytest.raises(asyncio.IncompleteReadError):
+            await NmtrapdFrameReader().read_frame(reader)
+
+
+class TestStrapsTrapReceiver:
+    @pytest.mark.timeout(5)
+    async def test_when_connected_to_straps_socket_then_it_should_process_incoming_trap(
+        self, straps_unix_server, straps_receiver_with_localhost
+    ):
+        receiver = straps_receiver_with_localhost
+        await receiver._connect()
+        receiver._reader_task = asyncio.ensure_future(receiver._read_loop())
+        await asyncio.sleep(0.1)
+        assert receiver._last_trap_time > 0
+        receiver.close()
+        await _gather_cancelled(receiver)
+
+    @pytest.mark.timeout(5)
+    async def test_when_connected_to_straps_socket_then_it_should_dispatch_trap_from_known_device(
+        self, straps_unix_server, straps_receiver_with_localhost
+    ):
+        receiver = straps_receiver_with_localhost
+        dispatched = []
+        original_dispatch = receiver.dispatch_trap
+
+        async def capture_dispatch(trap):
+            dispatched.append(trap)
+            await original_dispatch(trap)
+
+        receiver.dispatch_trap = capture_dispatch
+        await receiver._connect()
+        receiver._reader_task = asyncio.ensure_future(receiver._read_loop())
+        await asyncio.sleep(0.1)
+        assert len(dispatched) == 1
+        assert dispatched[0].agent.address == ipaddress.IPv4Address("127.0.0.1")
+        receiver.close()
+        await _gather_cancelled(receiver)
+
+    async def test_when_closing_and_multiplexer_disconnects_then_read_loop_should_exit(self, nonexistent_path):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+
+        reader = asyncio.StreamReader()
+        reader.feed_eof()
+        receiver._reader = reader
+        receiver._closing = True
+        await receiver._read_loop()
+
+    async def test_when_multiplexer_disconnects_then_reconnect_with_backoff_should_be_called(self, nonexistent_path):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+
+        reader = asyncio.StreamReader()
+        reader.feed_eof()
+        receiver._reader = reader
+
+        mock_reconnect = AsyncMock(side_effect=lambda: setattr(receiver, "_closing", True))
+        with patch.object(receiver, "_reconnect_with_backoff", mock_reconnect):
+            await receiver._read_loop()
+        mock_reconnect.assert_called_once()
+
+    async def test_when_straps_is_unavailable_at_startup_then_open_should_not_raise(self, nonexistent_path):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+
+        mock_reconnect = AsyncMock(side_effect=lambda: setattr(receiver, "_closing", True))
+        with patch.object(receiver, "_reconnect_with_backoff", mock_reconnect):
+            await receiver.open()
+            await asyncio.sleep(0.1)
+            receiver.close()
+            await _gather_cancelled(receiver)
+
+        mock_reconnect.assert_called_once()
+
+    async def test_when_read_loop_hits_generic_exception_then_it_should_attempt_reconnect(self, nonexistent_path):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+        receiver._reader = asyncio.StreamReader()
+
+        receiver._frame_reader.read_frame = AsyncMock(side_effect=RuntimeError("something broke"))
+
+        mock_reconnect = AsyncMock(side_effect=lambda: setattr(receiver, "_closing", True))
+        with patch.object(receiver, "_reconnect_with_backoff", mock_reconnect):
+            await receiver._read_loop()
+        mock_reconnect.assert_called_once()
+
+    async def test_when_raw_pdu_is_malformed_then_process_raw_trap_should_log_warning(self, nonexistent_path, caplog):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+        receiver._process_raw_trap(b"\x00\x01\x02", ipaddress.IPv4Address("10.0.0.1"))
+        assert "Failed to parse raw SNMP PDU" in caplog.text
+
+    @pytest.mark.timeout(5)
+    async def test_when_open_is_called_then_it_should_start_reader_and_watchdog(
+        self, straps_unix_server, straps_receiver_with_localhost
+    ):
+        receiver = straps_receiver_with_localhost
+        with (
+            patch("zino.trapd.straps_backend.WATCHDOG_CHECK_INTERVAL", 0.1),
+            patch("zino.trapd.straps_backend.WATCHDOG_SILENCE_THRESHOLD", 600),
+        ):
+            await receiver.open()
+            await asyncio.sleep(0.1)
+            assert receiver._reader_task is not None
+            assert receiver._watchdog_task is not None
+            assert not receiver._reader_task.done()
+            assert not receiver._watchdog_task.done()
+            receiver.close()
+            await _gather_cancelled(receiver)
+
+    async def test_when_close_is_called_then_it_should_set_closing_and_cancel_tasks(self, nonexistent_path):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+        receiver._reader_task = asyncio.ensure_future(asyncio.sleep(60))
+        receiver._watchdog_task = asyncio.ensure_future(asyncio.sleep(60))
+        receiver.close()
+        await asyncio.sleep(0)  # Let cancellations propagate
+        assert receiver._closing is True
+        assert receiver._reader_task.cancelled()
+        assert receiver._watchdog_task.cancelled()
+
+    async def test_when_straps_source_is_configured_then_it_should_use_straps_frame_reader(self):
+        config = TrapConfiguration(source="straps")
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+        assert isinstance(receiver._frame_reader, StrapsFrameReader)
+
+    async def test_when_nmtrapd_source_is_configured_then_it_should_use_nmtrapd_frame_reader(self):
+        config = TrapConfiguration(source="nmtrapd")
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+        assert isinstance(receiver._frame_reader, NmtrapdFrameReader)
+
+    @pytest.mark.timeout(5)
+    async def test_when_reconnect_fails_then_it_should_retry_multiple_times(self, nonexistent_path):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+
+        attempts = []
+
+        async def failing_connect():
+            attempts.append(time.monotonic())
+            raise OSError("connection refused")
+
+        with (
+            patch.object(receiver, "_connect", failing_connect),
+            patch("zino.trapd.straps_backend.RECONNECT_BASE_DELAY", 0.1),
+            patch("zino.trapd.straps_backend.RECONNECT_MAX_DELAY", 1),
+        ):
+            task = asyncio.ensure_future(receiver._reconnect_with_backoff())
+            await asyncio.sleep(1)
+            receiver._closing = True
+            await task
+
+        assert len(attempts) >= 3, f"Expected at least 3 reconnect attempts, got {len(attempts)}"
+
+    @pytest.mark.timeout(5)
+    async def test_when_watchdog_detects_silence_then_it_should_reconnect(self, nonexistent_path):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+        receiver._last_trap_time = time.monotonic() - 600
+        receiver._reader_task = asyncio.ensure_future(asyncio.sleep(60))
+
+        connect_called = asyncio.Event()
+
+        async def mock_connect():
+            connect_called.set()
+            receiver._closing = True
+
+        with (
+            patch("zino.trapd.straps_backend.WATCHDOG_CHECK_INTERVAL", 0.1),
+            patch("zino.trapd.straps_backend.WATCHDOG_SILENCE_THRESHOLD", 1),
+            patch.object(receiver, "_connect", mock_connect),
+        ):
+            receiver._watchdog_task = asyncio.ensure_future(receiver._watchdog_loop())
+            await asyncio.sleep(0.5)
+            receiver.close()
+            await _gather_cancelled(receiver)
+
+        assert connect_called.is_set()
+
+    @pytest.mark.timeout(5)
+    async def test_when_traps_are_flowing_then_watchdog_should_not_trigger_reconnect(self, nonexistent_path):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+        receiver._last_trap_time = time.monotonic()  # Just now — traps are flowing
+        receiver._reader_task = asyncio.ensure_future(asyncio.sleep(60))
+
+        connect_called = False
+
+        async def mock_connect():
+            nonlocal connect_called
+            connect_called = True
+
+        with (
+            patch("zino.trapd.straps_backend.WATCHDOG_CHECK_INTERVAL", 0.1),
+            patch("zino.trapd.straps_backend.WATCHDOG_SILENCE_THRESHOLD", 600),
+            patch.object(receiver, "_connect", mock_connect),
+        ):
+            receiver._watchdog_task = asyncio.ensure_future(receiver._watchdog_loop())
+            await asyncio.sleep(0.5)
+            receiver.close()
+            await _gather_cancelled(receiver)
+
+        assert not connect_called
+
+    @pytest.mark.timeout(5)
+    async def test_when_multiplexer_is_available_then_reconnect_should_establish_connection(
+        self, straps_unix_server, straps_receiver_with_localhost
+    ):
+        receiver = straps_receiver_with_localhost
+        await receiver._reconnect_with_backoff()
+        # Assert that internal state appears connected
+        assert receiver._reader is not None
+        receiver._close_connection()
+
+    @pytest.mark.timeout(5)
+    async def test_when_watchdog_reconnect_fails_then_it_should_log_error(self, nonexistent_path, caplog):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+        receiver._last_trap_time = time.monotonic() - 600
+        receiver._reader_task = asyncio.ensure_future(asyncio.sleep(60))
+
+        async def failing_connect():
+            raise OSError("socket not found")
+
+        with (
+            patch("zino.trapd.straps_backend.WATCHDOG_CHECK_INTERVAL", 0.1),
+            patch("zino.trapd.straps_backend.WATCHDOG_SILENCE_THRESHOLD", 1),
+            patch.object(receiver, "_connect", failing_connect),
+        ):
+            receiver._watchdog_task = asyncio.ensure_future(receiver._watchdog_loop())
+            await asyncio.sleep(0.5)
+            receiver.close()
+            await _gather_cancelled(receiver)
+
+        assert "failed to reconnect" in caplog.text
+
+    @pytest.mark.timeout(5)
+    async def test_when_nmtrapd_connect_is_called_then_it_should_open_tcp_connection(self):
+        config = TrapConfiguration(source="nmtrapd", nmtrapd_host="trap.example.com", nmtrapd_port=1702)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+
+        with patch("zino.trapd.straps_backend.asyncio.open_connection", new_callable=AsyncMock) as mock_open:
+            mock_open.return_value = (asyncio.StreamReader(), Mock())
+            await receiver._connect()
+            mock_open.assert_called_once_with("trap.example.com", 1702)
+        receiver._close_connection()
+
+    async def test_when_close_connection_is_called_then_writer_should_be_closed(self, nonexistent_path):
+        config = TrapConfiguration(source="straps", straps_socket=nonexistent_path)
+        receiver = StrapsTrapReceiver(trap_config=config, state=ZinoState())
+        mock_writer = Mock()
+        receiver._writer = mock_writer
+        receiver._reader = asyncio.StreamReader()
+        receiver._close_connection()
+        mock_writer.close.assert_called_once()
+        assert receiver._writer is None
+        assert receiver._reader is None
+
+
+async def _gather_cancelled(receiver: StrapsTrapReceiver):
+    """Awaits the receiver's background tasks so cancellations complete."""
+    tasks = [t for t in (receiver._reader_task, receiver._watchdog_task) if t and not t.done()]
+    if tasks:
+        await asyncio.wait(tasks, timeout=1)
+
+
+def make_straps_frame(addr: str, port: int, pdu: bytes) -> bytes:
+    """Builds a straps-formatted frame: addr(4,network) + port(2,network) + length(4,host)."""
+    addr_bytes = ipaddress.IPv4Address(addr).packed
+    return struct.pack("!4sH", addr_bytes, port) + struct.pack("=I", len(pdu)) + pdu
+
+
+def make_nmtrapd_frame(addr: str, port: int, pdu: bytes) -> bytes:
+    """Builds an nmtrapd-formatted frame: version(1) + unused(1) + port(2) + addr(4) + length(4), all network order."""
+    addr_int = int(ipaddress.IPv4Address(addr))
+    return struct.pack("!BBHII", 0, 0, port, addr_int, len(pdu)) + pdu
+
+
+@pytest.fixture
+def nonexistent_path(tmp_path):
+    """Returns a path guaranteed not to exist on the filesystem.
+
+    Unlike ``straps_socket_path``, this path is never used for an actual UNIX socket bind/connect,
+    so the AF_UNIX 108-byte path length limit does not apply here.
+    """
+    path = tmp_path / "nonexistent"
+    assert not path.exists()
+    return str(path)
+
+
+@pytest.fixture
+def straps_socket_path(tmp_path_factory):
+    """Returns a path for a test straps UNIX socket.
+
+    Uses ``tmp_path_factory`` with a short name because AF_UNIX socket paths are limited to 108
+    bytes on Linux, and pytest's default ``tmp_path`` combined with long test names can exceed
+    this limit.
+    """
+    return str(tmp_path_factory.mktemp("straps") / "s.sock")
+
+
+@pytest_asyncio.fixture
+async def straps_unix_server(straps_socket_path):
+    """Starts a mock straps UNIX socket server that sends a single framed trap."""
+    frame = make_straps_frame("127.0.0.1", 162, SNMPV2C_COLDSTART_TRAP)
+    stop = asyncio.Event()
+
+    async def handle_client(reader, writer):
+        writer.write(frame)
+        await writer.drain()
+        await stop.wait()
+        writer.close()
+
+    server = await asyncio.start_unix_server(handle_client, path=straps_socket_path)
+    yield server
+    stop.set()
+    await asyncio.sleep(0)
+    server.close()
+    await server.wait_closed()
+
+
+@pytest_asyncio.fixture
+async def straps_receiver_with_localhost(straps_socket_path, state_with_localhost):
+    config = TrapConfiguration(source="straps", straps_socket=straps_socket_path)
+    receiver = StrapsTrapReceiver(trap_config=config, state=state_with_localhost)
+    receiver.add_community("public")
+    receiver.auto_subscribe_observers()
+    return receiver

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -10,7 +10,7 @@ import subprocess
 import time
 from argparse import Namespace
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pexpect
 import pytest
@@ -173,6 +173,44 @@ async def test_when_running_as_root_without_user_config_should_log_warning(mock_
             pass
 
     assert "Zino is running with root privileges" in caplog.text
+
+
+@patch("zino.zino.os.geteuid", return_value=1000)
+async def test_when_trap_source_is_straps_then_init_event_loop_should_create_straps_receiver(mock_geteuid, event_loop):
+    mock_receiver = Mock()
+    mock_receiver.open = AsyncMock()
+    trap_config = Mock(source="straps", require_community=["public"])
+
+    with (
+        patch.object(state, "config", Mock(snmp=Mock(trap=trap_config), process=Mock(user=None))),
+        patch("zino.trapd.straps_backend.StrapsTrapReceiver", return_value=mock_receiver) as mock_cls,
+    ):
+        try:
+            zino.init_event_loop(args=Mock(trap_port=0, user=None, stop_in=None), loop=event_loop)
+        except Exception:
+            pass
+
+    mock_cls.assert_called_once()
+    mock_receiver.add_community.assert_called_once_with("public")
+    mock_receiver.auto_subscribe_observers.assert_called_once()
+
+
+@patch("zino.zino.os.geteuid", return_value=1000)
+async def test_when_straps_is_unavailable_then_init_event_loop_should_not_exit(mock_geteuid, event_loop):
+    mock_receiver = Mock()
+    mock_receiver.open = AsyncMock()
+    trap_config = Mock(source="straps", require_community=[])
+
+    with (
+        patch.object(state, "config", Mock(snmp=Mock(trap=trap_config), process=Mock(user=None))),
+        patch("zino.trapd.straps_backend.StrapsTrapReceiver", return_value=mock_receiver),
+    ):
+        try:
+            zino.init_event_loop(args=Mock(trap_port=0, user=None, stop_in=None), loop=event_loop)
+        except Exception:
+            pass
+
+    mock_receiver.open.assert_called_once()
 
 
 class TestZinoRescheduleDumpStateOnCommit:

--- a/zino.toml.example
+++ b/zino.toml.example
@@ -37,17 +37,32 @@ period = 1
 # library to be installed on your system).  "pysnmp" selects the pure Python library PySNMP, which is less performant.
 backend = "netsnmp"
 
+[snmp.trap]
 # Only accept SNMP trap messages with any community string in this list. The default value is [].
 # The netsnmp backend will accept an empty list to mean: Admit any trap message, regardless of community.  The pysnmp
 # backend will not function properly unless there is at least one community string in the list.
-trap.require_community = []
+require_community = []
 
+# Trap source mode.  "direct" (default) means Zino binds its own UDP port for trap reception.
+# "straps" connects to a straps UNIX domain socket, and "nmtrapd" connects to an nmtrapd TCP socket.
+# Using a trap multiplexer allows Zino to receive traps without starting as root.
+# source = "direct"
+
+# Path to the straps UNIX socket (only used when source = "straps").
+# Default: "/tmp/.straps-162"
+# straps_socket = "/tmp/.straps-162"
+
+# Host and port for nmtrapd TCP connection (only used when source = "nmtrapd").
+# nmtrapd_host = "localhost"
+# nmtrapd_port = 1702
+
+[snmp.agent]
 # SNMP agent configuration for responding to uptime queries from clients
 # This agent is used by clients like EMT for failover detection
-agent.enabled = true  # Enable/disable the SNMP agent (default: true)
-agent.port = 8000  # Port to listen on (default: 8000)
-agent.address = "0.0.0.0"  # Address to bind to (default: "0.0.0.0")
-# agent.community = "public"  # SNMP community string to accept (default: public)
+enabled = true  # Enable/disable the SNMP agent (default: true)
+port = 8000  # Port to listen on (default: 8000)
+address = "0.0.0.0"  # Address to bind to (default: "0.0.0.0")
+# community = "public"  # SNMP community string to accept (default: public)
 
 [scheduler]
 # When Zino is very busy, some scheduled recurring jobs may be delayed from running on their exactly scheduled


### PR DESCRIPTION
## Scope and purpose

Fixes #362.

Adds optional support for receiving SNMP traps through an external trap multiplexer (straps or nmtrapd) instead of binding directly to a UDP port.  This allows Zino to receive traps without root privileges, matching the mode of operation used by Zino 1 in production.

### This pull request
* Extracts shared trap processing logic into `NetsnmpTrapProcessorMixin`
* Adds `[snmp.trap]` configuration fields: `source`, `straps_socket`, `nmtrapd_host`, `nmtrapd_port`
* Adds `StrapsTrapReceiver` backend with automatic reconnection and watchdog
* Wires up the new backend in `init_event_loop()`

This depends on Uninett/netsnmp-cffi#21 (`parse_raw_trap()`), which has was just released in version 0.2.0 on PyPI.  The `netsnmp-cffi` dependency is therefore updated to require at least the new version.

## Contributor Checklist

* [x] Added a changelog fragment for towncrier
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
* [x] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~