### PR TITLE
Add `bare-except` rule to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I"]
+select = ["BLE001", "E4", "E7", "E9", "F", "I"]
 fixable = ["I"]
 
 [tool.coverage.report]

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -179,7 +179,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
         """Runs a command responder function asynchronously, ensuring that unhandled exceptions are dealt with"""
         try:
             await asyncio.ensure_future(responder(*args))
-        except Exception as error:  # noqa
+        except Exception as error:  # noqa: BLE001
             _logger.exception("unhandled exception raised during processing of %s command: %r", command, error)
             self._respond(500, "internal error")
         finally:

--- a/src/zino/flaps.py
+++ b/src/zino/flaps.py
@@ -270,5 +270,5 @@ async def stabilize_flapping_state(
     poll = LinkStateTask(device=polldev, state=state, config=config)
     try:
         await poll.poll_single_interface(ifindex)
-    except Exception:  # noqa
+    except Exception:  # noqa: BLE001
         port.state = old_state

--- a/src/zino/job_tracker.py
+++ b/src/zino/job_tracker.py
@@ -43,7 +43,7 @@ class JobTracker:
             job = self.scheduler.get_job(job_id)
             if job:
                 return job.name
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             _log.debug(f"Could not fetch job details for {job_id}: {e}")
 
         return None

--- a/src/zino/snmp/agent.py
+++ b/src/zino/snmp/agent.py
@@ -145,7 +145,7 @@ class ZinoSnmpAgent:
             self._setup_engine()
             self._running = True
             _log.info("SNMP agent started on %s:%d", self.listen_address, self.listen_port)
-        except Exception as error:
+        except Exception as error:  # noqa: BLE001
             _log.error("Failed to start SNMP agent: %s", error)
             self._running = False
             raise

--- a/src/zino/trapd/base.py
+++ b/src/zino/trapd/base.py
@@ -159,7 +159,7 @@ class TrapReceiverBase:
             try:
                 if not await observer.handle_trap(trap):
                     return
-            except Exception:  # noqa
+            except Exception:  # noqa: BLE001
                 _logger.exception("Unhandled exception in trap observer %r", observer)
 
     def _lookup_device(self, address: IPAddress) -> Optional[DeviceState]:

--- a/src/zino/trapd/pysnmp_backend.py
+++ b/src/zino/trapd/pysnmp_backend.py
@@ -95,7 +95,7 @@ class TrapReceiver(TrapReceiverBase):
             _logger.debug("(%r, %r, %s) = %s", mib, label, instance, raw_value.prettyPrint())
             try:
                 value = mib_value_to_python(raw_value)
-            except Exception:  # noqa
+            except Exception:  # noqa: BLE001
                 value = None
             trap.variables.append(TrapVarBind(OID(var), mib, label, instance, raw_value, value))
             if label == "snmpTrapOID":

--- a/src/zino/trapd/straps_backend.py
+++ b/src/zino/trapd/straps_backend.py
@@ -159,7 +159,7 @@ class StrapsTrapReceiver(NetsnmpTrapProcessorMixin, TrapReceiverBase):
                     return
                 _logger.warning("Connection to %s multiplexer lost (EOF)", self._trap_config.source)
                 await self._reconnect_with_backoff()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 if self._closing:
                     return
                 _logger.exception("Error reading from %s multiplexer", self._trap_config.source)
@@ -256,7 +256,7 @@ class StrapsTrapReceiver(NetsnmpTrapProcessorMixin, TrapReceiverBase):
         if self._writer:
             try:
                 self._writer.close()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
             self._writer = None
         self._reader = None

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -172,7 +172,7 @@ def init_event_loop(args: argparse.Namespace, loop: Optional[AbstractEventLoop] 
     _wait_for_dump_child()
     try:
         state.state.dump_state_to_file(state.config.persistence.file)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _log.exception("Final state dump failed")
 
     return True
@@ -196,7 +196,7 @@ async def fork_and_dump_state(filename: str):
         # Child process — serialize and exit
         try:
             state.state.dump_state_to_file(filename)
-        except Exception:
+        except Exception:  # noqa: BLE001
             _log.exception("State dump failed in child process")
             os._exit(1)
         os._exit(0)

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -157,7 +157,7 @@ async def test_when_args_specify_user_zino_init_event_loop_should_attempt_to_swi
             zino.init_event_loop(args=Mock(trap_port=0, user="nobody"), loop=event_loop)
         except MockError:
             raise
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
 
@@ -169,7 +169,7 @@ async def test_when_running_as_root_without_user_config_should_log_warning(mock_
     with caplog.at_level(logging.WARNING):
         try:
             zino.init_event_loop(args=Mock(trap_port=0, user=None, stop_in=None), loop=event_loop)
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
     assert "Zino is running with root privileges" in caplog.text
@@ -187,7 +187,7 @@ async def test_when_trap_source_is_straps_then_init_event_loop_should_create_str
     ):
         try:
             zino.init_event_loop(args=Mock(trap_port=0, user=None, stop_in=None), loop=event_loop)
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
     mock_cls.assert_called_once()
@@ -207,7 +207,7 @@ async def test_when_straps_is_unavailable_then_init_event_loop_should_not_exit(m
     ):
         try:
             zino.init_event_loop(args=Mock(trap_port=0, user=None, stop_in=None), loop=event_loop)
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
     mock_receiver.open.assert_called_once()


### PR DESCRIPTION
## Scope and purpose

Inspired by Uninett/nav#3347. Decided to also add it to Zino after a talk with @lunkwill42. 

Ref: https://docs.astral.sh/ruff/rules/blind-except/

I added missing noqas, feel free to push changes if there are any added noqas that can be replaced by explicit exception catches.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
  workflow changes, not visible to users
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
