### PR TITLE
Remove sonarcloud coverage upload and move coverage upload to test workflow

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,4 +1,4 @@
-name: Publish test and coverage results
+name: Publish test results
 
 on:
   workflow_run:
@@ -8,20 +8,11 @@ on:
 
 jobs:
   publish-test-results:
-    name: "Publish test and coverage results"
+    name: "Publish test results"
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
 
     steps:
-      # Checking out the repo is necessary codecov/codecov-action@v7 to work properly
-      # Codecov requires source code to process the coverage file and generate coverage
-      # reports
-      - name: Checkout Code
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0
-
       - name: Download and Extract Artifacts
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -43,32 +34,3 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: "Test results"
           files: artifacts/**/*-results.xml
-
-      - name: Read PR number file
-        if: ${{ hashFiles('artifacts/extra/pr_number') != '' }}
-        run: |
-          pr_number=$(cat artifacts/extra/pr_number)
-          re='^[0-9]+$'
-          if [[ $pr_number =~ $re ]] ; then
-            echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
-          fi
-
-      - name: Read base SHA file
-        if: ${{ hashFiles('artifacts/extra/base_sha') != '' }}
-        run: |
-          base_sha=$(cat artifacts/extra/base_sha)
-          re='[0-9a-f]{40}'
-          if [[ $base_sha =~ $re ]] ; then
-            echo "BASE_SHA=$base_sha" >> $GITHUB_ENV
-          fi
-
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v7
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          override_branch: ${{ github.event.workflow_run.head_branch}}
-          override_commit: ${{ github.event.workflow_run.head_sha}}
-          commit_parent: ${{ env.BASE_SHA }}
-          override_pr: ${{ env.PR_NUMBER }}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -62,32 +62,6 @@ jobs:
             echo "BASE_SHA=$base_sha" >> $GITHUB_ENV
           fi
 
-      - name: Read base name file
-        if: ${{ hashFiles('artifacts/extra/base_name') != '' }}
-        run: |
-          base_name=$(cat artifacts/extra/base_name)
-          re='^[0-9a-zA-Z._\/\-]+$'
-          if [[ $base_name =~ $re ]] ; then
-            echo "BASE_NAME=$base_name" >> $GITHUB_ENV
-          fi
-
-      - name: SonarQube Scan for Pull Request
-        uses: SonarSource/sonarqube-scan-action@v8.2.0
-        if: github.event.workflow_run.event == 'pull_request'
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
-            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
-            -Dsonar.pullrequest.base=${{ env.BASE_NAME }}
-
-      - name: SonarQube Scan for Push
-        uses: SonarSource/sonarqube-scan-action@v8.2.0
-        if: github.event.workflow_run.event == 'push'
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
       - name: Upload to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # Disable shallow clone for improved SonarCloud analysis
 
       - name: Cache
         uses: actions/cache@v6
@@ -70,27 +72,10 @@ jobs:
           path: |
             reports/**/*
 
-  upload-pr-info:
-    name: Save extra PR info in artifact
-    runs-on: ubuntu-latest
-    if: ${{ github.event.number && always() }}
-    env:
-      PR_NUMBER: ${{ github.event.number }}
-      BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      BASE_NAME: ${{ github.base_ref }}
-    steps:
-      - name: Make PR number file
-        run: |
-          mkdir -p ./extra
-          echo $PR_NUMBER > ./extra/pr_number
-      - name: Make base SHA file
-        run: |
-          echo $BASE_SHA > ./extra/base_sha
-      - name: Make base name file
-        run: |
-          echo $BASE_NAME > ./extra/base_name
-      - name: Upload PR info files
-        uses: actions/upload-artifact@v7
+      - name: Upload coverage reports to Codecov
+        if: github.repository_owner == 'Uninett'
+        uses: codecov/codecov-action@v7
         with:
-          name: extra
-          path: extra/
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,6 +11,3 @@ sonar.python.version=3.9, 3.10, 3.11, 3.12
 sonar.tests=tests
 
 sonar.exclusions=src/zino/snmp/mibdumps/**
-
-# Path for coverage files in the GitHub actions workflow
-sonar.python.coverage.reportPaths=artifacts/**/coverage.xml


### PR DESCRIPTION
## Scope and purpose

Sonarcloud coverage uploads were added in #409 as a tests to find out if we can switch from codecov to using sonarcloud for our coverage reporting. We decided against it as sonarcloud does not support coverage uploads for forks and it is only possible to set a manual threshold of coverage that a PR would have to hit, while codecov automatically takes the current overall coverage of a repository.

Codecov now supports tokenless upload for forks, so changes done in #230 can be reverted again.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Zino can be found in the
[README](https://github.com/Uninett/zino/blob/master/README.md#developing-zino).

<!-- Add an "X" inside the brackets to confirm -->
<!-- If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [ ] Added/amended tests for new/changed code <!-- In case CodeCov Upload makes the tests fail, simply rerun them a few minutes later -->
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
