### PR TITLE
Improve clarity of `zino.toml` configuration error messages

### DIFF
--- a/changelog.d/539.changed.md
+++ b/changelog.d/539.changed.md
@@ -1,0 +1,1 @@
+Configuration errors in `zino.toml` now report the underlying parser message (with line and column) for syntax errors, and friendlier messages — including key suggestions — for validation errors.

--- a/src/zino/config/__init__.py
+++ b/src/zino/config/__init__.py
@@ -26,8 +26,8 @@ def read_configuration(config_file_name: str, poll_file_name: Optional[str] = No
     with open(config_file_name, mode="rb") as cf:
         try:
             config_dict = load(cf)
-        except TOMLDecodeError:
-            raise InvalidConfigurationError
+        except TOMLDecodeError as error:
+            raise InvalidConfigurationError(str(error)) from error
 
     # Polldevs by command line argument will override config file entry
     if poll_file_name:

--- a/src/zino/config/__init__.py
+++ b/src/zino/config/__init__.py
@@ -1,9 +1,13 @@
+import re
+from difflib import get_close_matches
 from typing import Optional
 
 try:
     from tomllib import TOMLDecodeError, load
 except ImportError:
     from tomli import TOMLDecodeError, load
+
+from pydantic import BaseModel, ValidationError
 
 from .models import Configuration
 
@@ -39,3 +43,98 @@ def read_configuration(config_file_name: str, poll_file_name: Optional[str] = No
     config = Configuration.model_validate(obj=config_dict, strict=True)
 
     return config
+
+
+_TYPE_NAMES = {
+    "int_type": "int",
+    "float_type": "float",
+    "bool_type": "bool",
+    "string_type": "str",
+}
+
+
+def format_validation_error(error: ValidationError, model: type[BaseModel] = Configuration) -> list[str]:
+    """Format a Pydantic ValidationError into operator-friendly messages.
+
+    :param error: The Pydantic ValidationError raised by config validation.
+    :param model: The root model the error was raised against. Used to look up
+        valid sibling field names when suggesting alternatives for misspelled
+        keys.
+    :return: One human-readable message per entry in ``error.errors()``.
+    """
+    return [_format_single_error(detail, model) for detail in error.errors()]
+
+
+def _format_single_error(detail: dict, model: type[BaseModel]) -> str:
+    loc = detail.get("loc", ())
+    dotted = _format_loc(loc)
+    err_type = detail.get("type", "")
+
+    if err_type == "extra_forbidden":
+        return _format_unknown_key(loc, dotted, model)
+    if err_type == "missing":
+        return f"Missing required configuration key '{dotted}'"
+    if err_type == "literal_error":
+        return _format_literal_error(detail, dotted)
+    if err_type in _TYPE_NAMES:
+        return _format_type_error(detail, err_type, dotted)
+    if err_type == "assertion_error":
+        cleaned = re.sub(r"^Assertion failed,\s*", "", detail.get("msg", ""))
+        return f"Invalid value for '{dotted}': {cleaned}"
+    return f"Invalid configuration at '{dotted}': {detail.get('msg', '')}"
+
+
+def _format_loc(loc: tuple) -> str:
+    """Render a Pydantic error location tuple as a dotted path with [i] for list indices."""
+    parts = []
+    for part in loc:
+        if isinstance(part, int):
+            parts.append(f"[{part}]")
+        elif parts:
+            parts.append(f".{part}")
+        else:
+            parts.append(str(part))
+    return "".join(parts)
+
+
+def _format_unknown_key(loc: tuple, dotted: str, model: type[BaseModel]) -> str:
+    base = f"Unknown configuration key '{dotted}'"
+    parent = _resolve_model(model, loc[:-1])
+    if parent is None:
+        return base
+    suggestions = get_close_matches(str(loc[-1]), list(parent.model_fields.keys()), n=1)
+    if suggestions:
+        return f"{base}. Did you mean '{suggestions[0]}'?"
+    return base
+
+
+def _format_literal_error(detail: dict, dotted: str) -> str:
+    expected = detail.get("ctx", {}).get("expected", "")
+    user_input = detail.get("input")
+    return f"Invalid value {user_input!r} for '{dotted}'; must be one of: {expected}"
+
+
+def _format_type_error(detail: dict, err_type: str, dotted: str) -> str:
+    wanted = _TYPE_NAMES[err_type]
+    user_input = detail.get("input")
+    return f"Configuration key '{dotted}' must be of type {wanted}, got {user_input!r}"
+
+
+def _resolve_model(model: type[BaseModel], path: tuple) -> Optional[type[BaseModel]]:
+    """Walk down ``path`` from ``model``, returning the BaseModel at the end.
+
+    Returns None if the path encounters a non-BaseModel field. Optional/Union
+    submodels are not traversed; suggestions will simply not appear for keys
+    inside them.
+    """
+    current = model
+    for part in path:
+        field = current.model_fields.get(str(part))
+        if field is None:
+            return None
+        annotation = field.annotation
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            current = annotation
+        else:
+            return None
+    return current

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -19,7 +19,7 @@ from pydantic import ValidationError
 
 from zino import flaps, state, version
 from zino.api.server import ZinoServer
-from zino.config import InvalidConfigurationError, read_configuration
+from zino.config import InvalidConfigurationError, format_validation_error, read_configuration
 from zino.job_tracker import get_job_tracker
 from zino.scheduler import get_scheduler, load_and_schedule_polldevs
 from zino.snmp import import_snmp_backend
@@ -93,8 +93,8 @@ def load_config(args: argparse.Namespace) -> Optional[state.Configuration]:
     except InvalidConfigurationError as error:
         _log.fatal("Configuration file %s is not valid TOML: %s", args.config_file or DEFAULT_CONFIG_FILE, error)
         sys.exit(1)
-    except ValidationError as e:
-        _log.fatal(e)
+    except ValidationError as error:
+        _log.fatal("%s", "\n".join(format_validation_error(error)))
         sys.exit(1)
 
 

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -90,8 +90,8 @@ def load_config(args: argparse.Namespace) -> Optional[state.Configuration]:
         if args.config_file:
             _log.fatal(f"No config file with the name {args.config_file} found.")
             sys.exit(1)
-    except InvalidConfigurationError:
-        _log.fatal(f"Configuration file with the name {args.config_file or DEFAULT_CONFIG_FILE} is invalid TOML.")
+    except InvalidConfigurationError as error:
+        _log.fatal("Configuration file %s is not valid TOML: %s", args.config_file or DEFAULT_CONFIG_FILE, error)
         sys.exit(1)
     except ValidationError as e:
         _log.fatal(e)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -23,6 +23,15 @@ class TestReadConfiguration:
         with pytest.raises(InvalidConfigurationError):
             read_configuration(invalid_zino_conf)
 
+    def test_when_toml_is_invalid_then_error_should_carry_underlying_message(self, invalid_zino_conf):
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            read_configuration(invalid_zino_conf)
+
+        # The underlying tomllib message names a line and column.
+        message = str(excinfo.value)
+        assert "line" in message
+        assert "column" in message
+
     def test_raises_error_on_invalid_config_values(self, invalid_values_zino_conf):
         with pytest.raises(ValidationError) as excinfo:
             read_configuration(invalid_values_zino_conf)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,7 +1,7 @@
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
-from zino.config import InvalidConfigurationError, read_configuration
+from zino.config import InvalidConfigurationError, _resolve_model, format_validation_error, read_configuration
 
 
 class TestReadConfiguration:
@@ -50,3 +50,109 @@ class TestReadConfiguration:
 
         assert "polling.file" in str(excinfo.value)
         assert "non-existent-pollfile.cf doesn't exist or isn't readable" in str(excinfo.value)
+
+
+class TestFormatValidationError:
+    def test_when_key_is_misspelled_then_message_should_suggest_correct_key(self, extra_keys_zino_conf):
+        with pytest.raises(ValidationError) as excinfo:
+            read_configuration(extra_keys_zino_conf)
+
+        messages = format_validation_error(excinfo.value)
+        joined = "\n".join(messages)
+        assert "Unknown configuration key" in joined
+        assert "archiving.typo" in joined
+
+    def test_when_section_is_misspelled_then_message_should_suggest_section(self, tmp_path):
+        path = tmp_path / "section-typo.toml"
+        path.write_text('[snmpp]\nbackend = "netsnmp"\n')
+        with pytest.raises(ValidationError) as excinfo:
+            read_configuration(path)
+
+        messages = format_validation_error(excinfo.value)
+        assert any("Unknown configuration key 'snmpp'" in m for m in messages)
+        assert any("Did you mean 'snmp'" in m for m in messages)
+
+    def test_when_literal_is_invalid_then_message_should_list_allowed_values(self, tmp_path):
+        path = tmp_path / "bad-literal.toml"
+        path.write_text('[snmp.trap]\nsource = "diirect"\n')
+        with pytest.raises(ValidationError) as excinfo:
+            read_configuration(path)
+
+        messages = format_validation_error(excinfo.value)
+        joined = "\n".join(messages)
+        assert "snmp.trap.source" in joined
+        assert "must be one of" in joined
+        assert "'direct'" in joined and "'straps'" in joined and "'nmtrapd'" in joined
+
+    def test_when_value_has_wrong_type_then_message_should_name_expected_type(self, tmp_path):
+        path = tmp_path / "bad-type.toml"
+        path.write_text('[persistence]\nperiod = "five"\n')
+        with pytest.raises(ValidationError) as excinfo:
+            read_configuration(path)
+
+        messages = format_validation_error(excinfo.value)
+        joined = "\n".join(messages)
+        assert "persistence.period" in joined
+        assert "must be of type int" in joined
+
+    def test_when_pollfile_is_missing_then_message_should_describe_the_missing_file(
+        self, zino_conf_with_non_existent_pollfile
+    ):
+        with pytest.raises(ValidationError) as excinfo:
+            read_configuration(zino_conf_with_non_existent_pollfile)
+
+        messages = format_validation_error(excinfo.value)
+        assert any(
+            m.startswith("Invalid value for 'polling.file':") and "doesn't exist or isn't readable" in m
+            for m in messages
+        )
+
+    def test_when_required_field_is_missing_then_message_should_say_so(self):
+        class Inner(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+
+            required_field: str
+
+        with pytest.raises(ValidationError) as excinfo:
+            Inner.model_validate({})
+
+        messages = format_validation_error(excinfo.value, model=Inner)
+        assert messages == ["Missing required configuration key 'required_field'"]
+
+    def test_when_loc_contains_a_list_index_then_message_should_render_brackets(self):
+        class Inner(BaseModel):
+            ports: list[int]
+
+        with pytest.raises(ValidationError) as excinfo:
+            Inner.model_validate({"ports": [10, "nope"]})
+
+        messages = format_validation_error(excinfo.value, model=Inner)
+        assert any("ports[1]" in m for m in messages)
+
+    def test_when_unknown_key_is_inside_a_list_field_then_message_should_omit_suggestion(self):
+        class Item(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+
+            name: str
+
+        class Root(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+
+            items: list[Item]
+
+        with pytest.raises(ValidationError) as excinfo:
+            Root.model_validate({"items": [{"name": "ok", "extra": 1}]})
+
+        messages = format_validation_error(excinfo.value, model=Root)
+        assert messages == ["Unknown configuration key 'items[0].extra'"]
+
+
+class TestResolveModel:
+    def test_when_path_names_an_unknown_field_then_resolve_model_should_return_none(self):
+        class Sub(BaseModel):
+            x: int
+
+        class Root(BaseModel):
+            sub: Sub
+
+        assert _resolve_model(Root, ("nonexistent",)) is None


### PR DESCRIPTION
## Scope and purpose

Make `zino.toml` configuration errors easier to read. Operators have reported that the error output for syntax or validation problems is diffuse and confusing — most notably the case of defining both a scalar `trap = ...` value inside `[snmp]` and a `[snmp.trap]` block, where the only feedback was *"is invalid TOML"* with no line, column, or reason.

Two changes, in two commits:

1. **Preserve the underlying TOML parser message.** When the file fails to parse, surface tomllib's own diagnostic (which includes line and column) instead of swallowing it. The reported "double trap" case now produces:

   ```
   Configuration file zino.toml is not valid TOML: Cannot overwrite a value (at line 5, column 11)
   ```

2. **Format Pydantic validation errors as readable messages.** Replace Pydantic's raw rendering with a small per-error formatter that emits operator-friendly lines:

   * `Unknown configuration key 'snmp.bakcend'. Did you mean 'backend'?` (suggestion via `difflib.get_close_matches` against the parent model's field names)
   * `Invalid value 'diirect' for 'snmp.trap.source'; must be one of: 'direct', 'straps' or 'nmtrapd'`
   * `Configuration key 'persistence.period' must be of type int, got 'five'`
   * `Configuration key 'snmp.trap.require_community[1]' must be of type str, got 42` (list indices render with brackets)
   * `Missing required configuration key 'X'`
   * file-existence assertions drop the `Assertion failed,` prefix

   The `[type=..., input_value=...]` debug suffix and the `errors.pydantic.dev` URL are no longer leaked to operators. All errors from a single `ValidationError` are emitted as one `CRITICAL` log entry rather than one entry per error.

### This pull request
* ~~adds/changes/removes a dependency~~
* ~~changes the API~~


## Contributor Checklist

* [x] Added a changelog fragment for towncrier (verified with `towncrier build --draft`)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff
* [x] The first line of the commit message continues the sentence "If applied, this commit will ..."
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely~~