### PR TITLE
Always emit `port` attribute on portstate events

### DIFF
--- a/changelog.d/546.fixed.md
+++ b/changelog.d/546.fixed.md
@@ -1,0 +1,1 @@
+Fix legacy Zino-1 protocol clients (`ritz`, `curitz`, `zinolib`-based) crashing when a portstate event lacks a `port` attribute on the wire.  The API now always emits the attribute, falling back to an empty value when needed.

--- a/src/zino/statemodels.py
+++ b/src/zino/statemodels.py
@@ -2,6 +2,7 @@
 
 import datetime
 import fnmatch
+import functools
 import logging
 import pathlib
 import re
@@ -22,6 +23,7 @@ from typing import (
 )
 
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic_core import PydanticUndefined
 
 from zino.compat import StrEnum
 from zino.time import now
@@ -309,12 +311,36 @@ class Event(BaseModel):
 
         "Simple" attributes are typically "single line" public attributes, i.e. anything but `log` or `history`.
 
+        Fields whose value is None are omitted unless the field declares a non-None default, in which case the
+        default is emitted instead.  This honors the implicit contract that fields like `port: Optional[str] = ""`
+        are always present on the wire (clients expect them), while still letting genuinely optional fields be absent
+        when not applicable.
+
         It would be nice to be able to attach custom serializers to fields, but we need to support multiple
         serialization formats (one for JSON state dumps, one for the legacy Zino protocol), and it's not clear how
         Pydantic can support that.
         """
-        attrs = self.model_dump(mode="python", exclude={"log", "history"}, exclude_none=True, by_alias=True)
-        return {attr.replace("_", "-"): self.zinoify_value(value) for attr, value in attrs.items()}
+        excluded = {"log", "history"}
+        attrs = self.model_dump(mode="python", exclude=excluded, by_alias=True)
+        defaults = self._non_none_field_defaults_by_alias()
+        result = {}
+        for name, value in attrs.items():
+            if value is None:
+                value = defaults.get(name)
+                if value is None:
+                    continue
+            result[name.replace("_", "-")] = self.zinoify_value(value)
+        return result
+
+    @classmethod
+    @functools.cache
+    def _non_none_field_defaults_by_alias(cls) -> dict[str, Any]:
+        """Returns a mapping of (alias-or-name → declared default) for fields with a non-None default."""
+        return {
+            (info.alias or name): info.default
+            for name, info in cls.model_fields.items()
+            if info.default is not PydanticUndefined and info.default is not None
+        }
 
     @staticmethod
     def zinoify_value(value: Any) -> str:

--- a/tests/statemodels/statemodels_test.py
+++ b/tests/statemodels/statemodels_test.py
@@ -5,11 +5,13 @@ import os
 import pytest
 
 from zino.statemodels import (
+    BFDEvent,
     DeviceState,
     DeviceStates,
     Event,
     EventState,
     LogEntry,
+    PortStateEvent,
     ReachabilityEvent,
     regex_search,
 )
@@ -50,6 +52,32 @@ class TestEvent:
         attrs = fake_event.model_dump_simple_attrs()
 
         assert attrs["ac-down"] == "42"
+
+    def test_given_none_valued_field_with_non_none_default_when_dumping_then_default_should_be_emitted(self):
+        """Clients (ritz, curitz) expect certain attributes (e.g. `port` on portstate events) to always be
+        present.  A None value must therefore be replaced with the field's declared default rather than dropped
+        from the serialized output.
+        """
+        event = PortStateEvent(router="example-gw.example.org")
+        event.port = None
+
+        attrs = event.model_dump_simple_attrs()
+
+        assert "port" in attrs
+        assert attrs["port"] == ""
+
+    def test_optional_field_with_none_default_should_remain_omitted_from_output(self):
+        """Regression guard.  Fields whose declared default is None (e.g. `BFDEvent.bfdaddr`) are genuinely
+        optional on the wire and should remain absent when unset, rather than appearing as the literal string
+        ``"None"``.  Without this guard, future refactors of `model_dump_simple_attrs()` could silently start
+        emitting None-valued, None-default fields.
+        """
+        event = BFDEvent(router="example-gw.example.org")
+
+        attrs = event.model_dump_simple_attrs()
+
+        assert "bfdAddr" not in attrs
+        assert "bfdaddr" not in attrs
 
     def test_zinoify_value_when_value_is_enum_it_should_return_its_real_value(self):
         assert Event.zinoify_value(EventState.OPEN) == "open"


### PR DESCRIPTION
## Scope and purpose

Fixes #546.

Single-point fix to [`Event.model_dump_simple_attrs()`](https://github.com/Uninett/zino/blob/3d19876/src/zino/statemodels.py#L307) (the serializer the legacy Zino-1 protocol API uses to dump event attributes) so that fields with a non-`None` declared default (e.g. `port: Optional[str] = ""`) fall back to that default on the wire instead of being silently dropped when their in-memory value happens to be `None`.  Restores the implicit contract that legacy clients (`ritz`, `curitz`, anything `zinolib`-based) rely on.

The complementary question — *why* `event.port` can become `None` in the first place (most likely a link trap arriving for an ifIndex Zino 2 hasn't polled yet) — is tracked as a separate feature request in #547.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~ — bug fix with no observable change beyond what the changelog fragment describes
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long.  See https://cbea.ms/git-commit/
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done — follow-up filed as #547
