### PR TITLE
Coalesce legacy API response writes per command

### DIFF
--- a/changelog.d/543.fixed.md
+++ b/changelog.d/543.fixed.md
@@ -1,0 +1,1 @@
+Fix slow case-fetching for existing clients (`curitz`, `zinolib`) over real networks. The legacy API server now coalesces each response into a single `transport.write()` instead of one per protocol line, eliminating a Nagle/delayed-ACK stall that added ~40 ms per command on non-loopback links.

--- a/src/zino/api/legacy.py
+++ b/src/zino/api/legacy.py
@@ -84,6 +84,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
         self._multiline_buffer: List[str] = []
         self._authentication_challenge: Optional[str] = None
         self._responders = self._get_all_responders()
+        self._output_buffer = bytearray()
 
         self._state = state if state is not None else ZinoState()
         self._config = config if config else zino.state.config
@@ -114,6 +115,8 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
             self.server.active_clients.add(self)
         self._authentication_challenge = auth.get_challenge()
         self._respond_ok(f"{self._authentication_challenge} Hello, there")
+        # No dispatcher wraps this, so flush the greeting explicitly.
+        self._flush_response()
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
         _logger.info("Client disconnected: %s", self.peer_name)
@@ -149,6 +152,17 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
         return self._dispatch_command(message)
 
     def _dispatch_command(self, message: str):
+        task = self._dispatch_to_responder(message)
+        if task is None:
+            # Sync error paths returned without scheduling a task; flush
+            # here. Async paths flush in `_run_async_responder`'s `finally`.
+            self._flush_response()
+        return task
+
+    def _dispatch_to_responder(self, message: str):
+        """Resolves the responder, validates args, and either schedules an async
+        task or sends a synchronous error. Returns the task or None.
+        """
         responder, args = self._get_responder(message)
         if not responder:
             return self._respond_error(f'unknown command: "{message}"')
@@ -183,6 +197,7 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
             _logger.exception("unhandled exception raised during processing of %s command: %r", command, error)
             self._respond(500, "internal error")
         finally:
+            self._flush_response()
             self._current_task = None
 
     def _get_responder(self, message: str) -> tuple[Optional[Responder], List[str]]:
@@ -239,8 +254,15 @@ class Zino1BaseServerProtocol(asyncio.Protocol):
         self._respond_raw(f"{code} {message}")
 
     def _respond_raw(self, message: str):
-        """Encodes and sends a response line to the connected client"""
-        self.transport.write(f"{message}\r\n".encode("utf-8"))
+        """Buffers a response line until the next `_flush_response` call."""
+        self._output_buffer.extend(f"{message}\r\n".encode("utf-8"))
+
+    def _flush_response(self):
+        """Writes any buffered response bytes to the transport."""
+        if not self._output_buffer:
+            return
+        self.transport.write(bytes(self._output_buffer))
+        self._output_buffer.clear()
 
 
 class Zino1ServerProtocol(Zino1BaseServerProtocol):
@@ -263,6 +285,7 @@ class Zino1ServerProtocol(Zino1BaseServerProtocol):
     async def do_quit(self):
         """Implements the QUIT command"""
         self._respond(205, "Bye")
+        self._flush_response()
         self.transport.close()
 
     async def do_help(self):

--- a/tests/api/legacy_test.py
+++ b/tests/api/legacy_test.py
@@ -262,6 +262,33 @@ class TestZino1BaseServerProtocol:
 
         assert protocol not in server.active_clients
 
+    async def test_when_command_response_has_many_lines_then_it_should_be_emitted_as_a_single_write(self):
+        """Each command's response must be coalesced into a single
+        ``transport.write`` call. This is what prevents the per-line TCP
+        segment pattern that interacts pathologically with Nagle plus
+        delayed-ACK on real network links.
+        """
+
+        class TestProtocol(Zino1BaseServerProtocol):
+            async def do_multi(self):
+                self._respond(300, "line one of many")
+                self._respond_raw("line two")
+                self._respond_raw("line three")
+                self._respond_raw(".")
+
+        protocol = TestProtocol()
+        fake_transport = Mock()
+        protocol.connection_made(fake_transport)
+        fake_transport.write.reset_mock()  # discard the greeting write
+
+        await protocol.message_received("MULTI")
+
+        assert fake_transport.write.call_count == 1, (
+            f"expected one coalesced write, got {fake_transport.write.call_count}"
+        )
+        payload = fake_transport.write.call_args[0][0]
+        assert payload == b"300 line one of many\r\nline two\r\nline three\r\n.\r\n"
+
 
 class TestZino1ServerProtocolTranslateCaseIdToEvent:
     async def test_when_caseid_exists_it_should_return_event_object(self):
@@ -823,7 +850,7 @@ class TestZino1TestProtocol:
         protocol = MockProtocol()
         protocol.connection_made(buffered_fake_transport)
 
-        await protocol.do_multitest()
+        await protocol.message_received("MULTITEST")
         assert b"302 " in buffered_fake_transport.data_buffer.getvalue()
         assert b"200 ok" in buffered_fake_transport.data_buffer.getvalue()
 


### PR DESCRIPTION
## Scope and purpose

Fixes #543.

Existing Zino clients (`curitz`, anything built on `zinolib`) were taking many seconds to fetch the list of open cases from Zino 2 over real networks. The legacy API server's per-line `transport.write()` pattern was emitting 10–15 tiny TCP segments per command response, which interacted badly with Nagle + TCP delayed-ACK to add ~40 ms of stall per command. With clients issuing `GETATTRS` / `GETHIST` / `GETLOG` sequentially per case, that compounded to seconds per full fetch (the production symptom: ~7 s to load 67 open cases in `curitz`).

This PR coalesces each command's response into a single `transport.write()` — emulating what the legacy Tcl server does via `fconfigure -buffering line -blocking false`. No protocol or wire-format change; existing clients are unmodified.

See #543 for the full diagnosis. The measurement harness referenced from the issue (a public gist) reproduces the before/after numbers locally without needing root or `tcpdump`.

### Implementation notes

`_respond_raw` now buffers each line into a per-protocol `bytearray`, and `_flush_response` writes the whole buffer in a single `transport.write` call. Flush is invoked at exactly four lifecycle points, each a distinct moment when a response is complete:

* after the greeting in `connection_made`
* in `_dispatch_command`, for synchronous paths that returned without scheduling a task (unknown command, unauthenticated, argument errors)
* in `_run_async_responder`'s `finally`, covering every async command
* before `transport.close()` in `do_quit`

The existing dispatch body has been extracted verbatim into a private `_dispatch_to_responder` helper so the wrapper can flush on the sync return path without indenting the dispatch logic.

### Headline numbers (scenario B from the gist — 100-event fixture, client through a zero-delay local TCP proxy)

|                          | Pre-fix | Post-fix |
|--------------------------|---------|----------|
| Total fetch              | 7.07 s  | ~0.05 s  |
| `GETATTRS` mean          | 41 ms   | < 1 ms   |
| Server→client TCP chunks | ~1220   | 304      |

### This pull request
* ~~adds/changes/removes a dependency~~
* ~~changes the API~~ — only the internal write pattern; the line-oriented Zino-1 wire protocol is byte-for-byte identical.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long.
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~