### PR TITLE
Fix SNMP trap reception when running Zino in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Keep .git: setuptools_scm derives the package version from it at build time.
+
+# Virtualenvs and local tooling caches
+.venv/
+.direnv/
+.tox/
+.pytest_cache/
+.mutmut-cache
+__pycache__/
+*.pyc
+
+# Build artifacts and local runtime/scratch state
+docs/_build/
+tmp/
+.data/
+old-events/
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,13 @@ RUN /venv/bin/pip install .
 # Stage 2: Runtime stage
 FROM python:3.12-slim
 
+# Create an unprivileged user for Zino to drop to. The container starts as root
+# (to bind the privileged trap port), then Zino drops privileges to this user
+# unless told to drop to another UID; see docker-compose.yml and the --user
+# option. There is deliberately no USER directive: dropping is Zino's job.
+RUN groupadd --gid 1000 zino \
+    && useradd --uid 1000 --gid zino --home-dir /zino --shell /usr/sbin/nologin zino
+
 WORKDIR /zino
 
 COPY --from=build /venv /venv

--- a/changelog.d/+docker-host-networking-traps.fixed.md
+++ b/changelog.d/+docker-host-networking-traps.fixed.md
@@ -1,0 +1,1 @@
+The bundled Docker Compose setup now uses host networking, so Zino receives SNMP traps with their real source addresses; under bridge networking Docker rewrote the source to the gateway and Zino silently dropped every trap

--- a/changelog.d/+privilege-drop-numeric-uid.added.md
+++ b/changelog.d/+privilege-drop-numeric-uid.added.md
@@ -1,1 +1,1 @@
-`--user` and the `process.user` setting now accept a numeric `UID` or `UID:GID` in addition to a user name, so Zino can drop privileges to a UID that has no entry in `/etc/passwd` (e.g. inside a container)
+`--user` and the `process.user` setting now accept a numeric `UID` or `UID:GID` or, as previously, a user name, so Zino can drop privileges to a UID that has no entry in `/etc/passwd` (e.g. inside a container)

--- a/changelog.d/+privilege-drop-numeric-uid.added.md
+++ b/changelog.d/+privilege-drop-numeric-uid.added.md
@@ -1,0 +1,1 @@
+`--user` and the `process.user` setting now accept a numeric `UID` or `UID:GID` in addition to a user name, so Zino can drop privileges to a UID that has no entry in `/etc/passwd` (e.g. inside a container)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,20 @@ services:
     image: zino:latest
     # Option 2: Fetch image externally
     #image: ghcr.io/uninett/zino:latest
+    # Host networking is required so Zino sees the real source address of
+    # incoming SNMP traps. With bridge networking and published ports, Docker
+    # rewrites the source to the gateway address and Zino ignores the traps,
+    # because it matches them to devices by source address. See
+    # docs/howtos/use-docker-image.rst for the full explanation.
+    network_mode: host
     volumes:
-      # Mount the current directory into /zino inside the container
-      # It needs to contain the various necessary configuration files
+      # Mount the current directory into /zino inside the container.
+      # It needs to contain the various necessary configuration files.
       - ./:/zino
-    ports:
-      # Default trap port
-      - "162:162/udp"
-      # SNMP "ping" agent, for clients that want to verify Zino uptime
-      - "8000:8000/udp"
-      # Map the API and notification ports
-      - "8001:8001"
-      - "8002:8002"
-    # Example custom trap port configuration, must match with port mapping
-    #command: "--trap-port 1162"
+    # Zino starts as root to bind the privileged trap port (162), then drops
+    # privileges. By default it drops to the built-in unprivileged "zino" user
+    # (uid 1000); it never keeps running as root. Set HOST_UID/HOST_GID to your
+    # own ids instead, so the mounted config and the state files Zino writes are
+    # owned by (and writable by) you, e.g.:
+    #   HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up
+    command: "--user ${HOST_UID:-1000}:${HOST_GID:-1000}"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -56,10 +56,12 @@ The ``[process]`` section controls process-level behavior.
    user = "zino"
 
 ``user``
-   Username to switch to after binding to privileged ports. When Zino starts
-   as root, it will drop privileges to this user once protected ports (like
-   the SNMP trap port 162) are bound. This can be overridden by the ``--user``
-   command-line option. Default: not set (no privilege dropping).
+   User to switch to after binding to privileged ports. When Zino starts as
+   root, it drops privileges to this user once protected ports (like the SNMP
+   trap port 162) are bound. May be a user name, a numeric ``UID``, or a numeric
+   ``UID:GID`` pair; the numeric forms are useful in containers, where the
+   target UID may have no entry in ``/etc/passwd``. This can be overridden by
+   the ``--user`` command-line option. Default: not set (no privilege dropping).
 
 .. _configuring-trap-reception:
 

--- a/docs/howtos/use-docker-image.rst
+++ b/docs/howtos/use-docker-image.rst
@@ -2,64 +2,98 @@
 How to: Use the Zino Docker image
 =================================
 
-The repository includes a Dockerfile and a docker-compose file.
-You can use these to build and run the Zino application as a Docker container.
-The following steps show how to get started:
+The repository includes a ``Dockerfile`` and a ``docker-compose.yml`` file for
+building and running Zino as a Docker container.
 
-1. **Build the Docker Image**:
+Building the image
+------------------
 
-   If you have the Zino source code and Dockerfile in the current directory,
-   you can build the Docker image locally.
-   This is done using the `docker-compose` command:
+Build the image locally from the Zino source tree:
 
-   .. code:: shell
+.. code:: shell
 
-      docker-compose build
+   docker compose build
 
-   This command will build the Docker image with the tag `zino:latest`.
+This builds the image and tags it ``zino:latest``.
 
-2. **Run the Docker Container**:
+Running the container
+---------------------
 
-   Once the image is built, you can run the Zino container using `docker-compose`:
+.. code:: shell
 
-   .. code:: shell
+   docker compose up
 
-      docker-compose up
+This starts Zino using the settings in ``docker-compose.yml``.
 
-   This will start the Zino container,
-   exposing necessary ports as configured in the docker-compose file.
+Configuration files
+-------------------
 
-3. **Configuration Files**:
+The compose file mounts the current directory (``./``) into ``/zino`` inside the
+container, which is also Zino's working directory.  The current directory must
+contain the configuration files Zino needs: :file:`zino.toml`,
+:file:`polldevs.cf` and :file:`secrets`.
 
-   The `docker-compose` file is configured to mount the current directory (`./`)
-    into the `/zino` directory inside the container. 
-   Ensure that the current directory contains all necessary Zino configuration files.
+Why host networking is required
+-------------------------------
 
-4. **Port Mapping**:
+Zino identifies an incoming SNMP trap by its **source IP address**: it looks up
+the sending device by that address and ignores the trap if it doesn't match a
+device Zino polls.
 
-   The `docker-compose` file maps the following ports by default:
-   - Port `162` (Default trap port)
-   - Port `8001` (API port)
-   - Port `8002` (Notification port)
+This has an important consequence under Docker.  With the default **bridge**
+networking and published ports (``-p 162:162/udp``), Docker rewrites the source
+address of incoming UDP packets to the bridge gateway (e.g. ``172.17.0.1``).
+Zino then sees every trap as coming from the gateway, matches none of them to a
+device, and silently drops them all — the tell-tale symptom is a Zino that polls
+correctly but never reacts to traps.
 
-   If you wish to specify the trap port, 
-   uncomment and modify the `command` field in the `docker-compose` file accordingly.
-   For example:
+The bundled ``docker-compose.yml`` therefore uses **host networking**
+(``network_mode: host``): the container shares the host's network stack with no
+NAT, so Zino sees the real trap source addresses.  Host networking also means
+the container binds host ports directly, so there is no ``ports:`` section —
+ports 162 (traps), 8000 (the uptime agent) and 8001/8002 (the APIs) are served
+on the host as-is.
 
-   .. code:: yaml
+If host networking is not an option, receive traps through an SNMP trap
+multiplexer such as **nmtrapd** running on the host, outside Docker: the
+multiplexer binds port 162 and forwards traps — with their original source
+address — to Zino.  Point Zino at it with the ``[snmp.trap]`` ``source`` setting
+(see :ref:`configuring-trap-reception`).
 
-      command: "--trap-port 1162"
+Running as your own user
+------------------------
 
-5. **External Image Option**:
+Binding the privileged trap port 162 requires starting as root, so the container
+starts as root and then drops privileges to the built-in unprivileged ``zino``
+user — it never keeps running as root.  To instead drop to your own host user,
+so the mounted configuration and the state files Zino writes stay owned by (and
+writable by) you, set ``HOST_UID`` and ``HOST_GID`` when starting it:
 
-   If you do not wish to build the image locally, 
-   you can instead use the pre-built image available on GitHub Container Registry. 
-   To do this, comment out the `build` and `image: zino:latest` lines in the `docker-compose` file,
-   and uncomment the following line:
+.. code:: shell
 
-   .. code:: yaml
+   HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up
 
-      image: ghcr.io/uninett/zino:latest
+The compose file passes these to Zino's ``--user`` option, which drops to that
+numeric UID/GID once port 162 is bound.  Whichever user Zino drops to must be
+able to write the mounted directory, where it keeps its state file.
 
-   This will fetch the latest Zino image from the external registry.
+Using a different trap port
+---------------------------
 
+Zino listens on port 162 by default.  To use another port, add ``--trap-port``
+to the ``command`` in the compose file, keeping the ``--user`` part:
+
+.. code:: yaml
+
+   command: "--user ${HOST_UID:-0}:${HOST_GID:-0} --trap-port 1162"
+
+Using the pre-built image
+-------------------------
+
+To use the pre-built image from the GitHub Container Registry instead of
+building locally, comment out the ``build`` and ``image: zino:latest`` lines in
+the compose file and uncomment:
+
+.. code:: yaml
+
+   image: ghcr.io/uninett/zino:latest

--- a/src/zino/zino.py
+++ b/src/zino/zino.py
@@ -320,47 +320,74 @@ def setup_initial_job_schedule(loop: AbstractEventLoop, args: argparse.Namespace
         )
 
 
-def switch_to_user(username: str):
-    """Switch the process to another user (aka. drop privileges)"""
+def switch_to_user(user: str) -> bool:
+    """Switch the process to another user, i.e. drop privileges.
 
-    # Get UID/GID of current user
+    The target may be a user name, a numeric ``UID``, or a numeric ``UID:GID``
+    pair.  The numeric forms are useful in containers, where the desired UID
+    often has no matching entry in ``/etc/passwd``.
+
+    :param user: Target user as a name, ``UID``, or ``UID:GID``.
+    :return: True if privileges were dropped (or were already dropped).
+    """
+    resolved = _resolve_user_spec(user)
+    if resolved is None:
+        return False
+    uid, gid, supplementary_groups = resolved
+
     old_uid = os.getuid()
     old_gid = os.getgid()
-
-    try:
-        # Try to get information about the given username
-        user = pwd.getpwnam(username)
-    except KeyError:
-        _log.error("Could not find user %s", username)
-        return False
-
-    if old_uid == user.pw_uid:
-        # Already running as the given user
+    if old_uid == uid:
         _log.debug("Already running as uid/gid %d/%d.", old_uid, old_gid)
         return True
 
     try:
-        # Set primary group
-        os.setgid(user.pw_gid)
-
-        # Set non-primary groups
-        gids = [g.gr_gid for g in grp.getgrall() if username in g.gr_mem]
-        if gids:
-            os.setgroups(gids)
-
-        # Set user id
-        os.setuid(user.pw_uid)
+        os.setgid(gid)
+        if supplementary_groups:
+            os.setgroups(supplementary_groups)
+        os.setuid(uid)
     except OSError as error:
-        # Failed changing uid/gid
-        _log.error(
-            "Failed changing uid/gid from %d/%d to %d/%d (%s)", old_uid, old_gid, user.pw_uid, user.pw_gid, error
-        )
+        _log.error("Failed changing uid/gid from %d/%d to %d/%d (%s)", old_uid, old_gid, uid, gid, error)
         return False
 
-    # Switch successful
-    _log.info("Dropped privileges to user %s", username)
-    _log.debug("uid/gid changed from %d/%d to %d/%d.", old_uid, old_gid, user.pw_uid, user.pw_gid)
+    _log.info("Dropped privileges to %s (uid/gid %d/%d)", user, uid, gid)
     return True
+
+
+def _resolve_user_spec(user: str) -> Optional[tuple[int, int, list[int]]]:
+    """Resolve a user spec to a ``(uid, gid, supplementary group ids)`` tuple.
+
+    :param user: Target user as a name, a numeric ``UID``, or ``UID:GID``.
+    :return: The resolved ``(uid, gid, supplementary_groups)``, or None if the
+        spec was invalid or a named user could not be found.
+    """
+    if ":" in user:
+        uid, _, gid = user.partition(":")
+        if uid.isdigit() and gid.isdigit():
+            return int(uid), int(gid), []
+        _log.error("Invalid user specification %r; expected a name, UID, or UID:GID", user)
+        return None
+
+    if user.isdigit():
+        uid = int(user)
+        try:
+            entry = pwd.getpwuid(uid)
+        except KeyError:
+            # No passwd entry (common in containers); reuse the UID as the GID
+            return uid, uid, []
+        return entry.pw_uid, entry.pw_gid, _supplementary_groups(entry.pw_name)
+
+    try:
+        entry = pwd.getpwnam(user)
+    except KeyError:
+        _log.error("Could not find user %s", user)
+        return None
+    return entry.pw_uid, entry.pw_gid, _supplementary_groups(user)
+
+
+def _supplementary_groups(username: str) -> list[int]:
+    """Return the GIDs of the supplementary groups ``username`` belongs to."""
+    return [group.gr_gid for group in grp.getgrall() if username in group.gr_mem]
 
 
 def reschedule_dump_state_on_commit(new_event: Event, old_event: Optional[Event] = None) -> None:
@@ -465,7 +492,9 @@ def parse_args(arguments=None):
         "privileges.  Setting to 0 disables SNMP trap monitoring.",
     )
     parser.add_argument(
-        "--user", metavar="USER", help="Switch to this user immediately after binding to privileged ports"
+        "--user",
+        metavar="USER",
+        help="Switch to this user (name, UID, or UID:GID) immediately after binding to privileged ports",
     )
     args = parser.parse_args(args=arguments)
     return args

--- a/tests/zino_test.py
+++ b/tests/zino_test.py
@@ -295,6 +295,44 @@ class TestSwitchUser:
 
         assert not zino.switch_to_user(random_username)
 
+    @patch("os.getuid", return_value=0)
+    @patch("os.setgid")
+    @patch("os.setgroups")
+    @patch("os.setuid")
+    def test_when_given_numeric_uid_and_gid_it_should_switch_to_both(self, *_):
+        assert zino.switch_to_user("4321:100")
+        os.setuid.assert_called_once_with(4321)
+        os.setgid.assert_called_once_with(100)
+        os.setgroups.assert_not_called()
+
+    @patch("os.getuid", return_value=0)
+    @patch("pwd.getpwuid", side_effect=KeyError)
+    @patch("os.setgid")
+    @patch("os.setgroups")
+    @patch("os.setuid")
+    def test_when_given_numeric_uid_without_passwd_entry_it_should_reuse_uid_as_gid(self, *_):
+        assert zino.switch_to_user("4321")
+        os.setuid.assert_called_once_with(4321)
+        os.setgid.assert_called_once_with(4321)
+
+    @patch("os.getuid", return_value=0)
+    @patch("pwd.getpwuid")
+    @patch("grp.getgrall")
+    @patch("os.setgid")
+    @patch("os.setgroups")
+    @patch("os.setuid")
+    def test_when_given_numeric_uid_with_passwd_entry_it_should_use_its_gid_and_groups(self, *_):
+        pwd.getpwuid.return_value = Mock(pw_uid=4321, pw_gid=200, pw_name="someuser")
+        grp.getgrall.return_value = [Mock(gr_gid=4242, gr_mem=["someuser"])]
+
+        assert zino.switch_to_user("4321")
+        os.setuid.assert_called_once_with(4321)
+        os.setgid.assert_called_once_with(200)
+        os.setgroups.assert_called_once_with([4242])
+
+    def test_when_given_invalid_user_spec_it_should_return_false(self):
+        assert not zino.switch_to_user("not:numeric")
+
 
 class TestCountReachableObjects:
     def test_it_should_count_queried_classes(self):


### PR DESCRIPTION
## Scope and purpose

When Zino runs in Docker with the bundled compose setup, it silently receives no SNMP traps. Zino matches each trap to a device by its source IP address, but Docker's default bridge networking with published ports rewrites the source of incoming UDP packets to the bridge gateway — so every trap is unmatched and dropped. This has bitten a real deployment (Zino under Docker on a VM): polling works, traps never register.

The compose setup now uses host networking, which preserves the real source address. Binding the privileged trap port 162 requires starting as root, so the container starts as root and then drops privileges — to a built-in unprivileged `zino` user by default (never staying root), or to your own `HOST_UID:HOST_GID` so bind-mounted config and state files stay owned by you. Dropping to a host UID required teaching Zino's `--user`/`process.user` to accept a numeric `UID` or `UID:GID` (previously name-only via `getpwnam`, which can't target a UID with no `/etc/passwd` entry in the container).

The docs gain a "why host networking is required" section and note the external `nmtrapd` multiplexer as the alternative where host networking isn't possible.

### This pull request
* changes the Docker image, its compose setup, and its documentation
* adds a numeric `UID`/`UID:GID` form to the privilege-drop option

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
