### PR TITLE
Release SNMP session lock when open() fails in __enter__

### DIFF
--- a/changelog.d/+snmp-session-lock-wedge.fixed.md
+++ b/changelog.d/+snmp-session-lock-wedge.fixed.md
@@ -1,0 +1,4 @@
+Fix a bug where a failed SNMP session open (e.g. due to file descriptor
+exhaustion) could permanently wedge that device's session lock, silently
+disabling closure of a concurrently-opened, shared session for the same
+device and leaking a file descriptor.

--- a/src/zino/snmp/netsnmpy_backend.py
+++ b/src/zino/snmp/netsnmpy_backend.py
@@ -108,7 +108,11 @@ class SNMP:
 
     def __enter__(self):
         self._lock.acquire()
-        self.open()
+        try:
+            self.open()
+        except Exception:
+            self._lock.release()
+            raise
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/tests/snmp/netsnmpy_backend_test.py
+++ b/tests/snmp/netsnmpy_backend_test.py
@@ -1,4 +1,5 @@
 import asyncio
+import errno
 import os
 from unittest.mock import Mock, patch
 
@@ -302,3 +303,21 @@ class TestSnmpContextManager:
             with snmp_session as snmp2:
                 assert snmp2._is_open, "second context closed the session"
             assert snmp1._is_open, "second session exit close the session prematurely"
+
+    def test_when_open_raises_then_the_lock_should_not_remain_held(self, snmp_session):
+        with patch.object(snmp_session, "open", side_effect=OSError(errno.EMFILE, "Too many open files")):
+            with pytest.raises(OSError):
+                with snmp_session:
+                    pass
+        assert not snmp_session._lock._is_owned(), "lock was left acquired after open() raised in __enter__"
+
+    def test_when_open_raises_then_later_successful_context_should_still_close(self, snmp_session):
+        with patch.object(snmp_session, "open", side_effect=OSError(errno.EMFILE, "Too many open files")):
+            with pytest.raises(OSError):
+                with snmp_session:
+                    pass
+
+        with snmp_session as snmp:
+            assert snmp._is_open
+
+        assert not snmp_session._is_open, "session was never closed after a prior failed open wedged the lock"


### PR DESCRIPTION
## Scope and purpose

`SNMP.__enter__`/`__exit__` at [`src/zino/snmp/netsnmpy_backend.py:109-119`](https://github.com/Uninett/zino/blob/f05358d5dcdab5ef6e77ca165eb38b8efc372dd9/src/zino/snmp/netsnmpy_backend.py#L109-L119) use an `RLock` as a usage counter for the underlying low-level session: each `__enter__` increments it (`acquire()`), each `__exit__` decrements it (`release()`), and only once the count reaches zero does `__exit__` call `close()`. This is what lets several concurrent users of one device's shared session keep it open for as long as any of them still needs it.

`__enter__` increments the count and then calls `self.open()`, with no `try/finally` around it. If `open()` raises (e.g. `OSError(EMFILE)` when the process is low on file descriptors), `__enter__` itself raises, so Python's `with` statement never calls `__exit__` — the count that was just incremented is never decremented back down. That one "phantom" increment can never be undone, so the count can never return to zero again, and `close()` is never called again for that session, for as long as it lives.

A single failed open in isolation is harmless, since the session object is normally garbage-collected right away once nothing references it. But sessions are cached and shared across independent per-device jobs via [`get_snmp_session()`](https://github.com/Uninett/zino/blob/f05358d5dcdab5ef6e77ca165eb38b8efc372dd9/src/zino/snmp/__init__.py#L46), and each `Task` holds its own strong reference to that shared session (`self.snmp`, set in [`Task.__init__`](https://github.com/Uninett/zino/blob/f05358d5dcdab5ef6e77ca165eb38b8efc372dd9/src/zino/tasks/task.py#L20)). Several job types besides the main per-device poll can run concurrently against the same device's session — e.g. the reachability recheck job scheduled once a device goes unreachable ([`reachabletask.py:38,67-75`](https://github.com/Uninett/zino/blob/f05358d5dcdab5ef6e77ca165eb38b8efc372dd9/src/zino/tasks/reachabletask.py#L38)), trap-triggered single-port verification ([`link_traps.py:159-163`](https://github.com/Uninett/zino/blob/f05358d5dcdab5ef6e77ca165eb38b8efc372dd9/src/zino/trapobservers/link_traps.py#L159)), flap clearing/aging ([`flaps.py:159-176,253-272`](https://github.com/Uninett/zino/blob/f05358d5dcdab5ef6e77ca165eb38b8efc372dd9/src/zino/flaps.py#L159)), and the API-triggered `POLLRTR`/`POLLINTF` commands ([`api/legacy.py:443-478`](https://github.com/Uninett/zino/blob/f05358d5dcdab5ef6e77ca165eb38b8efc372dd9/src/zino/api/legacy.py#L443)). Each of these is scheduled under its own APScheduler job id, so `max_instances=1` on the main poll job (which only prevents a job from overlapping with itself) does not prevent them from running at the same time as the main job.

That gives a genuine leak path: if the main job's `open()` fails, leaving a phantom increment on the count, but one of these other jobs is independently holding a reference to that same (not-yet-collected) session and successfully opens it, that job's own `__exit__` decrements the count as normal — but because of the phantom increment, the count never reaches zero, so `close()` is skipped. The underlying `netsnmpy` session then stays open forever, since it's also kept alive by `netsnmpy`'s own internal `session_map` once opened — there is no other path left to close it.

The fix wraps `self.open()` in `__enter__` in a `try/except` that decrements the count again before re-raising, so a failed open no longer leaves a phantom increment behind for later, unrelated users of the same shared session.

<!-- remove things that do not apply -->

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://github.com/Uninett/zino/blob/master/README.md#before-merging-a-pull-request)
* [x] Added/amended tests for new/changed code
* [ ] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://github.com/Uninett/zino/blob/master/README.md#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See https://cbea.ms/git-commit/
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~
