### PR TITLE
Fix Docker image build triggered by GitHub releases

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -20,22 +20,23 @@ jobs:
       packages: write
 
     steps:
-      - name: Determine ref to build
-        id: ref
+      - name: Determine release tag to build
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
-            echo "ref=$tag" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="$RELEASE_TAG"
           else
-            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+            tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
           fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ steps.ref.outputs.ref }}
+          ref: ${{ steps.release.outputs.tag }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v4
@@ -49,7 +50,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.ref.outputs.ref }}
+            type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push backend Docker image

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -7,6 +7,11 @@ on:
       - published
       - edited
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to (re)build, e.g. 2.5.1. Defaults to the latest release."
+        required: false
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -25,9 +30,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
             tag="$RELEASE_TAG"
+          elif [ -n "$INPUT_VERSION" ]; then
+            tag="$INPUT_VERSION"
           else
             tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
           fi

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Determine release tag to build
-        id: release
+        id: resolve_tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ steps.release.outputs.tag }}
+          ref: ${{ steps.resolve_tag.outputs.tag }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v4
@@ -58,7 +58,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
+            type=semver,pattern={{version}},value=${{ steps.resolve_tag.outputs.tag }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push backend Docker image

--- a/changelog.d/+docker-image-release-build.fixed.md
+++ b/changelog.d/+docker-image-release-build.fixed.md
@@ -1,0 +1,1 @@
+Fixed the release workflow so that Docker images are actually built and published to the GitHub Container Registry when a release is made


### PR DESCRIPTION
## Scope and purpose

Publishing a GitHub release has never produced a Docker image. The release-triggered build passed the full git ref (`refs/tags/X`) to `docker/metadata-action`'s `type=semver` tag, which only accepts a bare version — so it generated no tags and `build-push-action` aborted with *"tag is needed when pushing to registry"*. Only the manual `workflow_dispatch` path worked, because it derived a clean tag via `gh release view`.

This emits the clean release tag (`github.event.release.tag_name`) on the release path, and adds an optional `version` input to the manual trigger so a specific past release can be rebuilt without cutting a new one (defaulting to the latest release).

A `release`-triggered run uses the workflow file as it exists at the release's tagged commit, so this fix only takes effect for releases cut after it merges; existing releases can instead be rebuilt on demand with the new `version` dispatch input.

User-controlled values (the release tag and the dispatch `version` input) are passed via environment variables rather than interpolated into the shell, to avoid script injection near the `packages: write` token.

### This pull request
* changes CI configuration only

### Testing

It's always finicky to "test" a github workflow. I already had a Zino fork, so I tested this workflow there and produced this package: https://github.com/lunkwill42/zino/pkgs/container/zino


## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] ~~Added/amended tests for new/changed code~~ (CI-only change)
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code (pre-commit hooks pass; no Python changed)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
