### PR TITLE
Bind trap port via CAP_NET_BIND_SERVICE in systemd unit

### DIFF
--- a/changelog.d/+systemd-net-bind-capability.fixed.md
+++ b/changelog.d/+systemd-net-bind-capability.fixed.md
@@ -1,0 +1,1 @@
+Reworked the systemd howto to bind the privileged SNMP trap port via the `CAP_NET_BIND_SERVICE` capability, so Zino runs as an unprivileged user instead of starting as root

--- a/docs/howtos/controlling-zino-with-systemd.rst
+++ b/docs/howtos/controlling-zino-with-systemd.rst
@@ -30,8 +30,18 @@ To start Zino in the background now, run:
 
     sudo systemctl start zino
 
-This will start ``zino`` as root; ``zino`` will drop its root privileges by
-itself as soon as port 162 is open for listening.
+This starts Zino directly as the unprivileged ``zino`` user.  Zino still needs
+to bind the SNMP trap port (UDP 162), and ports below 1024 normally require
+root.  Rather than starting as root, the unit grants Zino the single Linux
+capability that permits binding a privileged port — ``CAP_NET_BIND_SERVICE`` —
+through the ``AmbientCapabilities`` directive, while ``CapabilityBoundingSet``
+restricts the service to that one capability.  This way Zino can listen on port
+162 without ever running with root privileges.
+
+If you would rather have Zino start as root and drop its privileges afterwards
+(for example on a system without ``AmbientCapabilities`` support), set ``user``
+in the ``[process]`` section of ``zino.toml`` (see :ref:`configuring-process`)
+and change the unit to run as ``User=root`` instead.
 
 
 Removing redundant timestamps in logs

--- a/docs/howtos/zino.service.example
+++ b/docs/howtos/zino.service.example
@@ -3,10 +3,11 @@ Description=Zino
 After=network.target
 
 [Service]
-User=root
-Group=nogroup
+User=zino
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 WorkingDirectory=/home/zino
-ExecStart=/home/zino/.zino/bin/zino --user zino
+ExecStart=/home/zino/.zino/bin/zino
 Restart=always
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
## Scope and purpose

The systemd example ran Zino as root solely to bind the privileged SNMP trap port (UDP 162), then dropped privileges with the `--user` option once the port was open. systemd can hand the service that one narrow ability directly: `AmbientCapabilities=CAP_NET_BIND_SERVICE` lets it run as the unprivileged `zino` user from the start and still bind port 162, so Zino never holds root at all. `CapabilityBoundingSet` then restricts the service to that single capability.

This is a strictly tighter least-privilege posture than the start-as-root-then-drop approach, and removes the need for Zino's own privilege-dropping in the common systemd case. The howto keeps a short pointer to the `process.user` setting in `zino.toml` for systems without ambient-capability support.

Documentation-only — no behaviour change. Zino already attempts the trap-port bind unconditionally and only gates its drop-privileges logic on `euid`, so granting the capability is sufficient.

### This pull request
* changes documentation only

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] ~~Added/amended tests for new/changed code~~ (documentation-only change)
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
