### PR TITLE
Skip single-interface poll when port has vanished

### DIFF
--- a/changelog.d/263.fixed.md
+++ b/changelog.d/263.fixed.md
@@ -1,0 +1,1 @@
+Single-interface link state verification no longer crashes with an `AssertionError` when the target interface has disappeared from the `IF-MIB` (e.g. removed between a link trap firing and its reverification); the poll is now skipped gracefully.

--- a/src/zino/tasks/linkstatetask.py
+++ b/src/zino/tasks/linkstatetask.py
@@ -76,8 +76,12 @@ class LinkStateTask(Task):
         self.device_state.set_boot_time_from_uptime(self.sysuptime)
         _logger.debug("poll_single_interface %s result: %r", self.device.name, result)
 
-        assert all(ident.index == OID(f".{ifindex}") for ident, value in result)
-        row = {ident.object: value for ident, value in result}
+        # The GET-NEXT starts from ifindex-1, so keep only columns that match the requested index; if the interface
+        # no longer exists, none will match and we bail gracefully (cf. Zino 1's `filterLowestMatching`).
+        row = {ident.object: value for ident, value in result if ident.index == OID(f".{ifindex}")}
+        if not row:
+            _logger.info("%s: no match polling single interface %s", self.device.name, ifindex)
+            return
 
         self._update_single_interface(row)
 

--- a/tests/tasks/test_linkstatetask.py
+++ b/tests/tasks/test_linkstatetask.py
@@ -234,6 +234,19 @@ class TestBaseInterfaceRow:
             mock_getnext2.side_effect = TimeoutError
             assert await linkstatetask_with_one_link_down.poll_single_interface(42) is None
 
+    async def test_when_interface_no_longer_exists_poll_single_interface_should_not_crash(
+        self, linkstatetask_with_one_link_down
+    ):
+        """Regression test.  When the target interface is absent from the IF-MIB, the GET-NEXT started from ifindex-1
+        returns a higher (or different-column) instance.  poll_single_interface should detect the mismatch and return
+        gracefully instead of raising, mirroring Zino 1's behaviour.
+        """
+        nonexistent_index = 5  # the linksdown fixture only has interfaces 1 and 2
+        assert await linkstatetask_with_one_link_down.poll_single_interface(nonexistent_index) is None
+
+        device_state = linkstatetask_with_one_link_down.state.devices.get(linkstatetask_with_one_link_down.device.name)
+        assert nonexistent_index not in device_state.ports
+
 
 @pytest.fixture
 def linkstatetask_with_links_up(snmpsim, snmp_test_port):


### PR DESCRIPTION
## Scope and purpose

Fixes #263.

When an interface disappears from a device's `IF-MIB` between a link trap and the single-interface poll that verifies it, Zino 2 is unnecessarily loud and unspecific about it: the poll dies with a bare `AssertionError` and an alarming traceback at `ERROR` level. Zino 1 simply logs that the interface disappeared and carries on. This PR makes Zino 2 behave the same way.

`poll_single_interface` reads a single interface row by issuing a `GET-NEXT` starting from `ifindex - 1`, then asserted that every returned varbind belonged to the requested `ifindex`. When the target interface is gone, `GET-NEXT` skips past it and returns a higher index instead, so the assertion trips. The fix mirrors Zino 1's `pollSingleIf`/`filterLowestMatching`: keep only the columns matching the requested index, and return gracefully with a log message when none match.

The crash was never destructive — it happens before any state is written and after the SNMP session is closed — and the abandoned reverification self-heals on the next periodic poll. The visible effect is purely the noise.

### This pull request

* changes how `poll_single_interface` handles a `GET-NEXT` response that doesn't include the requested interface index: it keeps only the matching columns and returns gracefully instead of asserting.

## Contributor Checklist

* [x] Added a changelog fragment for towncrier
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff
* [x] The first line of the commit message continues the sentence "If applied, this commit will ..."
* [ ] ~~If applicable: Created new issues~~